### PR TITLE
Assorted map configuration updates requested by the HHs.

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -36,10 +36,8 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
   {{/if}}
   {{#if iconUrl}}sectionTitleIconUrl: '{{iconUrl}}',{{/if}}
   viewAllText: {{#if viewAllText}}'{{viewAllText}}'{{else}}'View All'{{/if}},
-  {{#if includeMap}}
-    includeMap: {{includeMap}},
-  {{/if}}
   {{#if mapConfig}}
+    includeMap: true,
     mapConfig: Object.assign({
       apiKey: HitchhikerJS.getDefaultMapApiKey('{{ mapConfig.mapProvider }}')
     }, {{{ json mapConfig }}}),

--- a/templates/vertical-map/page-config.json
+++ b/templates/vertical-map/page-config.json
@@ -19,10 +19,6 @@
       // Additional options are available in the documentation
     },
     **/
-    "Map": {
-      "mapProvider": "MapBox", // The name of the provider (e.g. Mapbox, Google)
-      // "apiKey": "" // This is provided by the theme, unless you would like to use your own
-    },
     "SearchBar": {
       "placeholderText": "Search" // The placeholder text in the answers search bar
     },
@@ -38,7 +34,10 @@
     "<REPLACE ME>": { // The vertical key from your search configuration
       // "label": "", // The name of the vertical in the section header and the navigation bar
       "cardType": "location-standard", // The name of the card to use - e.g. accordion, location, customcard 
-      "icon": "pin" // The icon to use on the card for this vertical
+      "icon": "pin", // The icon to use on the card for this vertical
+      "mapConfig": {
+        "mapProvider": "MapBox" // The name of the provider (e.g. Mapbox, Google)
+      }
     }
   }
 }


### PR DESCRIPTION
This PR includes a couple updates around the map configuration that were
requested by the HHs:

- For the universal template, if a VTC object lists a mapConfig for a vertical,
  we should interpret that vertical as having includeMap: true.
- The vertical-map template's JSON file should add mapConfig under VTC instead
  of having it under componentSettings.Map. This will encourage HHs to always
  use VTC for map configuration.

TEST=manual

Created a page with the updated vertical-map template. Ensured it looked as
expected. Created a universal page. Saw a map for a vertical that had mapConfig
set in it's VTC. In the universal config's VTC, added a new vertical with a
mapConfig. Saw a map for that vertical on the universal page too.