### PR TITLE
Update iframe.js for referrerPageUrl defaults

### DIFF
--- a/static/js/iframe.js
+++ b/static/js/iframe.js
@@ -36,15 +36,17 @@ const domain = isStaging() ? stagingDomain : prodDomain;
     // Parse the params out of the URL
     var params = paramString.split('&'),
                  verticalUrl;
+    var referrerPageUrl = document.referrer.split('?')[0].split('#')[0];
 
     // Default for localhost is index.html, empty o/w
     if (isLocalHost) {
       verticalUrl = 'index.html';
     }
 
-    // Don't include the verticalUrl in the frame src
+    // Don't include the verticalUrl or raw referrerPageUrl in the frame src
     var new_params = params.filter(function(param) {
-       return param.split('=')[0] !== 'verticalUrl';
+       return (param.split('=')[0] !== 'verticalUrl') &&
+        (param.split('=')[0] !== 'referrerPageUrl');
     });
 
     for (var i = 0; i < params.length; i ++) {
@@ -52,7 +54,13 @@ const domain = isStaging() ? stagingDomain : prodDomain;
       if (kv[0] === 'verticalUrl') {
         verticalUrl = kv[1];
       }
+
+      if (kv[0] === 'referrerPageUrl') {
+        referrerPageUrl = kv[1];
+      }
     }
+
+    new_params.push('referrerPageUrl=' + referrerPageUrl);
 
     // Build the Iframe URL
     var iframeUrl = domain;


### PR DESCRIPTION
When creating an iFrame, we should pass the referrerUrl to the iframe
source URL. If it does not exist in the parent URL, then we should use
document.referrer.

J=SPR-2452
TEST=manual

Tested on a QA site to test the iFrame navigation.

Test referrerPageUrl from parent is in iframe src URL.
Test referrerPageUrl is document.referrer if parent URL does not have a
referrerPageUrl query param