### PR TITLE
Update static asset path for hashing in webpack

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -84,7 +84,7 @@ module.exports = function () {
                * @param {String} value the path to the static asset
                */
               urlFilter: (_, value) => {
-                const assetsDir = '../static/assets/';
+                const assetsDir = 'static/assets/';
                 return value.startsWith(assetsDir);
               },
               list: [


### PR DESCRIPTION
TEST=manual

Run grunt webpack, serve page, and see yext logo image path hashed and correctly rendering.