### PR TITLE
Unescape config used in JS, delete unused partial

### DIFF
--- a/templates/universal-standard/script/navigation.hbs
+++ b/templates/universal-standard/script/navigation.hbs
@@ -3,22 +3,22 @@ container: '.js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig 'Universal')}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -4,7 +4,7 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
       {{!-- Map each Vertical config's verticalsToConfig --}}
       {{#each verticalConfigs}}
         {{#if verticalKey}}
-          '{{verticalKey}}': {
+          '{{{verticalKey}}}': {
             {{#with (lookup verticalsToConfig verticalKey)}}
               {{> VerticalConfig verticalKey=../verticalKey}}
             {{/with}}
@@ -24,18 +24,18 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
 ));
 
 {{#*inline 'VerticalConfig'}}
-  modifier: '{{verticalKey}}',
+  modifier: '{{{verticalKey}}}',
   {{#if cardType}}
     card: {
-        cardType: '{{cardType}}'
+      cardType: '{{{cardType}}}'
     },
   {{/if}}
-  sectionTitle: {{#if sectionTitle}}'{{sectionTitle}}'{{else}}{{#if label}}'{{label}}'{{else}}'{{verticalKey}}'{{/if}}{{/if}},
+  sectionTitle: {{#if sectionTitle}}'{{{sectionTitle}}}'{{else}}{{#if label}}'{{{label}}}'{{else}}'{{{verticalKey}}}'{{/if}}{{/if}},
   {{#if icon}}
-      sectionTitleIconName: '{{icon}}',
+    sectionTitleIconName: '{{{icon}}}',
   {{/if}}
-  {{#if iconUrl}}sectionTitleIconUrl: '{{iconUrl}}',{{/if}}
-  viewAllText: {{#if viewAllText}}'{{viewAllText}}'{{else}}'View All'{{/if}},
+  {{#if iconUrl}}sectionTitleIconUrl: '{{{iconUrl}}}',{{/if}}
+  viewAllText: {{#if viewAllText}}'{{{viewAllText}}}'{{else}}'View All'{{/if}},
   {{#if mapConfig}}
     includeMap: true,
     mapConfig: Object.assign({
@@ -52,7 +52,7 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
       let results = data.results;
       if (results) {
         results = results.filter((rex, idx) => {
-          return idx < {{universalLimit}};
+          return idx < {{{universalLimit}}};
         });
       }
       return Object.assign(data, {

--- a/templates/vertical-grid/script/facets.hbs
+++ b/templates/vertical-grid/script/facets.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('Facets', Object.assign({}, {
   container: '#js-answersFacets',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-grid/script/filterbox.hbs
+++ b/templates/vertical-grid/script/filterbox.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('FilterBox', Object.assign({}, {
   container: '#js-answersFilterBox',
-  {{#if componentSettings.FilterBox.verticalKey}}
-    verticalKey: '{{componentSettings.FilterBox.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.FilterBox }}}));

--- a/templates/vertical-grid/script/filteroptions.hbs
+++ b/templates/vertical-grid/script/filteroptions.hbs
@@ -1,3 +1,0 @@
-ANSWERS.addComponent('FilterOptions', Object.assign({}, {
-  container: '#grid-filteroptions-container'
-}, {{{ json componentSettings.FilterOptions }}}));

--- a/templates/vertical-grid/script/navigation.hbs
+++ b/templates/vertical-grid/script/navigation.hbs
@@ -3,22 +3,22 @@ container: '.js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig 'Universal')}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-grid/script/pagination.hbs
+++ b/templates/vertical-grid/script/pagination.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('Pagination', Object.assign({}, {
   container: '.js-answersPagination',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-grid/script/searchbar.hbs
+++ b/templates/vertical-grid/script/searchbar.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('SearchBar', Object.assign({}, {
   container: '.js-answersSearch',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/vertical-grid/script/sortoptions.hbs
+++ b/templates/vertical-grid/script/sortoptions.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('SortOptions', Object.assign({}, {
   container: '#js-answersSortOptions',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.SortOptions }}}));

--- a/templates/vertical-grid/script/verticalresults.hbs
+++ b/templates/vertical-grid/script/verticalresults.hbs
@@ -1,32 +1,32 @@
 ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   container: '.js-answersVerticalResults',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
-    modifier: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
+    modifier: '{{{verticalKey}}}',
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}
       {
-        verticalKey: '{{verticalKey}}',
+        verticalKey: '{{{verticalKey}}}',
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        {{#if iconUrl}}iconUrl: '{{iconUrl}}',{{/if}}
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        {{#if iconUrl}}iconUrl: '{{{iconUrl}}}',{{/if}}
         label:
-        {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
       {
       {{#with (lookup verticalsToConfig 'Universal')}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}}
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}}
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}
@@ -34,7 +34,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   ],
   {{#with (lookup verticalsToConfig verticalKey)}}
     card: {
-      {{#if cardType}}cardType: '{{cardType}}',{{/if}}
+      {{#if cardType}}cardType: '{{{cardType}}}',{{/if}}
     }
   {{/with}},
 }, {{{ json componentSettings.VerticalResults }}}));

--- a/templates/vertical-map/script/facets.hbs
+++ b/templates/vertical-map/script/facets.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('Facets', Object.assign({}, {
   container: '#js-answersFacets',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-map/script/filterbox.hbs
+++ b/templates/vertical-map/script/filterbox.hbs
@@ -1,10 +1,6 @@
 ANSWERS.addComponent('FilterBox', Object.assign({}, {
   container: '#js-answersFilterBox',
-  {{#if componentSettings.FilterBox.verticalKey}}
-    verticalKey: '{{componentSettings.FilterBox.verticalKey}}',
-  {{else}}
-    {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
-    {{/if}}
+  {{#if verticalKey}}
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.FilterBox }}}));

--- a/templates/vertical-map/script/navigation.hbs
+++ b/templates/vertical-map/script/navigation.hbs
@@ -3,22 +3,22 @@ container: '#js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig 'Universal')}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-map/script/pagination.hbs
+++ b/templates/vertical-map/script/pagination.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('Pagination', Object.assign({}, {
   container: '#js-answersPagination',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-map/script/searchbar.hbs
+++ b/templates/vertical-map/script/searchbar.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('SearchBar', Object.assign({}, {
   container: '#js-answersSearchBar',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/vertical-map/script/sortoptions.hbs
+++ b/templates/vertical-map/script/sortoptions.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('SortOptions', Object.assign({}, {
   container: '#js-answersSortOptions',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.SortOptions }}}));

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -1,32 +1,32 @@
 ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   container: '#js-answersVerticalResults',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
-    modifier: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
+    modifier: '{{{verticalKey}}}',
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}
       {
-        verticalKey: '{{verticalKey}}',
+        verticalKey: '{{{verticalKey}}}',
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        {{#if iconUrl}}iconUrl: '{{iconUrl}}',{{/if}}
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        {{#if iconUrl}}iconUrl: '{{{iconUrl}}}',{{/if}}
         label:
-        {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
       {
       {{#with (lookup verticalsToConfig 'Universal')}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}}
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}}
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}
@@ -34,7 +34,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   ],
   {{#with (lookup verticalsToConfig verticalKey)}}
     card: {
-      {{#if cardType}}cardType: '{{cardType}}',{{/if}}
+      {{#if cardType}}cardType: '{{{cardType}}}',{{/if}}
     }
   {{/with}},
 }, {{{ json componentSettings.VerticalResults }}}));

--- a/templates/vertical-standard/script/facets.hbs
+++ b/templates/vertical-standard/script/facets.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('Facets', Object.assign({}, {
   container: '#js-answersFacets',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-standard/script/filterbox.hbs
+++ b/templates/vertical-standard/script/filterbox.hbs
@@ -4,7 +4,7 @@ ANSWERS.addComponent('FilterBox', Object.assign({}, {
     verticalKey: '{{componentSettings.FilterBox.verticalKey}}',
   {{else}}
     {{#if verticalKey}}
-      verticalKey: '{{verticalKey}}',
+      verticalKey: '{{{verticalKey}}}',
     {{/if}}
   {{/if}}
 }, {{{ json componentSettings.FilterBox }}}));

--- a/templates/vertical-standard/script/navigation.hbs
+++ b/templates/vertical-standard/script/navigation.hbs
@@ -3,22 +3,22 @@ container: '.js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig 'Universal')}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-standard/script/pagination.hbs
+++ b/templates/vertical-standard/script/pagination.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('Pagination', Object.assign({}, {
   container: '.js-answersPagination',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-standard/script/searchbar.hbs
+++ b/templates/vertical-standard/script/searchbar.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('SearchBar', Object.assign({}, {
   container: '.js-answersSearch',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/vertical-standard/script/sortoptions.hbs
+++ b/templates/vertical-standard/script/sortoptions.hbs
@@ -1,6 +1,6 @@
 ANSWERS.addComponent('SortOptions', Object.assign({}, {
   container: '#js-answersSortOptions',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
   {{/if}}
 }, {{{ json componentSettings.SortOptions }}}));

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -1,32 +1,32 @@
 ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   container: '.js-answersVerticalResults',
   {{#if verticalKey}}
-    verticalKey: '{{verticalKey}}',
-    modifier: '{{verticalKey}}',
+    verticalKey: '{{{verticalKey}}}',
+    modifier: '{{{verticalKey}}}',
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}
       {
-        verticalKey: '{{verticalKey}}',
+        verticalKey: '{{{verticalKey}}}',
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        {{#if iconUrl}}iconUrl: '{{iconUrl}}',{{/if}}
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        {{#if iconUrl}}iconUrl: '{{{iconUrl}}}',{{/if}}
         label:
-        {{#if label}}'{{label}}'{{else}}{{#if ../verticalKey}}'{{../verticalKey}}'{{else}}'{{@key}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}},
+        {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
       {
       {{#with (lookup verticalsToConfig 'Universal')}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{icon}}',{{/if}}
-        label: {{#if label}}'{{label}}'{{else}}'{{@key}}'{{/if}},
-        url: {{#if url}}'{{url}}'{{else}}'{{@key}}.html'{{/if}}
+        {{#if icon}}icon: '{{{icon}}}',{{/if}}
+        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
+        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}}
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}
@@ -34,7 +34,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   ],
   {{#with (lookup verticalsToConfig verticalKey)}}
     card: {
-      {{#if cardType}}cardType: '{{cardType}}',{{/if}}
+      {{#if cardType}}cardType: '{{{cardType}}}',{{/if}}
     }
   {{/with}},
 }, {{{ json componentSettings.VerticalResults }}}));


### PR DESCRIPTION
Do not escape string or number config. Removed unused filteroptions partial.

SPR-2262
TEST=manual

Test each page template type to ensure it compiles as expected. View in browser and see page render properly. Try to put characters like "&" in the config and see them unescaped.
