### PR TITLE
Location card update to empty details by default

### DIFF
--- a/cards/location/component.js
+++ b/cards/location/component.js
@@ -26,7 +26,7 @@ class LocationCardComponent extends BaseCard.LocationCard {
       phoneEventType: 'TAP_TO_CALL', // The analytics event type for phone clicks
       phoneEventOptions: this.addDefaultEventOptions(), // The analytics event options for phone clicks
       distance: profile.d_distance, // Distance from the user’s or inputted location
-      details: profile.description, // The description for the card, displays below the address and phone
+      // details: profile.description, // The description for the card, displays below the address and phone
       // tagLabel: '', // The label of the displayed image
       // image: '', // The URL of the image to display on the card
       CTA1: { // The primary call to action for the card


### PR DESCRIPTION
TEST=manual

Use Location Card on vertical page with no details, check styling looks as expected and there are no details.