### PR TITLE
Provide some placeholder JS in the static directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+static/node_modules/
+static/dist/
+static/package-lock.json

--- a/static/entry.js
+++ b/static/entry.js
@@ -1,0 +1,7 @@
+// Import all SCSS
+const scss = require('./scss/placeholder.scss')
+
+// Import all JS
+const { helloWorld } = require('./js/helloworld');
+
+helloWorld();

--- a/static/js/helloworld.js
+++ b/static/js/helloworld.js
@@ -1,0 +1,3 @@
+exports.helloWorld = function () {
+  console.log('Hello');
+}

--- a/static/package.json
+++ b/static/package.json
@@ -9,7 +9,10 @@
   "author": "tmeyer@yext.com",
   "license": "BSD-3-Clause",
   "devDependencies": {
+    "clean-webpack-plugin": "^3.0.0",
+    "closure-webpack-plugin": "^2.3.0",
     "css-loader": "^3.4.2",
+    "google-closure-compiler": "^20200224.0.0",
     "grunt": "^1.0.4",
     "grunt-webpack": "^3.1.3",
     "mini-css-extract-plugin": "^0.9.0",

--- a/static/scss/placeholder.scss
+++ b/static/scss/placeholder.scss
@@ -1,0 +1,5 @@
+$body-color: white;
+
+body {
+  color: $body-color;
+}

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -1,9 +1,20 @@
+const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const ClosurePlugin = require('closure-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
-  mode: "production",
-  entry: "./scss/placeholder.scss",
-  plugins: [new MiniCssExtractPlugin()],
+  mode: 'production',
+  entry: './entry.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  },
+  plugins: [new CleanWebpackPlugin(), new MiniCssExtractPlugin({ filename: 'bundle.css' })],
+  optimization: {
+    minimize: true,
+    minimizer: [new ClosurePlugin()]
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
This PR provides an example of how one would include some additional JS in the
theme's static directory. All JS and SCSS is imported/used through a single
entry point, called entry.js. Right now, the JS directory contains a single
file that exports a function to print 'Hello World'. I added the Closure
compiler plugin to Webpack. That way, we use Closure to minimize any customer
supplied JS. I also added the CleanWebpackPlugin. This plugin cleans out the
dist directory as the first step of a Webpack bundle. This is the best
practice.

TEST=manual

Made sure that the JS was bundled properly and the CSS was too. Created a
simple HTML page to verify that 'Hello' was printed to the console when using
bundle.js and that the bundle.css could also be correctly imported.