### PR TITLE
Remove solo cta styling

### DIFF
--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -56,14 +56,14 @@
         {{#if (all card.CTA1.url card.CTA1.label)}}
         <div class="HitchhikerEventCard-primaryCTA">
           {{#with card.CTA1}}
-            {{> CTA hasSibling=(all ../card.CTA2 ../card.CTA2.url ../card.CTA2.label)}}
+            {{> CTA}}
           {{/with}}
         </div>
         {{/if}}
         {{#if (all card.CTA2.url card.CTA2.label)}}
         <div class="HitchhikerEventCard-secondaryCTA">
           {{#with card.CTA2}}
-            {{> CTA hasSibling=(all ../card.CTA1 ../card.CTA1.url ../card.CTA1.label)}}
+            {{> CTA}}
           {{/with}}
         </div>
         {{/if}}
@@ -74,7 +74,7 @@
 </div>
 
 {{#*inline 'CTA'}}
-  <a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}{{#unless hasSibling}} Hitchhiker-cta--solo{{/unless}}"
+  <a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}"
     href="{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -58,14 +58,14 @@
           {{#if (all card.CTA1.url card.CTA1.label)}}
           <div class="HitchhikerJobCard-primaryCTA">
             {{#with card.CTA1}}
-              {{> CTA hasSibling=(all ../card.CTA2 ../card.CTA2.url ../card.CTA2.label)}}
+              {{> CTA}}
             {{/with}}
           </div>
           {{/if}}
           {{#if (all card.CTA2.url card.CTA2.label)}}
           <div class="HitchhikerJobCard-secondaryCTA">
             {{#with card.CTA2}}
-              {{> CTA hasSibling=(all ../card.CTA1 ../card.CTA1.url ../card.CTA1.label)}}
+              {{> CTA}}
             {{/with}}
           </div>
           {{/if}}
@@ -76,7 +76,7 @@
 </div>
 
 {{#*inline 'CTA'}}
-  <a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}{{#unless hasSibling}} Hitchhiker-cta--solo{{/unless}}"
+  <a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}"
       href="{{url}}"
       data-eventtype="{{eventType}}"
       data-eventoptions='{{json eventOptions}}'

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -93,14 +93,14 @@
           {{#if (all card.CTA1.url card.CTA1.label)}}
           <div class="HitchhikerLocationCard-primaryCTA">
             {{#with card.CTA1}}
-              {{> CTA hasSibling=(all ../card.CTA2 ../card.CTA2.url ../card.CTA2.label)}}
+              {{> CTA}}
             {{/with}}
           </div>
           {{/if}}
           {{#if (all card.CTA2.url card.CTA2.label)}}
           <div class="HitchhikerLocationCard-secondaryCTA">
             {{#with card.CTA2}}
-              {{> CTA hasSibling=(all ../card.CTA1 ../card.CTA1.url ../card.CTA1.label)}}
+              {{> CTA}}
             {{/with}}
           </div>
           {{/if}}
@@ -128,7 +128,7 @@
 {{/inline}}
 
 {{#*inline 'CTA'}}
-<a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}{{#unless hasSibling}} Hitchhiker-cta--solo{{/unless}}"
+<a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}"
    href="{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -60,14 +60,14 @@
         {{#if (all card.CTA1.url card.CTA1.label)}}
         <div class="HitchhikerStandardCard-primaryCTA">
           {{#with card.CTA1}}
-            {{> CTA hasSibling=(all ../card.CTA2 ../card.CTA2.url ../card.CTA2.label)}}
+            {{> CTA}}
           {{/with}}
         </div>
         {{/if}}
         {{#if (all card.CTA2.url card.CTA2.label)}}
         <div class="HitchhikerStandardCard-secondaryCTA">
           {{#with card.CTA2}}
-            {{> CTA hasSibling=(all ../card.CTA1 ../card.CTA1.url ../card.CTA1.label)}}
+            {{> CTA}}
           {{/with}}
         </div>
         {{/if}}
@@ -78,7 +78,7 @@
 </div>
 
 {{#*inline 'CTA'}}
-  <a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}{{#unless hasSibling}} Hitchhiker-cta--solo{{/unless}}"
+  <a class="Hitchhiker-cta js-Hitchhiker-cta{{#if modifiers}} {{modifiers}}{{/if}}"
     href="{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'

--- a/static/scss/answers/cards/ctas.scss
+++ b/static/scss/answers/cards/ctas.scss
@@ -12,21 +12,10 @@
   border-radius: .25rem;
   min-width: 3.75rem;
 
-  &--solo {
-    flex-direction: column;
-    padding: $base-spacing / 2;
-  }
-
   &-iconWrapper
   {
     display: flex;
     padding-right: $base-spacing / 2;
-  }
-
-  &--solo &-iconWrapper {
-    justify-content: center;
-    padding-left: $base-spacing * 2;
-    padding-right: $base-spacing * 2;
   }
 
   &-iconLabel
@@ -35,10 +24,6 @@
     justify-content: center;
     align-items: center;
     white-space: nowrap;
-  }
-
-  &--solo &-iconLabel {
-    margin-top: $base-spacing / 2;
   }
 
   &-icon


### PR DESCRIPTION
CTAs should always be styled as if they are on mobile, removing solo CTA styling for when there is only one CTA.

TEST=manual,visual

Test each card with one and two CTAs in the browser. 