### PR TITLE
Remove QASubmission from every template's default componentSettings.

### DIFF
--- a/templates/universal/page-config.json
+++ b/templates/universal/page-config.json
@@ -1,10 +1,6 @@
 {
   "pageTitle": "<REPLACE ME>",
-  "componentSettings": {
-    "QASubmission": {
-      "entityId": "<REPLACE ME>"
-    }
-  },
+  "componentSettings": {},
   "verticalsToConfig": {
     "Universal": {
       "isFirst": "true"

--- a/templates/vertical/page-config.json
+++ b/templates/vertical/page-config.json
@@ -1,11 +1,7 @@
 {
   "verticalKey": "<REPLACE ME>",
   "pageTitle": "<REPLACE ME>",
-  "componentSettings": {
-    "QASubmission": {
-      "entityId": "<REPLACE ME>"
-    }
-  },
+  "componentSettings": {},
   "verticalsToConfig": {
     "<REPLACE ME>": {
       "cardType": "<REPLACE ME>"


### PR DESCRIPTION
This PR ensures that QASubmission is removed from the componentSettings of
every template's page-config.json. Leaving it in was causing confusion since
the QASubmission component does not show up on a universal, vertical, or
locator page by default.

J=SPR-2094
TEST=none