### PR TITLE
Update altText in menuitem-standard and product-standard cards

### DIFF
--- a/cards/menuitem-standard/component.js
+++ b/cards/menuitem-standard/component.js
@@ -18,7 +18,7 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       image: Formatter.image(profile.c_photo).url, // The URL of the image to display on the card
-      altText: Formatter.image(profile.c_photo).altText,  // The alternate text for the image
+      altText: Formatter.image(profile.c_photo).alternateText,  // The alternate text for the image
       // tagLabel: '', // The label of the displayed image
       titleEventOptions: this.addDefaultEventOptions(),
       listTitle: 'Allergens',

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -23,7 +23,7 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       image: Formatter.image(profile.c_photo).url, // The URL of the image to display on the card
-      altText: Formatter.image(profile.c_photo).altText, // The alt text of the image to display on the card
+      altText: Formatter.image(profile.c_photo).alternateText, // The alt text of the image to display on the card
       titleEventOptions: this.addDefaultEventOptions(),
       subtitle: price, // The sub-header text of the card
       details: profile.description, // The text in the body of the card


### PR DESCRIPTION
Image alt text comes back as `alternateText` from the API, example https://liveapi.yext.com/v2/accounts/me/answers/vertical/query?v=20190101&api_key=df4b24f4075800e5e9705090c54c6c13&jsLibVersion=v1.1.0&sessionTrackingEnabled=true&input=Ky-Miyasaka&experienceKey=olitest&version=STAGING&verticalKey=professional&limit=20&offset=0&locale=en, update menuitem-standard and product-standard cards to reflect this.

TEST=manual

Test menuitem-standard card and product-standard with an image with alt text. Inspect DOM in Chrome to see img alt text update.