### PR TITLE
Update VerticalResults config to have component settings override defaults

### DIFF
--- a/templates/locator/script/verticalresults.hbs
+++ b/templates/locator/script/verticalresults.hbs
@@ -1,14 +1,11 @@
-ANSWERS.addComponent('VerticalResults', Object.assign({{{ json componentSettings.VerticalResults }}}, {
+ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   container: '#js-answersVerticalResults',
-  {{#if componentSettings.VerticalResults.verticalKey}}
-    verticalKey: '{{componentSettings.VerticalResults.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
+      {{#if verticalKey}}
       {
         verticalKey: '{{verticalKey}}',
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
@@ -22,13 +19,12 @@ ANSWERS.addComponent('VerticalResults', Object.assign({{{ json componentSettings
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
         {{/with}}
       }{{#unless @last}},{{/unless}}
+      {{/if}}
     {{/each}}
   ],
-  {{#each verticalsToConfig}}
-    {{#ifeq @key ../verticalKey}}
-      card: {
-        {{#if cardType}}cardType: '{{cardType}}',{{/if}}
-      }
-    {{/ifeq}}
-  {{/each}}
-}));
+  {{#with (lookup verticalsToConfig verticalKey)}}
+    card: {
+      {{#if cardType}}cardType: '{{cardType}}',{{/if}}
+    }
+  {{/with}},
+}, {{{ json componentSettings.VerticalResults }}}));

--- a/templates/vertical/script/verticalresults.hbs
+++ b/templates/vertical/script/verticalresults.hbs
@@ -1,11 +1,7 @@
-ANSWERS.addComponent('VerticalResults', Object.assign({{{ json componentSettings.VerticalResults }}}, {
+ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   container: '.js-answersVerticalResults',
-  {{#if componentSettings.VerticalResults.verticalKey}}
-    verticalKey: '{{componentSettings.VerticalResults.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
@@ -26,11 +22,9 @@ ANSWERS.addComponent('VerticalResults', Object.assign({{{ json componentSettings
       {{/if}}
     {{/each}}
   ],
-  {{#each verticalsToConfig}}
-    {{#ifeq @key ../verticalKey}}
-      card: {
-        {{#if cardType}}cardType: '{{cardType}}',{{/if}}
-      }
-    {{/ifeq}}
-  {{/each}}
-}));
+  {{#with (lookup verticalsToConfig verticalKey)}}
+    card: {
+      {{#if cardType}}cardType: '{{cardType}}',{{/if}}
+    }
+  {{/with}},
+}, {{{ json componentSettings.VerticalResults }}}));


### PR DESCRIPTION
Use the "with", "lookup" helpers instead of "each", "ifeq". Allow component settings override theme defaults. In Locator template, check for verticalKey before making verticalPages config to be consistent with Vertical template.

TEST=manual

Generate pages using Vertical and Locator templates, look at HTML file after jambo build to check it. Then view page in browser and verify that the page renders as usual. Add componentSettings that are different from the defaults and see them take affect.