### PR TITLE
Universal Template: Accept vertical config from universal page's config.json

### DIFF
--- a/templates/universal/script/universalresults.hbs
+++ b/templates/universal/script/universalresults.hbs
@@ -36,7 +36,6 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
   {{#if iconUrl}}sectionTitleIconUrl: '{{iconUrl}}',{{/if}}
   viewAllText: {{#if viewAllText}}{{viewAllText}}{{else}}'View All'{{/if}},
   {{#if mapConfig}}
-    includeMap: true,
     mapConfig: Object.assign({
       apiKey: HitchhikerJS.getDefaultMapApiKey(('{{ mapConfig.mapProvider }}'))
     }, {{{ json mapConfig }}}),


### PR DESCRIPTION
This allows vertical config for the Universal page to live in the Universal page's config. This may be used for verticals that don't have a page or in cases where configuration is different on the Universal page than on the Vertical page. If the Universal page's config has information for a vertical, it will not attempt to pull any config from the Vertical's page (if it exists).

TEST=manual

Generate a Universal page. Add configuration for a vertical without a page. Add (different) configuration for a vertical with a page.