### PR TITLE
Remove usages of hh-base-spacing var

### DIFF
--- a/static/scss/answers/templates/vertical-grid.scss
+++ b/static/scss/answers/templates/vertical-grid.scss
@@ -78,17 +78,17 @@
     }
 
     &-filtersWrapper {
-      margin-right: calc(var(--hh-base-spacing) * 2);
-      
+      margin-right: calc(var(--yxt-base-spacing) * 2);
+
       .yxt-FilterBox-container {
-        margin-bottom: var(--hh-base-spacing);
+        margin-bottom: var(--yxt-base-spacing);
       }
-  
+
       .yxt-Facets-container {
         padding: 0;
       }
     }
-  
+
 
     &-verticalResults
     {

--- a/static/scss/answers/templates/vertical-standard.scss
+++ b/static/scss/answers/templates/vertical-standard.scss
@@ -31,10 +31,10 @@
   }
 
   &-filtersWrapper {
-    margin-right: calc(var(--hh-base-spacing) * 2);
-    
+    margin-right: calc(var(--yxt-base-spacing) * 2);
+
     .yxt-FilterBox-container {
-      margin-bottom: var(--hh-base-spacing);
+      margin-bottom: var(--yxt-base-spacing);
     }
 
     .yxt-Facets-container {


### PR DESCRIPTION
The --hh-base-spacing var does not seem to exist nowadays. Cleaning up any remaining usages.

TEST=manual

Generate pages vertical-standard and vertical-grid, serve. Inspect padding to ensure it looks like mocks/as expected.