### PR TITLE
Add 'any' and 'all' handlebars helpers

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -19,11 +19,11 @@
           {{> @partial-block }}
 
           ANSWERS.registerHelper('all', function (...args) {
-            return args.filter(item =>item).length === args.length;
+            return args.filter(item => item).length === args.length;
           });
 
           ANSWERS.registerHelper('any', function (...args) {
-            return args.filter(item =>item).length > 1;
+            return args.filter(item => item).length > 1;
           });
         }
       }


### PR DESCRIPTION
Add 'all' and 'any' handlebars helpers that take in a variable amount of arguments. Adding these handlebars helpers allows multiple conditions in 'if' statements. Usage for that would look like this:

{{#if (any A B) }}

TEST=manual

On local site, test compilation of handlebars templates using both 'all' and 'any'. Set A to true, B to false; A false, B false; A true, B true. Verify that for 'all' and 'any' that the statements evaluate properly.