### PR TITLE
universal-standard script: use deepmerge for verticalsToConfig

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -1,32 +1,46 @@
-ANSWERS.addComponent('UniversalResults', Object.assign({}, {
+const universalVerticalsToConfig = {
+  {{!-- Map the Universal config's verticalsToConfig --}}
+  {{#each verticalsToConfig}}
+    '{{@key}}':
+      {{#with (deepMerge
+        this 
+        (lookup @root/componentSettings.UniversalResults.config @key)
+        (lookup @root/componentSettings.UniversalResults.verticals @key)
+      )}}
+        Object.assign({}, {{{ json this }}}, { {{> VerticalConfig verticalKey=@key }} })
+      {{/with}}
+    ,
+  {{/each}}
+};
+
+const pageVerticalsToConfig = {
+  {{!-- Map each Page config's verticalsToConfig --}}
+  {{#each verticalConfigs}}
+    {{#if verticalKey}}
+      '{{{verticalKey}}}': 
+        {{#with (deepMerge
+          (lookup verticalsToConfig verticalKey)
+          (lookup @root/verticalsToConfig verticalKey)
+          (lookup @root/componentSettings.UniversalResults.config verticalKey)
+          (lookup @root/componentSettings.UniversalResults.verticals verticalKey)
+        )}}
+          Object.assign({}, {{{ json this }}}, { {{> VerticalConfig verticalKey=../verticalKey url=@key }} })
+        {{/with}}
+      ,
+    {{/if}}
+  {{/each}}
+};
+
+ANSWERS.addComponent('UniversalResults', Object.assign({},
+  {{{ json componentSettings.UniversalResults }}}, 
+  {
     container: '.js-answersUniversalResults',
-    config: Object.assign({}, {
-      {{!-- Map each Vertical config's verticalsToConfig --}}
-      {{#each verticalConfigs}}
-        {{#if verticalKey}}
-          '{{{verticalKey}}}': {
-            {{#with (lookup verticalsToConfig verticalKey)}}
-              {{> VerticalConfig verticalKey=../verticalKey url=@key }}
-            {{/with}}
-          },
-        {{/if}}
-      {{/each}}
-    }, {
-      {{!-- Map the Universal config's verticalsToConfig --}}
-      {{#each verticalsToConfig}}
-        '{{@key}}': Object.assign(
-          {},
-          { {{> VerticalConfig verticalKey=@key }} },
-          {{#each ../verticalConfigs}}
-            {{#ifeq verticalKey @../key}}
-              { {{> VerticalConfig @../this verticalKey=verticalKey url=@key }} },
-            {{/ifeq}}
-          {{/each}}
-        ),
-      {{/each}}
-    }),
-  },
-  {{{ json componentSettings.UniversalResults }}}
+    verticals: Object.assign({},
+      {{{ json componentSettings.UniversalResults.verticals}}},
+      universalVerticalsToConfig,
+      pageVerticalsToConfig
+    ),
+  }
 ));
 
 {{#*inline 'VerticalConfig'}}


### PR DESCRIPTION
This commit updates the universal-standard script to do a deepMerge of
pageConfig V2Cs, the universal page config's V2C, and the universal page
config's componentSettings.UniversalResults

TEST=manual
test that I can specify universalLimit in a page config's V2C, a viewMoreLabel
in the universal page config's V2C, and appliedFilters.showChangeFilters in
the universal page config's UniversalResults componentSettings, and all 3 will
be used in config.

test that priority given to configs is componentSettings, universal V2C, then
page V2C, with highest priority first. Tested using universalLimit