### PR TITLE
change webpack config to a function to fix grunt watch

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -4,81 +4,84 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ClosurePlugin = require('closure-webpack-plugin');
 const HtmlPlugin = require('html-webpack-plugin');
 
-const jamboConfig = JSON.parse(fs.readFileSync('jambo.json'))
+module.exports = function () {
+  const jamboConfig = JSON.parse(fs.readFileSync('jambo.json'))
+  const htmlPlugins = [];
+  if (fs.existsSync(jamboConfig.dirs.output)) {
+    fs.recurseSync(jamboConfig.dirs.output, ['**/*.html'], (filepath, relative) => {
+      htmlPlugins.push(new HtmlPlugin({
+        filename: relative,
+        template: path.join(jamboConfig.dirs.output, relative),
+        inject: false
+      }));
+    });
+  }
 
-const htmlPlugins = [];
-fs.recurseSync(jamboConfig.dirs.output, ['**/*.html'], (filepath, relative, filename) => {
-  htmlPlugins.push(new HtmlPlugin({
-    filename: filename,
-    template: path.join(jamboConfig.dirs.output, filename),
-    inject: false
-  }));
-});
-
-module.exports = {
-  mode: 'production',
-  entry: './static/entry.js',
-  output: {
-    filename: 'bundle.js',
-    path: path.resolve(__dirname, jamboConfig.dirs.output),
-    library: 'HitchhikerJS',
-    libraryTarget: 'window'
-  },
-  plugins: [
-    new MiniCssExtractPlugin({ filename: 'bundle.css' }),
-    ...htmlPlugins
-  ],
-  optimization: {
-    minimizer: [new ClosurePlugin()]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.scss$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          'css-loader',
-          'resolve-url-loader',
-          'sass-loader'
-        ],
-      },
-      {
-        test: /\.(png|ico|gif|jpe?g|svg|webp|eot|otf|ttf|woff2?)$/,
-        loader: 'file-loader?name=[name].[contenthash].[ext]',
-      },
-      {
-        test: /\.html$/i,
-        loader: 'html-loader',
-        options: {
-          attributes: {
-            /**
-             * @param {String} _ the html attribute like 'href' or 'src'
-             * @param {String} value the path to the static asset
-             */
-            urlFilter: (_, value) => {
-              const assetsDir = '../static/assets/';
-              return value.startsWith(assetsDir);
-            },
-            list: [
-              {
-                tag: 'img',
-                attribute: 'src',
-                type: 'src',
+  return {
+    mode: 'production',
+    entry: './static/entry.js',
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, jamboConfig.dirs.output),
+      library: 'HitchhikerJS',
+      libraryTarget: 'window'
+    },
+    plugins: [
+      new MiniCssExtractPlugin({ filename: 'bundle.css' }),
+      ...htmlPlugins
+    ],
+    optimization: {
+      minimizer: [new ClosurePlugin()]
+    },
+    module: {
+      rules: [
+        {
+          test: /\.scss$/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            'css-loader',
+            'resolve-url-loader',
+            'sass-loader'
+          ],
+        },
+        {
+          test: /\.(png|ico|gif|jpe?g|svg|webp|eot|otf|ttf|woff2?)$/,
+          loader: 'file-loader?name=[name].[contenthash].[ext]',
+        },
+        {
+          test: /\.html$/i,
+          loader: 'html-loader',
+          options: {
+            attributes: {
+              /**
+               * @param {String} _ the html attribute like 'href' or 'src'
+               * @param {String} value the path to the static asset
+               */
+              urlFilter: (_, value) => {
+                const assetsDir = '../static/assets/';
+                return value.startsWith(assetsDir);
               },
-              {
-                tag: 'link',
-                attribute: 'href',
-                type: 'src',
-              },
-              {
-                tag: 'meta',
-                attribute: 'content',
-                type: 'src',
-              }
-            ]
+              list: [
+                {
+                  tag: 'img',
+                  attribute: 'src',
+                  type: 'src',
+                },
+                {
+                  tag: 'link',
+                  attribute: 'href',
+                  type: 'src',
+                },
+                {
+                  tag: 'meta',
+                  attribute: 'content',
+                  type: 'src',
+                }
+              ]
+            }
           }
         }
-      }
-    ],
-  },
+      ],
+    },
+  }
 };


### PR DESCRIPTION
This commit fixes issues with grunt watch trying to read from the output directory before it is created by jambo build. 

I changed the webpack config to be a funcion, then moved file system interactions in the webpack config. This makes it so that these interactions are run when the webpack task itself is run, instead of when the webpack config is imported.

Also added an isExists check before fs.recurseSync in the webpack config.

TEST=manual
rm -rf desktop
grunt watch
\* save a config file to update grunt watch \*
see that page builds with no issues, open page and no console errors
see that page html was affected by HtmlWebpackPlugin (page html is minified and
references to ../static/assets were replaced)
change favicon to another image in static/assets
see that page builds, opened page has no console errors, and that favicon changed

also tested that having pages inside a folder in the output directory like desktop/subdir
were built correctly

check that running grunt webpack by itself with no desktop directory does not crash

went to test jambo site in prod, manually changed webpack config to this, saw that could change favicon to a png and then a gif file