### PR TITLE
remove map apiKey from vertical-standard

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -37,7 +37,7 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
   viewAllText: {{#if viewAllText}}{{viewAllText}}{{else}}'View All'{{/if}},
   {{#if mapConfig}}
     mapConfig: Object.assign({
-      apiKey: HitchhikerJS.getDefaultMapApiKey(('{{ mapConfig.mapProvider }}'))
+      apiKey: HitchhikerJS.getDefaultMapApiKey('{{ mapConfig.mapProvider }}')
     }, {{{ json mapConfig }}}),
   {{/if}}
 {{/inline}}

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -3,13 +3,6 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   {{#if verticalKey}}
     verticalKey: '{{verticalKey}}',
   {{/if}}
-  {{#with componentSettings.VerticalResults}}
-    {{#if mapConfig}}
-      mapConfig: Object.assign({
-        apiKey: HitchhikerJS.getDefaultMapApiKey(('{{ mapConfig.mapProvider }}'))
-      }, {{{ json mapConfig }}}),
-    {{/if}}
-  {{/with}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}


### PR DESCRIPTION
This commit removes default mapConfig apiKey from vertical-standard, since verticals with maps should use the vertical-map template, and also fixes an extra set of parenthesis in universal-standard's getDefaultMapApiKey. Apparently javascript methods run fine with extra parenthesis but this should still be removed.