### PR TITLE
Move config that is not injected out of with statement

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -2,6 +2,7 @@
   "sdkVersion": "1.3", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   "experienceKey": "<REPLACE ME>",
+  // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
   "locale": "en", // The default locale for searches. Examples: UK: en-GB, Spanish: es, Spain Spanish: es-ES.
   "logo": "", // The link to the logo for open graph meta tag - og:image.

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -20,7 +20,6 @@
       },
       {{#with env.JAMBO_INJECTED_DATA}}
         {
-          experienceKey: "{{../global_config.experienceKey}}",
           {{#if businessId}}businessId: "{{businessId}}",{{/if}}
           {{#with (lookup (lookup (lookup this 'answers') 'experiences') ../global_config.experienceKey)}}
             {{#if apiKey}}apiKey: "{{apiKey}}",{{/if}}


### PR DESCRIPTION
Since experienceKey and experienceVersion are not injected config, they should be set even when env.JAMBO_INJECTED_DATA is falsy. Locally they were not being set and so I was receiving autocomplete errors.

TEST=manual

Test on local dev site. `npx jambo build && grunt webpack` before the change, notice experienceKey and experienceVersion did not show up in the output page.html file; serving
and searching produced autocomplete errors. After the change, experienceKey and experienceVersion appear in the output page.html file and autocomplete works.