### PR TITLE
Add wrapper div around hours in direct answer card

### DIFF
--- a/directanswercards/allfields-standard/component.js
+++ b/directanswercards/allfields-standard/component.js
@@ -105,9 +105,9 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
         break;
       case "hours":
         if (isArray) {
-          arrayValue = answer.value.map((value) => Formatter.openStatus({hours: value}));
+          arrayValue = answer.value.map((value) => `<div>${Formatter.openStatus({hours: value})}</div>`);
         } else {
-          regularValue = Formatter.openStatus({hours: answer.value});
+          regularValue = `<div>${Formatter.openStatus({hours: answer.value})}</div>`;
         }
         value = isArray ? arrayValue : regularValue;
         break;


### PR DESCRIPTION
The openStatus hours formatter returns multiple elements. Adding a wrapper so that the elements are grouped together.

TEST=manual

Test locally with a direct answer that returns hours. See elements in wrapper div, and aligned horizontally instead of vertically stacked.