### PR TITLE
Fixes for ifeq 'true', add quotes, add missing param to universal

### DIFF
--- a/templates/universal-standard/script/navigation.hbs
+++ b/templates/universal-standard/script/navigation.hbs
@@ -8,14 +8,14 @@ verticalPages: [
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig 'Universal')}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -35,7 +35,10 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
       sectionTitleIconName: '{{icon}}',
   {{/if}}
   {{#if iconUrl}}sectionTitleIconUrl: '{{iconUrl}}',{{/if}}
-  viewAllText: {{#if viewAllText}}{{viewAllText}}{{else}}'View All'{{/if}},
+  viewAllText: {{#if viewAllText}}'{{viewAllText}}'{{else}}'View All'{{/if}},
+  {{#if includeMap}}
+    includeMap: {{includeMap}},
+  {{/if}}
   {{#if mapConfig}}
     mapConfig: Object.assign({
       apiKey: HitchhikerJS.getDefaultMapApiKey('{{ mapConfig.mapProvider }}')

--- a/templates/vertical-map/script/navigation.hbs
+++ b/templates/vertical-map/script/navigation.hbs
@@ -8,14 +8,14 @@ verticalPages: [
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig 'Universal')}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -12,7 +12,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         {{#if iconUrl}}iconUrl: '{{iconUrl}}',{{/if}}
         label:

--- a/templates/vertical-standard/script/navigation.hbs
+++ b/templates/vertical-standard/script/navigation.hbs
@@ -8,14 +8,14 @@ verticalPages: [
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig 'Universal')}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
         url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -12,7 +12,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
-        {{#ifeq isFirst 'true'}}isFirst: true,{{/ifeq}}
+        {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: '{{icon}}',{{/if}}
         {{#if iconUrl}}iconUrl: '{{iconUrl}}',{{/if}}
         label:


### PR DESCRIPTION
Previously the theme was using {{#ifeq isFirst 'true'}} checks to test if the isFirst variable was true. That check only worked if the JSON's isFirst value was the string "true", but did not work with the boolean true. Updated to check if the isFirst config option is present, if so, use it. Since there are no quotes in the hbs, "true" as a string or as a boolean would be printed without the quotes.

Add quotes to the viewAllText in UniversalResults, they were previously absent which caused parse errors.

Add includeMap param to UniversalResults if the user passes it through. 

TEST=manual

Use local test site, specify isFirst using boolean then string for true and false values. Add viewAllText to a vertical in verticalsToConfig. Add a map on UniversalResults using the includeMap config option.