### PR TITLE
Templates: Add support for iconUrl to Universal, Vertical, and Locator

### DIFF
--- a/templates/locator/script/verticalresults.hbs
+++ b/templates/locator/script/verticalresults.hbs
@@ -16,6 +16,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({{{ json componentSettings
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
+        {{#if iconUrl}}iconUrl: '{{iconUrl}}',{{/if}}
         label:
         {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},

--- a/templates/universal/script/universalresults.hbs
+++ b/templates/universal/script/universalresults.hbs
@@ -12,25 +12,10 @@ ANSWERS.addComponent('UniversalResults', Object.assign({{{ json componentSetting
                   {{/if}}
                   title: {{#if sectionTitle}}'{{sectionTitle}}'{{else}}{{#if label}}'{{label}}'{{else}}'{{../verticalKey}}'{{/if}}{{/if}},
                   {{#if icon}}
-                      icon: '{{icon}}',
+                      sectionTitleIconName: '{{icon}}',
                   {{/if}}
+                  {{#if iconUrl}}sectionTitleIconUrl: '{{iconUrl}}',{{/if}}
                   viewAllText: {{#if viewAllText}}{{viewAllText}}{{else}}'View All'{{/if}},
-                  verticalPages: [
-                  {{#with ../../verticalConfigs}}
-                    {{#each this}}
-                      {{#if verticalKey}}
-                        {
-                          verticalKey: '{{verticalKey}}',
-                          {{#with (lookup verticalsToConfig verticalKey)}}
-                            {{#if icon}}icon: '{{icon}}',{{/if}}
-                            label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-                            url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
-                          {{/with}}
-                        }{{#unless @last}},{{/unless}}
-                      {{/if}}
-                    {{/each}}
-                  {{/with}}
-                  ],
               {{/with}}
           },
         {{/if}}

--- a/templates/vertical/script/verticalresults.hbs
+++ b/templates/vertical/script/verticalresults.hbs
@@ -17,6 +17,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({{{ json componentSettings
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
+        {{#if iconUrl}}iconUrl: '{{iconUrl}}',{{/if}}
         label:
         {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},


### PR DESCRIPTION
Add iconUrl support to the theme for VerticalResults and UniversalResults in the Universal, Vertical, and Locator templates. Also remove unused `verticalPages` param from the Universal template.

TEST=manual

Generate a page using each of these templates, add iconUrl to config. Add the `noResults` config to Vertical and Locator, trigger a no-results state where another vertical had results, view updated icons. On Universal page, search and note that the section title icons update.