### PR TITLE
Add target="_top" to phone links

### DIFF
--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -44,7 +44,7 @@
   <a class="HitchhikerLocationStandard-phone--mobile js-Hitchhiker-phone" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_parent">
+    target="_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -130,7 +130,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_parent">
+    target="_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -106,7 +106,7 @@
   <a class="HitchhikerProfessionalStandard-phone--mobile" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions="{{json card.phoneEventOptions}}"
-    target="_parent">
+    target="_top">
     {{card.phone}}
   </a>
 </div>


### PR DESCRIPTION
Needed to allow phone link click to call behavior on
ios safari in an iframe

T=https://yextops.zendesk.com/agent/tickets/335446
TEST=manual
tested adding this css on browserstack to techops production site
fixed the issue