### PR TITLE
don't inject bundled css/js

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -49,7 +49,7 @@
     {{#if global_config.favicon}}
       <link rel="shortcut icon" href="../{{global_config.favicon}}">
     {{/if}}
-
+    <script src="bundle.js"></script>
     {{#if global_config.googleAnalyticsId}}
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id={{global_config.googleAnalyticsId}}"></script>
@@ -71,6 +71,7 @@
       })(window,document,'script','{{#if global_config.googleTagManagerName}}{{global_config.googleTagManagerName}}{{else}}dataLayer{{/if}}','{{global_config.googleTagManagerId}}');</script>
       <!-- End Google Tag Manager -->
     {{/if}}
+    <link rel="stylesheet" type="text/css" href="bundle.css">
 	</head>
   <body>
     {{#if global_config.googleTagManagerId}}

--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -780,4 +780,4 @@ export default class Formatters {
   }
 }
 
-global.Formatters = Formatters;
+global.Formatter = Formatters;

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -10,7 +10,8 @@ const htmlPlugins = [];
 fs.recurseSync(jamboConfig.dirs.output, ['**/*.html'], (filepath, relative, filename) => {
   htmlPlugins.push(new HtmlPlugin({
     filename: filename,
-    template: path.join(jamboConfig.dirs.output, filename)
+    template: path.join(jamboConfig.dirs.output, filename),
+    inject: false
   }));
 });
 
@@ -18,13 +19,13 @@ module.exports = {
   mode: 'production',
   entry: './static/entry.js',
   output: {
-    filename: 'HitchhikerJS.[contenthash].js',
+    filename: 'bundle.js',
     path: path.resolve(__dirname, jamboConfig.dirs.output),
     library: 'HitchhikerJS',
     libraryTarget: 'window'
   },
   plugins: [
-    new MiniCssExtractPlugin({ filename: 'HitchhikerCSS.[contenthash].css' }),
+    new MiniCssExtractPlugin({ filename: 'bundle.css' }),
     ...htmlPlugins
   ],
   optimization: {


### PR DESCRIPTION
We won't get [contenthash] caching on css and js but I think that's okay for now.
Also fix typo, the old reference to the Formatters class was Formatter not Formatters
TEST=manual
ran HitchhikerJS.Formatters._intToDay(1) and Formatter._intToDay(1) in
the console
opened universal-standard, vertical-standard, vertical-map pages and no console errors
checked that generated html had bundle.js and bundle.css in the <head>
check that my favicon still loads