### PR TITLE
Return empty {} in Formatter.image when given a null img

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -195,7 +195,7 @@ export default class Formatters {
   */
   static image(img, size = '200x', atLeastAsLarge = true) {
     if (!img) {
-      return null;
+      return {};
     }
     if (!img.url) {
       return img;


### PR DESCRIPTION
This change lets people just do
image: HitchhikerJS.Formatters.image(profile.c_jobPhoto).url
instead of
image: profile.c_jobPhoto ? HitchhikerJS.Formatters.image(profile.c_jobPhoto).url : null,

J=SPR-2184
TEST=manual
test that in console can do HitchhikerJS.Formatters.image(null).url and get undefined
test that it works with alias Formatter.image(null) as well