### PR TITLE
Add details toggle styling back, add margin top

### DIFF
--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -17,9 +17,11 @@
   @include sr-only-focusable();
 }
 
-.HitchhikerCard-details-toggle
+.HitchhikerCard-detailsToggle
 {
     text-align: left;
+    margin-top: calc(var(--yxt-base-spacing) / 4);
+
     @include Text(
         $color: var(--yxt-color-brand-primary),
         $line-height: var(--yxt-line-height-md),


### PR DESCRIPTION
Adds margin top to the details toggle styling. Also updates the CSS selector to be consistent with the selector change from this PR: https://github.com/yext/answers-hitchhiker-theme/pull/170.

TEST=manual

Run grunt webpack with the styling changes, visually inspect and verify that they look correct.