### PR TITLE
add default files for answers-variables and fonts in theme

### DIFF
--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -3,7 +3,9 @@
 
 // Core variables and mixins
 @import "common/variables";
+@import 'answers-variables-default';
 @import '../answers-variables';
+@import "common/fonts-default";
 @import "../fonts";
 @import "common/mixins";
 @import "common/base";

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -1,0 +1,44 @@
+// These variables are not meant to be changed by the HH. They are the default values for the theme.
+// Variable overrides should be in the answers-variables.scss file.
+
+:root {
+  // control colors throughout the theme and SDK
+  --yxt-color-brand-primary: #0f70f0;
+  --yxt-color-brand-hover: #0C5ECB;
+  --yxt-color-brand-white: #fff;
+  --yxt-color-text-primary: #212121;
+  --yxt-color-text-secondary: #757575;
+  --yxt-color-link-primary: var(--yxt-color-brand-primary);
+  --yxt-color-borders: #dcdcdc;
+  --yxt-color-error: #940000;
+  --yxt-color-background-highlight: #fafafa;
+
+  // theme specific variables
+  --hh-answers-background-color: #eeeff0;
+  --hh-answers-container-width: 700px;
+  --hh-answers-container-width-filters: 950px;
+  --hh-color-gray-1: #dcdcdc;
+  --hh-color-gray-2: #fafafa;
+
+  // common border variables
+  --yxt-border-default: 1px solid var(--yxt-color-borders);
+
+  // spacing variable, used in padding/margins across the site
+  --yxt-base-spacing: 16px;
+
+  // component specific variable overrides
+  --yxt-autocomplete-text-font-size: 16px;
+  --yxt-results-title-bar-text-color: var(--yxt-color-text-primary);
+  --yxt-results-title-bar-background: var(--yxt-color-background-highlight);
+  --yxt-searchbar-button-background-color-base: white;
+  --yxt-searchbar-button-background-color-hover: white;
+  --yxt-searchbar-button-background-color-active: white;
+  --yxt-searchbar-button-text-color-hover: #0f70f0;
+}
+
+// breakpoint variables for use in media queries within the theme styling
+$breakpoint-mobile-max: 767px;
+$breakpoint-mobile-min: 768px;
+
+$breakpoint-mobile-sm-max: 575px;
+$breakpoint-mobile-sm-min: 576px;

--- a/static/scss/answers/common/fonts-default.scss
+++ b/static/scss/answers/common/fonts-default.scss
@@ -1,0 +1,59 @@
+// These variables are not meant to be changed by the HH. They are the default values for the theme.
+// Variable overrides should be in the fonts.scss file.
+
+$font-weight-bold: 700;
+$font-weight-semibold: 600;
+$font-weight-medium: 500;
+$font-weight-normal: 400;
+$font-weight-light: 300;
+
+:root {
+  --yxt-font-weight-bold: #{$font-weight-bold};
+  --yxt-font-weight-semibold: #{$font-weight-semibold};
+  --yxt-font-weight-medium: #{$font-weight-medium};
+  --yxt-font-weight-normal: #{$font-weight-normal};
+  --yxt-font-weight-light: #{$font-weight-light};
+
+  --yxt-font-size-xs: 10px;
+  --yxt-font-size-sm: 12px;
+  --yxt-font-size-md: 14px;
+  --yxt-font-size-md-lg: 16px;
+  --yxt-font-size-lg: 18px;
+  --yxt-font-size-xlg: 20px;
+  --yxt-font-size-xxlg: 40px;
+
+  --yxt-line-height-xs: 1;
+  --yxt-line-height-sm: 1.2;
+  --yxt-line-height-md-sm: 4/3;
+  --yxt-line-height-md: 1.4;
+  --yxt-line-height-lg: 1.5;
+  --yxt-line-height-xlg: 5/3;
+  --yxt-line-height-xxlg: 1.7;
+
+  --yxt-font-family: "Open Sans",system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+@font-face
+{
+  font-family: "Open Sans";
+  src: url('../../assets/fonts/opensans-regular-webfont.woff') format("woff");
+  font-weight: $font-weight-normal;
+  font-style: normal;
+}
+
+@font-face
+{
+  font-family: "Open Sans";
+  src: url('../../assets/fonts/opensans-bold-webfont.woff') format("woff");
+  font-weight: $font-weight-bold;
+  font-style: normal;
+}
+
+@font-face
+{
+  font-family: "Open Sans";
+  src: url('../../assets/fonts/opensans-semibold-webfont.woff') format("woff");
+  font-weight: $font-weight-semibold;
+  font-style: normal;
+}
+


### PR DESCRIPTION
These files are meant to be defaults that are subject to change in the
theme. Thus if we add more variables to the theme, we will not touch the
repo-level variable files. These new variables will be behind the scenes
and repo-level work on styling will continue to work.

J=SPR-2372
TEST=manual

Tested on a new Jambo site. Tested a variable change in both the
theme-level "-default" files and the repo-level HH-editable files. Made
sure the repo-level variables took precedence but when not present, the
defaults showed up.