### PR TITLE
Fix accordion card chevron icon not flipping after setState

### DIFF
--- a/cards/accordion/component.js
+++ b/cards/accordion/component.js
@@ -68,6 +68,7 @@ class AccordionCardComponent extends BaseCard.AccordionCard {
     const accordionToggleSelector = '.js-HitchhikerAccordionCard-toggle';
     const accordionContentSelector = '.js-HitchhikerAccordionCard-content';
     const accordionExpandedClass = 'HitchhikerAccordionCard--expanded';
+    const accordionCardSelector = '.js-HitchhikerAccordionCard';
 
     const accordionToggleEl = self._container.querySelector(accordionToggleSelector);
     if (!accordionToggleEl) {
@@ -77,8 +78,10 @@ class AccordionCardComponent extends BaseCard.AccordionCard {
     const contentEl = this._container.querySelector(accordionContentSelector);
     contentEl.style.height = `${self.isExpanded ? contentEl.scrollHeight : 0}px`;
 
+    const cardEl = this._container.querySelector(accordionCardSelector);
+
     accordionToggleEl.addEventListener('click', function() {
-      this.classList.toggle(accordionExpandedClass, !self.isExpanded);
+      cardEl.classList.toggle(accordionExpandedClass, !self.isExpanded);
       self.isExpanded = !self.isExpanded;
       const isExpanded = self.isExpanded;
       this.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');


### PR DESCRIPTION
Moved the --expanded class to the top level. setState was putting
--expanded at the top level but the click handler was putting the class
on the button, I think it probably makes more sense at the top but
either should work here.

TEST=manual
this time also watching the icon
expand -> show more -> collapse -> expand (see that is still showing more) -> show less -> collapse -> expand

expand -> show more -> show less -> show more -> show less -> collapse