### PR TITLE
fix cta icon error when only iconUrl present

### DIFF
--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -82,11 +82,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="Hitchhiker-cta-iconWrapper">
       <div class="Hitchhiker-cta-icon" data-component="IconComponent" data-opts='{ 
-        {{#if iconUrl}}
-        "iconUrl": "{{iconUrl}}"
-        {{else if iconName}}
+        "iconUrl": "{{iconUrl}}",
         "iconName": "{{iconName}}"
-        {{/if}}
       }'>
       </div>
     </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -68,11 +68,8 @@
   {{#if (any iconName iconUrl)}}
   <div class="Hitchhiker-cta-iconWrapper">
     <div class="Hitchhiker-cta-icon" data-component="IconComponent" data-opts='{ 
-      {{#if iconUrl}}
-      "iconUrl": "{{iconUrl}}"
-      {{else if iconName}}
+      "iconUrl": "{{iconUrl}}",
       "iconName": "{{iconName}}"
-      {{/if}}
     }'>
     </div>
   </div>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -84,11 +84,8 @@
       {{#if (any iconName iconUrl)}}
       <div class="Hitchhiker-cta-iconWrapper">
         <div class="Hitchhiker-cta-icon" data-component="IconComponent" data-opts='{ 
-          {{#if iconUrl}}
-          "iconUrl": "{{iconUrl}}"
-          {{else if iconName}}
+          "iconUrl": "{{iconUrl}}",
           "iconName": "{{iconName}}"
-          {{/if}}
         }'>
         </div>
       </div>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -136,11 +136,8 @@
   {{#if (any iconName iconUrl)}}
   <div class="Hitchhiker-cta-iconWrapper">
     <div class="Hitchhiker-cta-icon" data-component="IconComponent" data-opts='{ 
-      {{#if iconUrl}}
-      "iconUrl": "{{iconUrl}}"
-      {{else if iconName}}
+      "iconUrl": "{{iconUrl}}",
       "iconName": "{{iconName}}"
-      {{/if}}
     }'>
     </div>
   </div>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -110,11 +110,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="Hitchhiker-cta-iconWrapper">
       <div class="Hitchhiker-cta-icon" data-component="IconComponent" data-opts='{ 
-        {{#if iconUrl}}
-        "iconUrl": "{{iconUrl}}"
-        {{else if iconName}}
+        "iconUrl": "{{iconUrl}}",
         "iconName": "{{iconName}}"
-        {{/if}}
       }'>
       </div>
     </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -117,11 +117,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="Hitchhiker-cta-iconWrapper">
       <div class="Hitchhiker-cta-icon" data-component="IconComponent" data-opts='{ 
-        {{#if iconUrl}}
-        "iconUrl": "{{iconUrl}}"
-        {{else if iconName}}
+        "iconUrl": "{{iconUrl}}",
         "iconName": "{{iconName}}"
-        {{/if}}
       }'>
     </div>
     {{/if}}

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -86,11 +86,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="Hitchhiker-cta-iconWrapper">
       <div class="Hitchhiker-cta-icon" data-component="IconComponent" data-opts='{ 
-        {{#if iconUrl}}
-        "iconUrl": "{{iconUrl}}"
-        {{else if iconName}}
+        "iconUrl": "{{iconUrl}}",
         "iconName": "{{iconName}}"
-        {{/if}}
       }'>
       </div>
     </div>


### PR DESCRIPTION
> fixes an issue with a leading comma in data-opts if
> only iconUrl is present
> 
> also fix 2 instances where iconUrl if iconName is not present
> 
> TEST=manual
> changed events vertical to use event-standard card in universal,
> checked that using only iconUrl does not error like before
> checked that having both present uses iconUrl
> checked that only iconName still works

forget the above!
we don't need the null checking, handlebars will interpret null and undefined as blank strings.  I think this makes intuitive sense as well, since if I was using building an html page with handlebars and passed in a null/undefined variable into a div I would probably want it to be blank, not "null" or "undefined".
test=manual
test1:
iconName: chevron
iconUrl: https://media1.tenor.com/images/678955ca4337fc9a61ceb342ecb26760/tenor.gif
-> url

test2:
iconUrl: https://media1.tenor.com/images/678955ca4337fc9a61ceb342ecb26760/tenor.gif
-> url

test3:
iconName: chevron
-> chevron

test4:
iconName: null
iconUrl: https://media1.tenor.com/images/678955ca4337fc9a61ceb342ecb26760/tenor.gif
-> url

test5:
iconName: chevron
iconUrl: null
-> chevron

test6:
iconName: null
iconUrl: null
-> no icon