### PR TITLE
Bump SDK version to v1.1

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -1,5 +1,5 @@
-<link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v1.0/answers.css">
-<script src="https://assets.sitescdn.net/answers/v1.0/answerstemplates.compiled.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v1.1/answers.css">
+<script src="https://assets.sitescdn.net/answers/v1.1/answerstemplates.compiled.min.js"></script>
 <script>
   function initAnswers() {
     const JAMBO_INJECTED_DATA = {{{json env.JAMBO_INJECTED_DATA}}} || {};
@@ -38,5 +38,5 @@
     ));
   };
 </script>
-<script src="https://assets.sitescdn.net/answers/v1.0/answers.min.js" onload="initAnswers()" async></script>
+<script src="https://assets.sitescdn.net/answers/v1.1/answers.min.js" onload="initAnswers()" async></script>
 


### PR DESCRIPTION
There was an issue in the SDK with the yxt-Results-titleBar border not matching the border of the cards. A PR (https://github.com/yext/answers/pull/763) is out to fix this in SDK v1.1.1
TEST=manual
tested that the search bar still works in v1.1, which was the main non-readme change, and did a general smoke test (searching for things, clicking tabs, doing near me queries)