### PR TITLE
fix styling for accordion subtitle

### DIFF
--- a/static/scss/answers/cards/accordion.scss
+++ b/static/scss/answers/cards/accordion.scss
@@ -70,8 +70,9 @@
   &-subtitle
   {
     font-size: $font-size-md;
-    color: $text-secondary;
+    color: $color-text-secondary;
     padding-bottom: $base-spacing / 2;
+    margin-left: $base-spacing;
   }
 
   &-details
@@ -80,7 +81,7 @@
 
     margin: $base-spacing / 2 $base-spacing;
     font-size: $font-size-md;
-    color: $text-primary;
+    color: $color-text-primary;
     line-height: $line-height-md;
   }
 


### PR DESCRIPTION
The subtitle was missing a margin-left and also was referencing a color variable that didn't exist. This has been updated to work.

J=SPR-2202
TEST=manual

Updated the static folder in my jambo site, ran grunt webpack, and verified that subtitles looked correct.