### PR TITLE
Add spacing between accordion title and chevron icon

### DIFF
--- a/static/scss/answers/cards/faq-accordion.scss
+++ b/static/scss/answers/cards/faq-accordion.scss
@@ -43,14 +43,13 @@
       $line-height: var(--yxt-line-height-lg),
       $weight: var(--yxt-font-weight-semibold),
     );
-    
-    margin-right: calc(var(--yxt-base-spacing)/2);
   }
 
   &-icon
   {
     display: flex;
     flex-shrink: 0;
+    margin-left: calc(var(--yxt-base-spacing) / 2);
   }
 
   &-icon svg


### PR DESCRIPTION
Add spacing to the left of the accordion chevron icon to fix issue where the title runs into the icon.

J=SPR-2508
TEST=manual

Tested on local test site. Added long title to make sure title and icon have space between them.