### PR TITLE
Remove unused map partials from vertical template

### DIFF
--- a/templates/vertical/markup/map.hbs
+++ b/templates/vertical/markup/map.hbs
@@ -1,1 +1,0 @@
-<div id="standard-map-container"></div>

--- a/templates/vertical/script/map.hbs
+++ b/templates/vertical/script/map.hbs
@@ -1,3 +1,0 @@
-ANSWERS.addComponent('Map', Object.assign({{{ json componentSettings.Map }}}, {
-  container: '#standard-map-container'
-}));


### PR DESCRIPTION
The vertical template's page.html.hbs does not use these partials, and a map component is not wanted/needed in this template. If a map is wanted, HHs will use the Locator template instead. Deleting the unused partials.

TEST=manual

Generate page with vertical template, compile, and view in browser.