### PR TITLE
Add error message to map provider helper if config is missing

### DIFF
--- a/static/js/default-map-api-key.js
+++ b/static/js/default-map-api-key.js
@@ -4,6 +4,11 @@
  * @returns {String}
  */
 export function getDefaultMapApiKey(mapProvider) {
+    if (!mapProvider) {
+      throw new Error(
+        `Please provide a valid mapProvider. '${mapProvider}' is invalid. Expects either 'google' or 'mapbox'.`
+      );
+    }
     switch (mapProvider.toLowerCase()) {
       case 'google':
         return 'AIzaSyB5D45ghF1YMfqTLSzWubmlCN1euBVPhFw';


### PR DESCRIPTION
Was previously getting a "Uncaught TypeError: Cannot read property 'toLowerCase' of undefined" error. This new error message is more user-friendly.

TEST=manual

Test with a page config missing a map provider. See error message. Test with a correct page, see helper operate normally.