### PR TITLE
Update static SCSS assets to support RTF formatting for card.details.

### DIFF
--- a/static/scss/answers/cards/accordion.scss
+++ b/static/scss/answers/cards/accordion.scss
@@ -81,6 +81,8 @@
 
   &-details
   {
+    @include rich_text_formatting;
+
     margin: 8px 16px;
     font-size: 14px;
     color:$text-primary;

--- a/static/scss/answers/cards/location.scss
+++ b/static/scss/answers/cards/location.scss
@@ -5,6 +5,11 @@
   font-size: .875rem;
   background-color: #fff;
 
+  &-bio
+  {
+    @include rich_text_formatting;
+  }
+
   &-wrapper,
   &-contentWrapper
   {

--- a/static/scss/answers/cards/standard.scss
+++ b/static/scss/answers/cards/standard.scss
@@ -5,6 +5,11 @@
   display: flex;
   font-size: .875rem;
 
+  &-detailsText
+  {
+    @include rich_text_formatting;
+  }
+
   &-wrapper,
   &-contentWrapper
   {

--- a/static/scss/common/mixins.scss
+++ b/static/scss/common/mixins.scss
@@ -4,3 +4,63 @@
 // Utility Mixins:
 
 @import 'util/UtilityMixins';
+
+@mixin u_styling {
+  text-decoration: underline;
+}
+
+@mixin ul_styling
+{
+  list-style-type: initial;
+  list-style-position: inside;
+}
+
+@mixin ol_styling
+{
+  list-style-type: decimal;
+  list-style-position: inside;
+}
+
+@mixin strong_styling
+{
+  font-weight: $font-weight-bold;
+}
+
+@mixin em_styling
+{
+  font-style: italic;
+}
+
+@mixin rich_text_formatting
+{
+  ul
+  {
+    @include ul_styling;
+
+    display: flex;
+    flex-direction: column;
+  }
+
+  ol
+  {
+    @include ol_styling;
+
+    display: flex;
+    flex-direction: column;
+  }
+
+  strong
+  {
+    @include strong_styling;
+  }
+
+  em
+  {
+    @include em_styling;
+  }
+  
+  u
+  {
+    @include u_styling;
+  }
+}


### PR DESCRIPTION
This PR updates the static SCSS assets to support RTF formatting for a card's
details field. The common/base.scss includes a number of CSS resets that
impact tags used for RTF formatting. These resets were preventing the resultant
HTML of the RTF formatter from displaying properly. So, I added a number of
mixins to fix these styling problems. These mixins were the same ones added by
Consulting to get RTF formatting styled properly for the NJ Covid site. I am
only including these mixins when styling card.details for the various Cards.
Currently, we only offer RTF formatting for this field.

J=SPR-2131
TEST=manual

For each of the 3 types of cards, made sure RTF values were properly displayed
for the details.