### PR TITLE
patch accordion card replaying expanding animation on show more/less

### DIFF
--- a/static/scss/answers/cards/accordion.scss
+++ b/static/scss/answers/cards/accordion.scss
@@ -55,6 +55,11 @@
     transform: rotate(-90deg);
   }
 
+  &--expanded &-content	
+  {	
+    height: auto;
+  }
+
   &-content
   {
     height: 0;


### PR DESCRIPTION
The accordion card needs height: auto on its &-content
when it is expanded, otherwise what happens when you click showmore/less
is that setState is called, the accordion card rerenders with &-content
having height 0, then &-content has its height set to scrollHeight
by the component and the expanding animation plays.

TEST=manual
tested that clicking showmore/show less does not replay the animation
animation