### PR TITLE
Update Theme to no longer expect layout templates in the 'partials' d…

### DIFF
--- a/templates/universal-standard/page.html.hbs
+++ b/templates/universal-standard/page.html.hbs
@@ -1,4 +1,4 @@
-{{#> partials/layouts/html }}
+{{#> layouts/html }}
   <div>
     {{#> script/core }}
       {{> cards/all }}
@@ -31,4 +31,4 @@
       {{> templates/universal-standard/markup/locationbias }}
     </footer>
   </div>
-{{/partials/layouts/html }}
+{{/layouts/html }}

--- a/templates/vertical-grid/page.html.hbs
+++ b/templates/vertical-grid/page.html.hbs
@@ -1,4 +1,4 @@
-{{#> partials/layouts/html }}
+{{#> layouts/html }}
   <div>
     {{#> script/core }}
       {{> cards/all }}
@@ -40,4 +40,4 @@
       {{> templates/vertical-grid/markup/locationbias }}
     </footer>
   </div>
-{{/partials/layouts/html }}
+{{/layouts/html }}

--- a/templates/vertical-map/page.html.hbs
+++ b/templates/vertical-map/page.html.hbs
@@ -1,4 +1,4 @@
-{{#> partials/layouts/html }}
+{{#> layouts/html }}
   <div>
     {{#> script/core }}
       {{> cards/all }}
@@ -39,4 +39,4 @@
       {{> templates/vertical-map/markup/locationbias }}
     </footer>
   </div>
-{{/partials/layouts/html }}
+{{/layouts/html }}

--- a/templates/vertical-standard/page.html.hbs
+++ b/templates/vertical-standard/page.html.hbs
@@ -1,4 +1,4 @@
-{{#> partials/layouts/html }}
+{{#> layouts/html }}
   <div>
     {{#> script/core }}
       {{> cards/all }}
@@ -40,4 +40,4 @@
       {{> templates/vertical-standard/markup/locationbias }}
     </footer>
   </div>
-{{/partials/layouts/html }}
+{{/layouts/html }}


### PR DESCRIPTION
…irectory.

Layout templates will now be overridden like any other template in the Theme.
This means that an overridden layout will be located in a top-level 'layouts'
directory, instead of the 'partials' directory. This is being done to allow
the Theme to be upgrade more easily in a site repo.

J=SPR-2391
TEST=manual

Created a new site repo with a local version of Jambo (that does not copy any
layout templates to 'partials' on Theme import). Added a page of each template
type. Made sure that all pages were built correctly during 'jambo build'. Then,
I overwrote the Theme's layout. In my top-level 'layouts' directory, I made
some changes to html.hbs. Saw those changes reflected in my pages after another
'jambo build'.