### PR TITLE
Global Config: Remove old verticalSettings, add businessId

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -1,19 +1,5 @@
 {
   "apiKey": "<REPLACE ME>",
   "experienceKey": "<REPLACE ME>",
-  "verticalSettings": {
-    "<VERTICAL KEY PLACEHOLDER>": {
-      "icon": "<REPLACE ME>",
-      "label": "<REPLACE ME>",
-      "url": "<REPLACE ME>",
-      "isFirst": "<REPLACE ME>",
-      "card": {
-        "cardType": "<REPLACE ME>",
-        "cardMappings": {
-          "title": "<REPLACE ME>",
-          "details": "<REPLACE ME>"
-        }
-      }
-    }
-  }
+  "businessId": "<REPLACE ME>"
 }


### PR DESCRIPTION
BusinessId is needed for analytics. VerticalSettings is not used, now we support storing each vertical's settings in its page's config.