### PR TITLE
Changed faq-accordion card to use RTF answer field

### DIFF
--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -16,7 +16,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
     return {
       title: profile.name, // The header text of the card
       // subtitle: '', // The sub-header text of the card
-      details: profile.answer, // The text in the body of the card
+      details: ANSWERS.formatRichText(profile.answer), // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // showMoreDetails: {


### PR DESCRIPTION
Updated the faq-accordion theme to call the RTF formatting function for the answer field.

TEST=manual

Test on desktop by testing on a local site with faq vertical. Inserted a custom RTF for an faq entity and used dataForRender method to test if the styling of the RTF is correct.