### PR TITLE
Include all card attributes in dataForRender for Standard and Accordion.

### DIFF
--- a/cards/accordion/component.js
+++ b/cards/accordion/component.js
@@ -14,17 +14,18 @@ class AccordionCardComponent extends BaseCard.AccordionCard {
    */
   dataForRender(profile) {
     return {
-      title: profile.name,
-      // subtitle: '',
-      details: profile.answer,
+      title: profile.name, // The header text of the card
+      // subtitle: '', // The sub-header text of the card
+      details: profile.answer, // The text in the body of the card
+      // The calls to action on the card
       callsToAction: profile.c_ctas ? profile.c_ctas.map((cta) => {
         return {
-          label: cta.text,
-          url: cta.url,
-          iconName: cta.icon,
-          target: "_parent",
-          modifiers: "yxt-CTA--solo",
-          eventType: "CTA_CLICK"
+          label: cta.text, // The label of the CTA
+          url: cta.url, // The URL a user will be directed to when clicking
+          iconName: cta.icon, // The icon to use for the CTA
+          target: "_parent", // If the URL will be opened in a new tab, etc.
+          modifiers: "yxt-CTA--solo", // Additional CSS classes for the CTA
+          eventType: "CTA_CLICK" // Type of Analytics event fired when clicking the CTA
         };
       }) : [],
     };

--- a/cards/standard/component.js
+++ b/cards/standard/component.js
@@ -14,22 +14,23 @@ class StandardCardComponent extends BaseCard.StandardCard {
    */
   dataForRender(profile) {
     return {
-      title: profile.name,
-      titleUrl: profile.websites,
-      // image: '',
-      // tagLabel: '',
+      title: profile.name, // The header text of the card
+      titleUrl: profile.websites, // If the card title is a clickable link, set URL here
+      // target: '', // If the title's URL should open in a new tab, etc.
+      // image: '', // The URL of the image to display on the card
+      // tagLabel: '', // The label of the displayed image
       titleEventOptions: this.addDefaultEventOptions(),
-      subtitle: '',
-      details: profile.description,
-      // target: '',
+      subtitle: '', // The sub-header text of the card
+      details: profile.description, // The text in the body of the card
+      // The calls to action on the card
       callsToAction: [
         {
-          url: profile.c_primaryCTA,
-          iconName: 'chevron',
-          label: 'View Details',
-          target: '_parent',
-          modifiers: 'yxt-CTA--solo',
-          eventType: 'CTA_CLICK',
+          url: profile.c_primaryCTA, // The URL a user will be directed to when clicking
+          iconName: 'chevron', // The icon to use for the CTA
+          label: 'View Details', // The label of the CTA
+          target: '_parent', // If the URL will be opened in a new tab, etc.
+          modifiers: 'yxt-CTA--solo', // Additional CSS classes for the CTA
+          eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         }
       ]
     };


### PR DESCRIPTION
This PR ensures that both Standard and Accordion cards list all available
attributes in their respective dataForRender method. Those attributes that do
not have a set value are left commented out to demonstrate how they could
be added.

Also included in the PR is a fix for the HH Theme. Jambo recently updated the
naming scheme for Partials. The HH Theme needed to be updated to accomodate for
the differently named partials. There was a PR with the HH Theme updates, but
I missed a couple of partial references.

J=SPR-1985
TEST=none