### PR TITLE
Remove duplicate verticalKeys from vertical-map and vertical-standard

### DIFF
--- a/templates/vertical-map/script/facets.hbs
+++ b/templates/vertical-map/script/facets.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('Facets', Object.assign({}, {
   container: '#js-answersFacets',
-  {{#if componentSettings.Facets.verticalKey}}
-    verticalKey: '{{componentSettings.Facets.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-map/script/pagination.hbs
+++ b/templates/vertical-map/script/pagination.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('Pagination', Object.assign({}, {
   container: '#js-answersPagination',
-  {{#if componentSettings.Pagination.verticalKey}}
-    verticalKey: '{{componentSettings.Pagination.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-map/script/searchbar.hbs
+++ b/templates/vertical-map/script/searchbar.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('SearchBar', Object.assign({}, {
   container: '#js-answersSearchBar',
-  {{#if componentSettings.SearchBar.verticalKey}}
-    verticalKey: '{{componentSettings.SearchBar.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/vertical-standard/script/facets.hbs
+++ b/templates/vertical-standard/script/facets.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('Facets', Object.assign({}, {
   container: '#js-answersFacets',
-  {{#if componentSettings.Facets.verticalKey}}
-    verticalKey: '{{componentSettings.Facets.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-standard/script/pagination.hbs
+++ b/templates/vertical-standard/script/pagination.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('Pagination', Object.assign({}, {
   container: '.js-answersPagination',
-  {{#if componentSettings.Pagination.verticalKey}}
-    verticalKey: '{{componentSettings.Pagination.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-standard/script/searchbar.hbs
+++ b/templates/vertical-standard/script/searchbar.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('SearchBar', Object.assign({}, {
   container: '.js-answersSearch',
-  {{#if componentSettings.SearchBar.verticalKey}}
-    verticalKey: '{{componentSettings.SearchBar.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{verticalKey}}',
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));


### PR DESCRIPTION
Since the componentSettings are lower in the Object.assign() the verticalKey from componentSettings will already override defaults, this is just removing extra code.

