### PR TITLE
Default title link for job standard card to landingPageUrl

### DIFF
--- a/cards/job-standard/component.js
+++ b/cards/job-standard/component.js
@@ -15,7 +15,7 @@ class job_standardCardComponent extends BaseCard['job-standard'] {
   dataForRender(profile) {
     return {
       title: profile.name, // The header text of the card
-      url: profile.website, // If the card title is a clickable link, set URL here
+      url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       // image: '', // The URL of the image to display on the card
       // tagLabel: '', // The label of the displayed image


### PR DESCRIPTION
It seems the Job entity does not have the website field. Change the
default url to the landing page url so the HHs do not have to fork the
card for every job standard.

J=None
TEST=manual

Created Job entity with two urls:
        Application URL: http://www.yext.com/apply
        Landing Page URL: http://www.yext.com/landing

Added to rosetest answers experience

Tested on a new site to see that the url for a job entity
is using the landingPageUrl instead of the (non-existant) website field