### PR TITLE
Add support for vertical search limits

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -34,7 +34,6 @@
       },
       {
         onReady: () => {
-
           {{> @partial-block }}
 
           {{#if global_config.conversionTrackingEnabled}}


### PR DESCRIPTION
Allow implementers to specify a verticalLimit, which passes in config to the SDK that limits the number of results returned for a vertical on a vertical page. Per Liz, the verticalLimit should be specified in verticalsToConfig.

TEST=manual

Specify verticalLimit in verticalsToConfig on a vertical page. View in browser and see the limit applied.