### PR TITLE
Map Component to default to config from verticalsToConfig if present

### DIFF
--- a/templates/locator/script/map.hbs
+++ b/templates/locator/script/map.hbs
@@ -1,7 +1,21 @@
-ANSWERS.addComponent('Map', Object.assign(
-  {
-    apiKey: HitchhikerJS.getDefaultMapApiKey('{{ componentSettings.Map.mapProvider }}')
-  },
-  {{{ json componentSettings.Map }}}, 
-  { container: '#js-answersMap' }
-));
+ANSWERS.addComponent('Map', Object.assign({},
+{
+  container: '#js-answersMap',
+  apiKey: HitchhikerJS.getDefaultMapApiKey(
+    {{#if componentSettings.Map.mapProvider}}
+      '{{componentSettings.Map.mapProvider}}'
+    {{else}}
+      {{#with (lookup verticalsToConfig verticalKey)}}
+        {{#if mapConfig}}
+          '{{mapConfig.mapProvider}}'
+        {{/if}}
+      {{/with}}
+    {{/if}}
+  ),
+},
+{{#with (lookup verticalsToConfig verticalKey)}}
+  {{#if mapConfig}}
+    {{{json mapConfig}}},
+  {{/if}}
+{{/with}}
+{{{ json componentSettings.Map }}}));


### PR DESCRIPTION
If there is a map config in the page's verticalsToConfig (for the verticalKey of the page), then the Map Component will default to using that configuration. If there is Map configuration provided in component settings, that will still take priority.

TEST=manual

Use locator template with map config in componentSettings, verticalsToConfig, both, and neither.