### PR TITLE
Config: Set optional layout config to empty string

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -2,8 +2,8 @@
   "apiKey": "<REPLACE ME>",
   "experienceKey": "<REPLACE ME>",
   "businessId": "<REPLACE ME>",
-  "logo": "<REPLACE ME>",
-  "favicon": "<REPLACE ME>",
-  "googleTagManagerName": "<REPLACE ME>",
-  "googleTagManagerID": "<REPLACE ME>"
+  "logo": "",
+  "favicon": "",
+  "googleTagManagerName": "",
+  "googleTagManagerID": ""
 }

--- a/templates/locator/page-config.json
+++ b/templates/locator/page-config.json
@@ -12,8 +12,7 @@
       "cardType": "LocationCard"
     }
   },
-  "metaTitle": "<REPLACE ME>",
-  "metaDescription": "<REPLACE ME>",
-  "canonicalUrl": "<REPLACE ME>",
-  "keywords": "<REPLACE ME>"
+  "metaDescription": "",
+  "canonicalUrl": "",
+  "keywords": ""
 }

--- a/templates/universal/page-config.json
+++ b/templates/universal/page-config.json
@@ -10,7 +10,7 @@
       "isFirst": "true"
     }
   },
-  "metaDescription": "<REPLACE ME>",
-  "canonicalUrl": "<REPLACE ME>",
-  "keywords": "<REPLACE ME>"
+  "metaDescription": "",
+  "canonicalUrl": "",
+  "keywords": ""
 }

--- a/templates/vertical/page-config.json
+++ b/templates/vertical/page-config.json
@@ -11,7 +11,7 @@
       "cardType": "<REPLACE ME>"
     }
   },
-  "metaDescription": "<REPLACE ME>",
-  "canonicalUrl": "<REPLACE ME>",
-  "keywords": "<REPLACE ME>"
+  "metaDescription": "",
+  "canonicalUrl": "",
+  "keywords": ""
 }


### PR DESCRIPTION
Updating optional layout config to empty string. If HH's do not want to enter anything for this config, now no action is required. Previously, a HH would have had to delete "<REPLACE ME>" or the entire config option.

TEST=manual

Generate page of each type, note that layout elements corresponding to this config are not present in the DOM. 