### PR TITLE
Pull SDK version from global config instead of hardcoding

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -1,4 +1,5 @@
 {
+  "sdkVersion": "1.1", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   "experienceKey": "<REPLACE ME>",
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -1,5 +1,11 @@
-<link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v1.1/answers.css">
-<script src="https://assets.sitescdn.net/answers/v1.1/answerstemplates.compiled.min.js"></script>
+<script>
+  const sdkVersion = '{{global_config.sdkVersion}}';
+  if (!sdkVersion) {
+    console.error('ERROR: no sdkVersion specified, please specify an sdkVersion in the global_config.');
+  }
+</script>
+<link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.css">
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answerstemplates.compiled.min.js"></script>
 <script>
   function initAnswers() {
     const JAMBO_INJECTED_DATA = {{{json env.JAMBO_INJECTED_DATA}}} || {};
@@ -52,5 +58,5 @@
     ));
   };
 </script>
-<script src="https://assets.sitescdn.net/answers/v1.1/answers.min.js" onload="initAnswers()" async></script>
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.min.js" onload="initAnswers()" async></script>
 


### PR DESCRIPTION
TEST=manual

Test without specifying version, see console error: "ERROR: no sdkVersion specified, please specify an SDK version in the global_config." Test with version and inspect DOM to see that the correct version is being used.