### PR TITLE
Formatter.address(): add null check for profile.address

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -8,6 +8,9 @@ import CtaFormatter from '@yext/cta-formatter';
  */
 export default class Formatters {
     static address(profile) {
+      if (!profile.address) {
+        return '';
+      }
       return components__address__i18n__addressForCountry({
         profile: profile,
         derivedData: {address: {stateName: ''}},


### PR DESCRIPTION
TEST=manual
check that my local vertical-map page can display profiles without an address field