### PR TITLE
Add strong tag styling in filter options

### DIFF
--- a/static/scss/answers/legacy-aeb/lanswers-overrides.scss
+++ b/static/scss/answers/legacy-aeb/lanswers-overrides.scss
@@ -43,3 +43,7 @@
     text-decoration: none;
   }
 }
+
+.yxt-FilterOptions-options strong {
+  font-weight: var(--yxt-font-weight-bold);
+}


### PR DESCRIPTION
Our CSS resets were removing the styling here. Longer term, the SDK should style things using classes, but for this specific one short term we will fix here.

TEST=manual
J=SPR-2530

Serve site locally with searchable facets, see bolding applied to text within strong tags.