### PR TITLE
Support the injection of account data from the JAMBO_INJECTED_DATA va…

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -2,9 +2,20 @@
 <script src="https://assets.sitescdn.net/answers/v1.0.0/answerstemplates.compiled.min.js"></script>
 <script>
   function initAnswers() {
-    ANSWERS.init(Object.assign({"templateBundle": TemplateBundle.default}, {{{ json global_config }}}, { onReady: () => {
-      {{> @partial-block }}
-    }}));
+    ANSWERS.init(Object.assign(
+      {"templateBundle": TemplateBundle.default},
+      {{#with env.JAMBO_INJECTED_DATA}}
+        {
+          experienceKey: "{{../global_config.experienceKey}}",
+          {{#if businessId}}businessId: "{{businessId}}",{{/if}}
+          {{#with (lookup (lookup (lookup this 'answers') 'experiences') ../global_config.experienceKey)}}
+            {{#if apiKey}}apiKey: "{{apiKey}}"{{/if}}
+          {{/with}}
+        },
+      {{/with}}
+      {{{ json global_config }}}, 
+      { onReady: () => { {{> @partial-block }} } }
+    ));
   };
 </script>
 <script src="https://assets.sitescdn.net/answers/v1.0.0/answers.min.js" onload="initAnswers()" async></script>


### PR DESCRIPTION
…riable.

This PR updates the core.hbs partial to pull both apiKey and businessId from the env.JAMBO_INJECTED_DATA parameter. This parameter represents the JAMBO_INJECTED_DATA environment variable, which can store account data. Note that priority is still given to the global_config.json. So, if apiKey or businessId are defined in that file, those values will be used when initializing the SDK. However, if those values are not present in the file, we can now pull them from JAMBO_INJECTED_DATA.

In a future PR, we will update the global_config.json template to not include apiKey.

J=SPR-2037,SPR-2038
TEST=manual

Tested the following:

- The businessId and apiKey in my local JAMBO_INJECTED_DATA were correctly included in the 
   output HTML.
- The apiKey and businessId in my global_config.json took priority.
- Everything worked as normal if I did not have a JAMBO_INJECTED_DATA environment variable 
   (but the values were specified in the global_config).