### PR TITLE
Support custom URLs in the Universal 'View All' links.

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -6,7 +6,7 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
         {{#if verticalKey}}
           '{{{verticalKey}}}': {
             {{#with (lookup verticalsToConfig verticalKey)}}
-              {{> VerticalConfig verticalKey=../verticalKey }}
+              {{> VerticalConfig verticalKey=../verticalKey url=@key }}
             {{/with}}
           },
         {{/if}}
@@ -14,9 +14,15 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
     }, {
       {{!-- Map the Universal config's verticalsToConfig --}}
       {{#each verticalsToConfig}}
-        '{{@key}}': {
-          {{> VerticalConfig verticalKey=@key }}
-        },
+        '{{@key}}': Object.assign(
+          {},
+          { {{> VerticalConfig verticalKey=@key }} },
+          {{#each ../verticalConfigs}}
+            {{#ifeq verticalKey @../key}}
+              { {{> VerticalConfig @../this verticalKey=verticalKey url=@key }} },
+            {{/ifeq}}
+          {{/each}}
+        ),
       {{/each}}
     }),
   },
@@ -25,6 +31,14 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
 
 {{#*inline 'VerticalConfig'}}
   modifier: '{{{verticalKey}}}',
+  {{#if url}}
+    verticalPages: [
+      {
+        verticalKey: '{{{verticalKey}}}',
+        url: '{{{url}}}'
+      }
+    ],
+  {{/if}}
   {{#if cardType}}
     card: {
       cardType: '{{{cardType}}}'


### PR DESCRIPTION
Previously, the 'View All' links displayed on Universal search assumed that
the page for a vertical was named [verticalKey].html. This assumption was
valid in the AEB, where it prescribed HTML file names. It is not valid in
Jambo, however, where someone can give the vertical's HTML file any name.

The verticalConfigs object created by Jambo is the source of truth for the
URLs. The keys of each entry in this object are the URL for a particular
vertical. Now, in the universalresults script partial, we use these keys to
correctly set the 'View All' link for a vertical. It is possible that there is
a vertical displayed on Universal that does not have a page. In that case, the
'View All' link will go to a non-existant page. This, however, is an existing
issue with the SDK. There is not anything we can currently do to fix this in
the Theme itself.

J=SPR-2351
TEST=manual

Created a local site repo with a universal page and two vertical pages. These
pages had names different than their associated verticalKeys. Ensured that the
'View All' links for these verticals directed me to the correct page. Overwrote
the config for one of the verticals in the Universal's VTC. Ensured that the
correct URL was still injected into the associated 'View All' link.