### PR TITLE
Add closing div to professional-standard icon component container

### DIFF
--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -119,7 +119,7 @@
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
         "iconUrl": "{{iconUrl}}",
         "iconName": "{{iconName}}"
-      }'>
+      }'></div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>


### PR DESCRIPTION
TEST=manual

Use card on local site, inspect DOM in browser to see the icon class is inside the iconWrapper class.