### PR TITLE
dataForRender: Expose Derived fields with d_ prefix

### DIFF
--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -13,9 +13,14 @@ BaseCard.{{componentName}} = class extends ANSWERS.Component {
 
   setState(data) {
     const details = this._config.details;
+    const { _raw, ...derivedFields } = this.result;
+    const profile = { ..._raw };
+    for (const field of Object.keys(derivedFields)) {
+      profile[`d_${field}`] = derivedFields[field];
+    }
     return super.setState({
       ...data,
-      card: this.dataForRender(this.result._raw),
+      card: this.dataForRender(profile),
       cardName: `{{componentName}}`,
       result: this.result,
       details


### PR DESCRIPTION
This commit exposes additional attributes of a
card's Result by adding them to dataForRender with
a d_prefix (d for derived).

J=SPR-1890
TEST=manual
npx jambo init
npx jambo import --theme answers-hitchhiker-theme
change themes/answers-hithchiker-theme/cards/card_component.js with new code
add console logs to themes/answers-hitchhiker-theme/ card_component.js and standard/component.js
  for the profile object sent to dataForRender
npx jambo page --name bob --theme answers-hitchhiker-theme --template vertical
update config/config.json and config/bob.json
npx jambo build
check console logs that data is being passed correctly