### PR TITLE
Add results title bar variables by default, fix --yxt background var

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -29,6 +29,8 @@
 
   // component specific variable overrides
   --yxt-autocomplete-text-font-size: 16px;
+  --yxt-results-title-bar-text-color: var(--yxt-color-text-primary);
+  --yxt-results-title-bar-background: var(--yxt-color-background-highlight);
   --yxt-searchbar-button-background-color-base: white;
   --yxt-searchbar-button-background-color-hover: white;
   --yxt-searchbar-button-background-color-active: white;

--- a/static/scss/answers/cards/faq-accordion.scss
+++ b/static/scss/answers/cards/faq-accordion.scss
@@ -6,7 +6,7 @@
   &:hover,
   &:focus
   {
-    background-color: var(--hh-color-background-highlight);
+    background-color: var(--yxt-color-background-highlight);
   }
 
   &-toggle


### PR DESCRIPTION
From the HH: "These are helpful when we want to use the brand's primary
color as the background for the title bar on Universal Results."

Fix --hh -> --yxt variable

J=SPR-2335
TEST=manual

Tested on a jambo site with FAQs, re-imported files from the theme
Changed the new variables to make sure we saw changes in the results title
bar. Checked to see FAQ background color on hover matched the
background-hover variable.