### PR TITLE
Add border to cards on universal

### DIFF
--- a/static/scss/answers/cards/common.scss
+++ b/static/scss/answers/cards/common.scss
@@ -9,11 +9,3 @@
         $style: italic);
     @include TextButton($padding: 0);
 }
-
-.Answers-universalResults
-{
-    .yxt-Card + .yxt-Card
-    {
-        border-top: $border-default;
-    }
-}

--- a/static/scss/legacy-aeb/lanswers-overrides.scss
+++ b/static/scss/legacy-aeb/lanswers-overrides.scss
@@ -39,7 +39,7 @@
 
   @media (min-width: $breakpoint-mobile-max)
   {
-    &:not(:last-child)
+    &:not(:last-child):not(.yxt-Card--universal)
     {
       border-bottom: none;
     }


### PR DESCRIPTION
I wanted a way to do this without referencing any yxt-* classes from
the sdk, but the two divs the HitchhikerCard is nested in make this really hard.
Opted to use yxt-Card instead of yxt-Card--universal since this seemed less likely to be messed up by an sdk change.
TEST=manual
Checked that faq-accordion and location-standard cards had borders on universal