### PR TITLE
Add distance formatters for miles and kilometers

### DIFF
--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -25,7 +25,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
       phone: Formatter.nationalizedPhoneDisplay(profile), // The phone number for the card
       phoneEventType: 'TAP_TO_CALL', // The analytics event type for phone clicks
       phoneEventOptions: this.addDefaultEventOptions(), // The analytics event options for phone clicks
-      distance: profile.d_distance, // Distance from the user’s or inputted location
+      distance: Formatter.toMiles(profile), // Distance from the user’s or inputted location
       // details: profile.description, // The description for the card, displays below the address and phone
       // tagLabel: '', // The label of the displayed image
       // image: '', // The URL of the image to display on the card

--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -43,6 +43,22 @@ export default class Formatters {
         return `https://www.google.com/maps/search/?api=1&query=${query}&output=classic`
     }
 
+  static toKilometers(profile, key = 'd_distance', displayUnits = 'km') {
+    if (!profile[key]) {
+      return '';
+    }
+    const distanceInKilometers = profile[key] / 1000; // Convert meters to kilometers
+    return distanceInKilometers.toFixed(1) + ' ' + displayUnits;
+  }
+
+  static toMiles(profile, key = 'd_distance', displayUnits = 'mi') {
+    if (!profile[key]) {
+      return '';
+    }
+    const distanceInMiles = profile[key] / 1609.344; // Convert meters to miles
+    return distanceInMiles.toFixed(1) + ' ' + displayUnits;
+  }
+
   static isTodayHoliday(holidayItem, todayDate) {
     if (!holidayItem.date) {
       return false;


### PR DESCRIPTION
Add formatters that convert the API distance response (in meters) to miles or kilometers and add the units after the distance. Users can specify the key and the display units.

TEST=manual

Test locally using both formatters and an online distance converter to verify the correct values.