### PR TITLE
Add formatter to nationalize phone number, use in Location Card

### DIFF
--- a/cards/location/component.js
+++ b/cards/location/component.js
@@ -22,7 +22,7 @@ class LocationCardComponent extends BaseCard.LocationCard {
       hours: Formatter.openStatus(profile),
       // services: [], // Used for a comma delimited list of services for the location
       address: profile.address, // The address for the card
-      phone: profile.mainPhone || '', // The phone number for the card
+      phone: Formatter.nationalizedPhoneDisplay(profile), // The phone number for the card
       phoneEventType: 'TAP_TO_CALL', // The analytics event type for phone clicks
       phoneEventOptions: this.addDefaultEventOptions(), // The analytics event options for phone clicks
       distance: profile.d_distance, // Distance from the user’s or inputted location

--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -1,3 +1,5 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
+
 /**
  * Contains some of the commonly used formatters for parsing pieces
  * of profile information.
@@ -15,6 +17,14 @@ export default class Formatters {
             return '';
         }
         return `${profile[key]}`;
+    }
+
+    static nationalizedPhoneDisplay(profile, key = 'mainPhone') {
+      if (!profile[key]) {
+          return '';
+      }
+      const phoneNumber = parsePhoneNumberFromString(profile[key])
+      return phoneNumber ? phoneNumber.formatNational() : '';
     }
 
     static emailLink(profile) {

--- a/static/package.json
+++ b/static/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "bootstrap-sass": "^3.4.1",
-    "font-awesome": "^4.7.0"
+    "font-awesome": "^4.7.0",
+    "libphonenumber-js": "^1.7.51"
   }
 }


### PR DESCRIPTION
Use the NPM libphonenumber-js package to parse phone numbers into national format. 

TEST=manual

Test passing in non-existant phone numbers, get back empty string. Test using profile data with existing phone numbers, see them format correctly.