### PR TITLE
Use theme direct answer cards by default

### DIFF
--- a/templates/universal-standard/page-config.json
+++ b/templates/universal-standard/page-config.json
@@ -11,7 +11,7 @@
     },
     **/
     "DirectAnswer": {
-      "footerText": "Was this what you were looking for?"
+      "defaultCard": "allfields-standard"
     },
     "SearchBar": {
       "placeholderText": "Search" // The placeholder text in the answers search bar

--- a/templates/universal-standard/page.html.hbs
+++ b/templates/universal-standard/page.html.hbs
@@ -2,6 +2,7 @@
   <div>
     {{#> script/core }}
       {{> cards/all }}
+      {{> directanswercards/all }}
       {{> templates/universal-standard/script/searchbar }}
       {{> templates/universal-standard/script/spellcheck }}
       {{> templates/universal-standard/script/navigation }}


### PR DESCRIPTION
Adjust the config in the universal page template's config.json to use the allfields-standard direct answer card. Also add the directanswercards/all partial to the universal page tempalte's page.html.hbs file.

TEST=manual

Generate a new universal page locally. Serve page and search for direct answer, see new card being used.