### PR TITLE
Update Partial naming scheme in accordance with Jambo changes.

### DIFF
--- a/cards/accordion/component.js
+++ b/cards/accordion/component.js
@@ -1,4 +1,4 @@
-{{> cards_card_component componentName='AccordionCard'}}
+{{> cards/card_component componentName='AccordionCard'}}
 
 class AccordionCardComponent extends BaseCard.AccordionCard {
   constructor(config = {}, systemConfig = {}) {

--- a/cards/standard/component.js
+++ b/cards/standard/component.js
@@ -1,4 +1,4 @@
-{{> cards_card_component componentName='StandardCard'}}
+{{> cards/card_component componentName='StandardCard'}}
 
 class StandardCardComponent extends BaseCard.StandardCard {
   constructor(config = {}, systemConfig = {}) {

--- a/templates/universal/page.html.hbs
+++ b/templates/universal/page.html.hbs
@@ -1,26 +1,26 @@
-{{#> layouts_html }}
+{{#> layouts/html }}
   <div>
-    {{#> script_core }}
-      {{> templates_universal_script_searchbar }}
-      {{> templates_universal_script_spellcheck }}
-      {{> templates_universal_script_navigation }}
-      {{> templates_universal_script_universalresults }}
-      {{!-- {{> templates_universal_script_qasubmission }} --}}
-    {{/script_core}}
+    {{#> script/core }}
+      {{> templates/universal/script/searchbar }}
+      {{> templates/universal/script/spellcheck }}
+      {{> templates/universal/script/navigation }}
+      {{> templates/universal/script/universalresults }}
+      {{!-- {{> templates/universal/script/qasubmission }} --}}
+    {{/script/core}}
     <div class="Answers">
       <div class="Answers-navWrapper">
         <div class="Answers-container">
-          {{> templates_universal_markup_searchbar }}
-          {{> templates_universal_markup_navigation}}
+          {{> templates/universal/markup/searchbar }}
+          {{> templates/universal/markup/navigation}}
         </div>
       </div>
       <div class="Answers-container Answers-resultsWrapper">
-        {{> templates_universal_markup_spellcheck }}
+        {{> templates/universal/markup/spellcheck }}
         <div class="Answers-filtersAndResults">
-          {{> templates_universal_markup_universalresults }}
+          {{> templates/universal/markup/universalresults }}
         </div>
-        {{!-- {{> templates_universal_markup_qasubmission }} --}}
+        {{!-- {{> templates/universal/markup/qasubmission }} --}}
       </div>
     </div>
   </div>
-{{/layouts_html}}
+{{/layouts/html}}

--- a/templates/vertical/page.html.hbs
+++ b/templates/vertical/page.html.hbs
@@ -1,33 +1,33 @@
-{{#> layouts_html }}
+{{#> layouts/html }}
   <div>
-    {{#> script_core }}
-      {{> cards_standard_component }}
-      {{> templates_vertical_script_searchbar}}
-      {{> templates_vertical_script_spellcheck}}
-      {{> templates_vertical_script_navigation}}
-      {{> templates_vertical_script_verticalresults}}
-      {{> templates_vertical_script_pagination}}
-      {{> templates_vertical_script_locationbias}}
-      {{!-- {{> templates_vertical_script_qasubmission}} --}}
-    {{/script_core}}
+    {{#> script/core }}
+      {{> cards/standard/component }}
+      {{> templates/vertical/script/searchbar}}
+      {{> templates/vertical/script/spellcheck}}
+      {{> templates/vertical/script/navigation}}
+      {{> templates/vertical/script/verticalresults}}
+      {{> templates/vertical/script/pagination}}
+      {{> templates/vertical/script/locationbias}}
+      {{!-- {{> templates/vertical/script/qasubmission}} --}}
+    {{/script/core}}
     <div class="Answers">
       <div class="Answers-navWrapper">
         <div class="Answers-container">
-          {{> templates_vertical_markup_searchbar }}
-          {{> templates_vertical_markup_navigation}}
+          {{> templates/vertical/markup/searchbar }}
+          {{> templates/vertical/markup/navigation}}
         </div>
       </div>
       <div class="Answers-container Answers-resultsWrapper">
-        {{> templates_vertical_markup_spellcheck }}
+        {{> templates/vertical/markup/spellcheck }}
         <div class="Answers-filtersAndResults">
-          {{> templates_vertical_markup_verticalresults }}
+          {{> templates/vertical/markup/verticalresults }}
         </div>
-        {{> templates_vertical_markup_pagination }}
-        {{!-- {{> templates_vertical_markup_qasubmission }} --}}
+        {{> templates/vertical/markup/pagination }}
+        {{!-- {{> templates/vertical/markup/qasubmission }} --}}
       </div>
     </div>
     <footer class="Answers-footer">
-      {{> templates_vertical_markup_locationbias }}
+      {{> templates/vertical/markup/locationbias }}
     </footer>
   </div>
-{{/layouts_html }}
+{{/layouts/html }}


### PR DESCRIPTION
The Partial naming conventions in Jambo have recently been changed. Now, Jambo
names a Partial according to its relative path, with the file extension
removed. The Theme must be updated to reflect this change.

J=SPR-1988
TEST=manual

Made a simple test site with the updated Theme. Made sure it could Jambo build
without errors and that it looked as expected when served.