### PR TITLE
Scroll to top of page on iframe load

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -78,6 +78,13 @@ export function generateIFrame(domain, queryParam, urlParam) {
   iframe.style.minWidth = '100%';
   iframe.id = 'answers-frame';
 
+  // Scroll to the top of the page when the iframe loads or a link is clicked.
+  iframe.addEventListener('load', () => {
+    document.documentElement.scrollTop = 0;
+    // For Safari
+    document.body.scrollTop = 0;
+  });
+
   window.onpopstate = function() {
     iframe.contentWindow.location.replace(calcFrameSrc());
   };


### PR DESCRIPTION
T=https://yextops.zendesk.com/agent/tickets/335900
TEST=manual
tested that when you click a view all link in universal,
on loading the vertical page you are scrolled to the top of the page