### PR TITLE
Move from SDK v0.14.0 to v0.13.3

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -1,5 +1,5 @@
-<link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/dev/v0.14.0/answers.css">
-<script src="https://assets.sitescdn.net/answers/dev/v0.14.0/answerstemplates.compiled.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/dev/v0.13.3/answers.css">
+<script src="https://assets.sitescdn.net/answers/dev/v0.13.3/answerstemplates.compiled.min.js"></script>
 <script>
   function initAnswers() {
     ANSWERS.init(Object.assign({"templateBundle": TemplateBundle.default}, {{{ json global_config }}}, { onReady: () => {
@@ -7,5 +7,5 @@
     }}));
   };
 </script>
-<script src="https://assets.sitescdn.net/answers/dev/v0.14.0/answers.js" onload="initAnswers()" async></script>
+<script src="https://assets.sitescdn.net/answers/dev/v0.13.3/answers.js" onload="initAnswers()" async></script>
 

--- a/templates/universal/script/universalresults.hbs
+++ b/templates/universal/script/universalresults.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('UniversalResults', Object.assign({{{ json componentSettings.UniversalResults }}}, {
     container: '.js-answersUniversalResults',
-    verticals: {
+    config: {
       {{#each verticalConfigs}}
         {{#if verticalKey}}
           {{verticalKey}}: {


### PR DESCRIPTION
v0.14.0 will not be released for a while; v0.13.3 is going to
be v1.0.0 when it is released. The HH theme should
be tested with v0.13.3 rather than v0.14.0.

TEST=manual

`jambo build` and inspect page in the browser to verify that the script/link tags
were for v0.13.3. Briefly test Universal and Vertical page by clicking around and seeing
no console errors.