### PR TITLE
Add aria-labels to CTAs in all cards with CTAs

### DIFF
--- a/cards/event-standard/component.js
+++ b/cards/event-standard/component.js
@@ -35,7 +35,8 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
         url: profile.ticketUrl || profile.website, // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'RSVP', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -44,7 +45,8 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
         url: Formatter.getDirectionsUrl(profile),
         target: '_top',
         eventType: 'DRIVING_DIRECTIONS',
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '',
       }
     };
   }

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -91,7 +91,8 @@
     href="{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
-    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}>
+    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{

--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -33,7 +33,8 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
         target: '_top', // Where the new URL will be opened. To open in a new tab use '_blank'
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         // Event options for the analytics event fired when this CTA is clicked.
-        eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ })
+        eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ }),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -42,7 +43,8 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',
         eventType: 'CTA_CLICK',
-        eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ })
+        eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ }),
+        // ariaLabel: '',
       },
     };
   }

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -79,7 +79,8 @@
    href="{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
-   target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}>
+   target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
+   {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{

--- a/cards/job-standard/component.js
+++ b/cards/job-standard/component.js
@@ -36,7 +36,8 @@ class job_standardCardComponent extends BaseCard['job-standard'] {
         url: profile.applicationUrl || profile.landingPageUrl, // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       }
     };
   }

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -92,7 +92,8 @@
 <div class="HitchhikerJobStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
-    target="{{#if target}}{{target}}{{else}}_top{{/if}}">
+    target="{{#if target}}{{target}}{{else}}_top{{/if}}"
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{

--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -36,6 +36,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
         target: '_top', // If the URL will be opened in a new tab, etc.
         eventType: 'TAP_TO_CALL', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(), // The analytics event options for CTA clicks
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       CTA2: { // The secondary call to action for the card
         label: 'Get Directions',
@@ -44,6 +45,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
         target: '_top',
         eventType: 'DRIVING_DIRECTIONS',
         eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '',
       }
     };
   }

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -78,9 +78,12 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{url}}"
-    data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
-    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}>
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{

--- a/cards/menuitem-standard/component.js
+++ b/cards/menuitem-standard/component.js
@@ -41,7 +41,8 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
         url: profile.orderUrl, // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -50,7 +51,8 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
         url: profile.landingPageUrl,
         target: '_top',
         eventType: 'CTA_CLICK',
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '',
       }
     };
   }

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -108,9 +108,12 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{url}}"
-    data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
-    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}>
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{

--- a/cards/product-prominentimage/component.js
+++ b/cards/product-prominentimage/component.js
@@ -36,7 +36,8 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -45,7 +46,8 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',
         eventType: 'CTA_CLICK',
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '',
       }
     };
   }

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -92,7 +92,8 @@
     href="{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
-    target="{{#if target}}{{target}}{{else}}_top{{/if}}">
+    target="{{#if target}}{{target}}{{else}}_top{{/if}}"
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -41,7 +41,8 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -50,7 +51,8 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '',
       },
     };
   }

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -86,9 +86,12 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{url}}"
-    data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
-    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}>
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"

--- a/cards/professional-location/component.js
+++ b/cards/professional-location/component.js
@@ -44,7 +44,8 @@ class professional_locationCardComponent extends BaseCard['professional-location
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -53,7 +54,8 @@ class professional_locationCardComponent extends BaseCard['professional-location
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',
         eventType: 'CTA_CLICK',
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: ''
       }
     };
   }

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -146,9 +146,12 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{url}}"
-    data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
-    target="{{#if target}}{{target}}{{else}}_top{{/if}}">
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target="{{#if target}}{{target}}{{else}}_top{{/if}}"
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{

--- a/cards/professional-standard/component.js
+++ b/cards/professional-standard/component.js
@@ -41,7 +41,8 @@ class professional_standardCardComponent extends BaseCard['professional-standard
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -50,7 +51,8 @@ class professional_standardCardComponent extends BaseCard['professional-standard
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',
         eventType: 'CTA_CLICK',
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: ''
       }
     };
   }

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -124,9 +124,12 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{url}}"
-    data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
-    target="{{#if target}}{{target}}{{else}}_top{{/if}}">
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target="{{#if target}}{{target}}{{else}}_top{{/if}}"
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{

--- a/cards/standard/component.js
+++ b/cards/standard/component.js
@@ -36,7 +36,8 @@ class standardCardComponent extends BaseCard['standard'] {
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       // The secondary CTA of the card
       CTA2: {
@@ -45,7 +46,8 @@ class standardCardComponent extends BaseCard['standard'] {
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',
         eventType: 'CTA_CLICK',
-        eventOptions: this.addDefaultEventOptions()
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '',
       }
     };
   }

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -90,9 +90,12 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{url}}"
-    data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
-    target="{{#if target}}{{target}}{{else}}_top{{/if}}">
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target="{{#if target}}{{target}}{{else}}_top{{/if}}"
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{


### PR DESCRIPTION
TEST=manual

Locally test the faq-accordion and location-standard cards by adding text to the "ariaLabel" and then inspecting the DOM to see it there. Test those cards without adding text to ariaLabel, inspect DOM to see the aria-label attribute completely missing, as expected.