### PR TITLE
core.hbs: Deep merge global_config, verticalsToConfig, pageSettings

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -27,8 +27,8 @@
         ...{{{ json this }}},
         {{#if verticalLimit}}
           search: {
-            ...{{{ json search }}},
-            limit: {{verticalLimit}}
+            limit: {{verticalLimit}},
+            ...{{{ json search }}}
           },
         {{/if}}
       {{/with}}


### PR DESCRIPTION
This commit updates core.hbs to deepMerge global_config, v2c, and pageSettings.
To make things slightly more readable I separated the configs into separate
variables, and updated the code to use the spread operator (since it's being babel-ified)

TEST=manual
test that I can specify verticalLimit in global_config, v2c, or pageSettings and it will be
merged with anything else in the search: {} config object, including defaultInitialSearch.
Tested that the priority order is correct, with global_config, v2c, and pageSettings,
in order of increasing priority.

Tested that verticalLimit has higher priority than plain old limit (probably not important
they shouldn't be specifying both)

Also tested in ie11.