### PR TITLE
Reduce padding top on answers-nav

### DIFF
--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -34,7 +34,7 @@
   &-nav
   {
     position: relative;
-    padding-top: 32px;
+    padding-top: 10px;
   }
 
   &-navWrapper


### PR DESCRIPTION
Reduce padding top on answers-nav from 32px to 10px.

J=SPR-2505

TEST=manual

Tested on test site to make sure padding top on answers-nav is reduced to 10px.