### PR TITLE
Fix default card specified in vertical-map's page-config.

### DIFF
--- a/templates/vertical-map/page-config.json
+++ b/templates/vertical-map/page-config.json
@@ -37,7 +37,7 @@
   "verticalsToConfig": {
     "<REPLACE ME>": { // The vertical key from your search configuration
       // "label": "", // The name of the vertical in the section header and the navigation bar
-      "cardType": "location", // The name of the card to use - e.g. accordion, location, customcard 
+      "cardType": "location-standard", // The name of the card to use - e.g. accordion, location, customcard 
       "icon": "pin" // The icon to use on the card for this vertical
     }
   }


### PR DESCRIPTION
The 'location' card no longer exists. Instead, it is called
'location-standard'.

TEST=none