### PR TITLE
Update jambo version to v1.5.0

### DIFF
--- a/static/package.json
+++ b/static/package.json
@@ -23,7 +23,7 @@
     "grunt-webpack": "^3.1.3",
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
-    "jambo": "^1.4.0",
+    "jambo": "^1.5.0",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.13.1",
     "resolve-url-loader": "^3.1.1",


### PR DESCRIPTION
The theme now uses a "deepMerge" hbs helper that was introduced in v1.5.0 of jambo. 

TEST=compilation