### PR TITLE
Update DirectAnswer styling to match YAnswers page.

### DIFF
--- a/static/scss/answers/templates/universal-standard.scss
+++ b/static/scss/answers/templates/universal-standard.scss
@@ -9,11 +9,12 @@
   &-filtersAndResults
   {
     display: flex;
+    flex-direction: column;
+  }
 
-    @include bplte(xs)
-    {
-      flex-direction: column;
-    }
+  &-directAnswer
+  {
+    margin-bottom: $base-spacing;
   }
 
   &-universalResults


### PR DESCRIPTION
This PR updates the styling of the DirectAnswer component on the universal-standard template. The styling now matches the DirectAnswer component's styling on the YAnswers page. This is the styling Liz desires by default.

TEST=manual

Visually inspected styling to confirm it matched YAnswers.