### PR TITLE
Add iframe-prod.js and iframe-staging.js

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -1,0 +1,86 @@
+export function generateIFrame(domain, queryParam, urlParam) {
+  var isLocalHost = window.location.host.split(':')[0] === 'localhost';
+  var containerEl = document.querySelector('#answers-container');
+  var iframe = document.createElement('iframe');
+  iframe.allow = 'geolocation';
+
+  domain = domain || '';
+  queryParam = queryParam || 'query';
+  urlParam = urlParam || 'verticalUrl';
+
+  var calcFrameSrc = function() {
+    var paramString = window.location.search;
+    paramString = paramString.substr(1, paramString.length);
+
+    // Parse the params out of the URL
+    var params = paramString.split('&'),
+                 verticalUrl;
+    var referrerPageUrl = document.referrer.split('?')[0].split('#')[0];
+
+    // Default for localhost is index.html, empty o/w
+    if (isLocalHost) {
+      verticalUrl = 'index.html';
+    }
+
+    // Don't include the verticalUrl or raw referrerPageUrl in the frame src
+    var new_params = params.filter(function(param) {
+       return (param.split('=')[0] !== 'verticalUrl') &&
+        (param.split('=')[0] !== 'referrerPageUrl');
+    });
+
+    for (var i = 0; i < params.length; i ++) {
+      var kv = params[i].split('=');
+      if (kv[0] === 'verticalUrl') {
+        verticalUrl = kv[1];
+      }
+
+      if (kv[0] === 'referrerPageUrl') {
+        referrerPageUrl = kv[1];
+      }
+    }
+
+    new_params.push('referrerPageUrl=' + referrerPageUrl);
+
+    // Build the Iframe URL
+    var iframeUrl = domain;
+    if (verticalUrl) {
+      iframeUrl += '/' + verticalUrl;
+    }
+
+    iframeUrl += '?' + new_params.join('&');
+    return iframeUrl;
+  };
+  // For dynamic iFrame resizing
+  var resizer = document.createElement('script');
+
+  resizer.onload = function() {
+    iFrameResize({
+      //log: true,
+      checkOrigin: false,
+      onMessage: function(data) {
+        iframe.iFrameResizer.resize();
+        var currLocation = window.location.href.split('?')[0];
+        var newLocation = currLocation + '?' + data.message;
+        if (window.location.href !== newLocation) {
+          history.pushState({query: data.message}, window.document.title, newLocation);
+        }
+      }
+    }, '#answers-frame');
+  };
+  resizer.src = "https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.1.1/iframeResizer.min.js";
+  document.body.appendChild(resizer);
+
+  iframe.src = calcFrameSrc();
+  iframe.frameBorder = 0;
+
+   // For dynamic iFrame sizing
+  iframe.style.width = '1px';
+  iframe.style.minWidth = '100%';
+  iframe.id = 'answers-frame';
+
+  window.onpopstate = function() {
+    iframe.contentWindow.location.replace(calcFrameSrc());
+  };
+
+  containerEl.appendChild(iframe);
+}

--- a/static/js/iframe-prod.js
+++ b/static/js/iframe-prod.js
@@ -1,0 +1,12 @@
+import { generateIFrame } from './iframe-common';
+
+const injectedData = JSON.parse(process.env.JAMBO_INJECTED_DATA || '{}');
+
+let prodDomain = '';
+if (injectedData.pages && injectedData.pages.domains && injectedData.pages.domains.prod && injectedData.pages.domains.prod.domain) {
+  const isHttps = injectedData.pages.domains.prod.isHttps;
+  prodDomain = isHttps ? 'https://' : 'http://';
+  prodDomain += injectedData.pages.domains.prod.domain;
+}
+
+generateIFrame(prodDomain);

--- a/static/js/iframe-staging.js
+++ b/static/js/iframe-staging.js
@@ -1,0 +1,12 @@
+import { generateIFrame } from './iframe-common';
+
+const injectedData = JSON.parse(process.env.JAMBO_INJECTED_DATA || '{}');
+
+let stagingDomain = '';
+if (injectedData.pages && injectedData.pages.domains && injectedData.pages.domains.staging && injectedData.pages.domains.staging.domain) {
+  const isHttps = injectedData.pages.domains.staging.isHttps;
+  stagingDomain = isHttps ? 'https://' : 'http://';
+  stagingDomain += injectedData.pages.domains.staging.domain;
+}
+
+generateIFrame(stagingDomain);

--- a/static/js/iframe.js
+++ b/static/js/iframe.js
@@ -1,4 +1,5 @@
 import { isStaging } from './is-staging';
+import { generateIFrame } from './iframe-common';
 
 const injectedData = JSON.parse(process.env.JAMBO_INJECTED_DATA || '{}');
 
@@ -18,91 +19,4 @@ if (injectedData.pages && injectedData.pages.domains) {
 }
 
 const domain = isStaging() ? stagingDomain : prodDomain;
