### PR TITLE
Default canonical url to prod domain in jambo injected data

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -36,12 +36,15 @@
     {{/if}}
     {{#if canonicalUrl}}
       <meta property="og:url" content="{{canonicalUrl}}">
+      <link rel="canonical" href="{{canonicalUrl}}" />
+    {{else if env.JAMBO_INJECTED_DATA.pages.domains.prod.domain}}
+      {{#with env.JAMBO_INJECTED_DATA.pages.domains.prod}}
+        <meta property="og:url" content="{{#if isHttps}}https://{{else}}http://{{/if}}{{domain}}">
+        <link rel="canonical" href="{{#if isHttps}}https://{{else}}http://{{/if}}{{domain}}">
+      {{/with}}
     {{/if}}
     <meta name="twitter:card" content="summary">
 
-    {{#if canonicalUrl}}
-      <link rel="canonical" href="{{canonicalUrl}}" />
-    {{/if}}
     {{#if pageTitle}}
       <title>{{pageTitle}}</title>
     {{/if}}


### PR DESCRIPTION
TEST=manual
```
export JAMBO_INJECTED_DATA='
{
  "businessId": 0,
  "answers": {
    "experiences": {
      "key": {
        "apiKey": "liveAPIKey"
      }
    }
  },
  "pages": {
    "stagingDomains": [
      "yextpages.local",
      "landingpagespreview.loc"
    ],
    "domains": {
      "prod": {
        "isHttps": true,
        "domain": "foo.com"
      },
      "staging": {
        "isHttps": true,
        "domain": "foo_com.yextpages.local"
      }
    }
  }
}
'
```
saw canonical url set to foo.com with https (so https://foo.com)

export JAMBO_INJECTED_DATA="{}"
saw no canonical url