### PR TITLE
Support both simple and complex images in image formatter

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -219,11 +219,7 @@ export default class Formatters {
   /*
   * Given object with url and alternateText, changes url to use https
   */
-  static image(simpleOrComplexImage, size = '200x', atLeastAsLarge = true) {
-    if (!simpleOrComplexImage) {
-      return {};
-    }
-
+  static image(simpleOrComplexImage = {}, size = '200x', atLeastAsLarge = true) {
     let img = simpleOrComplexImage.image || simpleOrComplexImage;
     if (!img) {
       return {};


### PR DESCRIPTION
Allow HHs to pass in a simple or complex image into the image formatter. Prior to this change, only simple images were supported. Passing complex images into the image formatter previously looked like this: 

      `image: profile.logo ? Formatter.image(profile.logo.image).url : profile.photoGallery ? Formatter.image(profile.photoGallery[0].image).url: null` 

but now could be written like this:

      `image: Formatter.image(profile.logo).url || Formatter.image(profile.photoGallery[0]).url || null` 


TEST=manual

Test locally with both simple and complex images.