### PR TITLE
Use mobile styling for product-prominentimage CTAs, set width

### DIFF
--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -2,6 +2,7 @@
 {
   display: flex;
   flex-direction: column;
+  width: 100%;
   font-size: var(--yxt-font-size-md);
   line-height: var(--yxt-line-height-md);
   background-color: var(--yxt-color-brand-white);


### PR DESCRIPTION
TEST=manual
J=SPR-2536, SPR-2507

Serve locally, see that entire card is now in one column rather than CTAs being in a second column. See desktop styling removed.