### PR TITLE
Add support for a conversionTrackingEnabled global_config option.

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -7,5 +7,6 @@
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer
   "googleTagManagerId": "", // The container id associated with your Google Tag Manager container
-  "googleAnalyticsId": "" // The tracking Id associated with your Google Analytics account
+  "googleAnalyticsId": "", // The tracking Id associated with your Google Analytics account
+  "conversionTrackingEnabled": false // Whether or not conversion tracking is enabled for all pages
 }

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -72,6 +72,10 @@
       <!-- End Google Tag Manager -->
     {{/if}}
     <link rel="stylesheet" type="text/css" href="bundle.css">
+
+    {{#if global_config.conversionTrackingEnabled}}
+      <script src="https://assets.sitescdn.net/ytag/ytag.min.js"></script>
+    {{/if}}
 	</head>
   <body>
     {{#if global_config.googleTagManagerId}}

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -22,6 +22,10 @@
         onReady: () => {
           {{> @partial-block }}
 
+          {{#if global_config.conversionTrackingEnabled}}
+            ANSWERS.setConversionsOptIn(true);
+          {{/if}}
+
           ANSWERS.registerHelper('all', function (...args) {
             return args.filter(item => item).length === args.length;
           });


### PR DESCRIPTION
This PR adds support for a conversionTrackingEnabled option in the
global_config. When true, this option will ensure that conversionTracking
is enabled in the SDK and the needed ytag script is included. Note that the
option defaults to false, as discussed with Liz.

J=SPR-2139
TEST=manaul

Set the new config option to true and obeserved that analytics events were
reported to the correct endpoint and that they also included a first party
cookie. Removed the config option and observed analytics events did not
include such a cookie and were reported to the correct endpoint.