### PR TITLE
Add horizontal padding to vertical grid template

### DIFF
--- a/static/scss/answers/templates/vertical-grid.scss
+++ b/static/scss/answers/templates/vertical-grid.scss
@@ -7,13 +7,15 @@
 
   .Hitchhiker-2-columns,
   .Hitchhiker-3-columns,
-  .Hitchhiker-4-columns 
+  .Hitchhiker-4-columns
   {
     .yxt-Card
     {
       flex-grow: 0;
       flex-shrink: 0;
       min-width: 0;
+      padding-right: calc(var(--yxt-base-spacing) / 4);
+      padding-left: calc(var(--yxt-base-spacing) / 4);
     }
 
     .yxt-Card-child


### PR DESCRIPTION
Padding was removed in a previous change to this template. Adding back as part of QA.

TEST=visual

Generate page using vertical grid template, serve.