### PR TITLE
Add page level configuration pageSettings

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -40,6 +40,7 @@
           {{/if}}
         {{/with}}
       },
+      {{{ json pageSettings }}},
       {
         onReady: () => {
           {{> @partial-block }}


### PR DESCRIPTION
Add support for a top-level object called "pageSettings". Any config an implementer puts in pageSettings will be put into the top-level Answers init config object.

TEST=manual

Add pageSettings config in a test vertical page's config.json, jambo build, then view output file and see the pageSettings in the output.