-
-(function(domain, queryParam, urlParam) {
-  var isLocalHost = window.location.host.split(':')[0] === 'localhost';
-  var containerEl = document.querySelector('#answers-container');
-  var iframe = document.createElement('iframe');
-  iframe.allow = 'geolocation';
-
-  domain = domain || '';
-  queryParam = queryParam || 'query';
-  urlParam = urlParam || 'verticalUrl';
-
-  var calcFrameSrc = function() {
-    var paramString = window.location.search;
-    paramString = paramString.substr(1, paramString.length);
-
-    // Parse the params out of the URL
-    var params = paramString.split('&'),
-                 verticalUrl;
-    var referrerPageUrl = document.referrer.split('?')[0].split('#')[0];
-
-    // Default for localhost is index.html, empty o/w
-    if (isLocalHost) {
-      verticalUrl = 'index.html';
-    }
-
-    // Don't include the verticalUrl or raw referrerPageUrl in the frame src
-    var new_params = params.filter(function(param) {
-       return (param.split('=')[0] !== 'verticalUrl') &&
-        (param.split('=')[0] !== 'referrerPageUrl');
-    });
-
-    for (var i = 0; i < params.length; i ++) {
-      var kv = params[i].split('=');
-      if (kv[0] === 'verticalUrl') {
-        verticalUrl = kv[1];
-      }
-
-      if (kv[0] === 'referrerPageUrl') {
-        referrerPageUrl = kv[1];
-      }
-    }
-
-    new_params.push('referrerPageUrl=' + referrerPageUrl);
-
-    // Build the Iframe URL
-    var iframeUrl = domain;
-    if (verticalUrl) {
-      iframeUrl += '/' + verticalUrl;
-    }
-
-    iframeUrl += '?' + new_params.join('&');
-    return iframeUrl;
-  };
-  // For dynamic iFrame resizing
-  var resizer = document.createElement('script');
-
-  resizer.onload = function() {
-    iFrameResize({
-      //log: true,
-      checkOrigin: false,
-      onMessage: function(data) {
-        iframe.iFrameResizer.resize();
-        var currLocation = window.location.href.split('?')[0];
-        var newLocation = currLocation + '?' + data.message;
-        if (window.location.href !== newLocation) {
-          history.pushState({query: data.message}, window.document.title, newLocation);
-        }
-      }
-    }, '#answers-frame');
-  };
-  resizer.src = "https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.1.1/iframeResizer.min.js";
-  document.body.appendChild(resizer);
-
-  iframe.src = calcFrameSrc();
-  iframe.frameBorder = 0;
-
-   // For dynamic iFrame sizing
-  iframe.style.width = '1px';
-  iframe.style.minWidth = '100%';
-  iframe.id = 'answers-frame';
-
-  window.onpopstate = function() {
-    iframe.contentWindow.location.replace(calcFrameSrc());
-  };
-
-  containerEl.appendChild(iframe);
-  }
-)(`${domain}`);
+generateIFrame(domain);

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -20,8 +20,10 @@ module.exports = function () {
   return {
     mode: 'production',
     entry: {
-      bundle: `./${jamboConfig.dirs.output}/static/entry.js`,
-      iframe: `./${jamboConfig.dirs.output}/static/js/iframe.js`,
+      'bundle': `./${jamboConfig.dirs.output}/static/entry.js`,
+      'iframe': `./${jamboConfig.dirs.output}/static/js/iframe.js`,
+      'iframe-prod': `./${jamboConfig.dirs.output}/static/js/iframe-prod.js`,
+      'iframe-staging': `./${jamboConfig.dirs.output}/static/js/iframe-staging.js`,
     },
     output: {
       filename: '[name].js',


### PR DESCRIPTION
Create two new iframe scripts to send to clients so that they can always
use a specific domain regardless. This is useful if a client only ever
wants to test staging on an iframe (or only prod).

Split out the common iframe js code into iframe-common.js

J=SPR-2510
TEST=manual

Create an iframe_test.html, iframe_prod.html, iframe_staging.html

```
<html><head></head><body><div id="answers-container"></div><script src="iframe.js"></script></body></html>
<html><head></head><body><div id="answers-container"></div><script src="iframe-prod.js"></script></body></html>
<html><head></head><body><div id="answers-container"></div><script src="iframe-staging.js"></script></body></html>
```

Test to see iframe url generated on `grunt webpack` is correctly
pointing to prod, prod, staging respectively.

```
(export JAMBO_INJECTED_DATA='{"businessId":<redacted>,"answers":{"experiences":{"verizon_answers":{"apiKey":"<redacted>"}}},"pages":{"stagingDomains":["yextpages.net","landingpagespreview.com"],"domains":{"prod":{"domain":"answers.verizon.com","isHttps":true},"staging":{"domain":"answers_verizon_com.yextpages.net","isHttps":true}}}}'; jambo build && grunt webpack)
```