### PR TITLE
Use Formatter in place of HitchhikerJS

### DIFF
--- a/cards/event/component.js
+++ b/cards/event/component.js
@@ -18,8 +18,8 @@ class EventCardComponent extends BaseCard.EventCard {
       url: profile.website, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      date: HitchhikerJS.Formatters.bigDate(profile),
-      subtitle: HitchhikerJS.Formatters.dateRange(profile),
+      date: Formatter.bigDate(profile),
+      subtitle: Formatter.dateRange(profile),
       details: profile.description, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
@@ -41,7 +41,7 @@ class EventCardComponent extends BaseCard.EventCard {
       CTA2: {
         label: 'Directions',
         iconName: 'directions',
-        url: HitchhikerJS.Formatters.getDirectionsUrl(profile),
+        url: Formatter.getDirectionsUrl(profile),
         target: '_top',
         eventType: 'DRIVING_DIRECTIONS',
         eventOptions: this.addDefaultEventOptions()

--- a/cards/location/component.js
+++ b/cards/location/component.js
@@ -19,7 +19,7 @@ class LocationCardComponent extends BaseCard.LocationCard {
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(), // The event options for title click analytics
       // subtitle: '', // The sub-header text of the card
-      hours: HitchhikerJS.Formatters.openStatus(profile),
+      hours: Formatter.openStatus(profile),
       // services: [], // Used for a comma delimited list of services for the location
       address: profile.address, // The address for the card
       phone: profile.mainPhone || '', // The phone number for the card


### PR DESCRIPTION
This is a follow-up to (#63) which adds a 'Formatter' alias to the window.
It updates the remaining usages of HitchhikerJS to use the new alias.

TEST=manual

Made sure both LocationCard and EventCard were still working 
properly by using each card on the page, checking hours on LocationCard
and date and directions on EventCard.