### PR TITLE
Use transform data to enable result limits on UniversalResults

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('UniversalResults', Object.assign({}, {
-  container: '.js-answersUniversalResults',
-  config: Object.assign({}, {
+    container: '.js-answersUniversalResults',
+    config: Object.assign({}, {
       {{!-- Map each Vertical config's verticalsToConfig --}}
       {{#each verticalConfigs}}
         {{#if verticalKey}}
@@ -40,5 +40,18 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
     mapConfig: Object.assign({
       apiKey: HitchhikerJS.getDefaultMapApiKey('{{ mapConfig.mapProvider }}')
     }, {{{ json mapConfig }}}),
+  {{/if}}
+  {{#if universalLimit}}
+    transformData: (data) => {
+      let results = data.results;
+      if (results) {
+        results = results.filter((rex, idx) => {
+          return idx < {{universalLimit}};
+        });
+      }
+      return Object.assign(data, {
+        results: results
+      });
+    },
   {{/if}}
 {{/inline}}


### PR DESCRIPTION
The AEB supported this, so for parity the HH theme needs to support it too. The back end of Answers does not currently support result limits on universal results, when that work is complete we should update this.

TEST=manual

On universal page, specify a limit through vTC. See results limited to the number I specified.