### PR TITLE
Update package-lock

### DIFF
--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -4497,9 +4497,9 @@
       "dev": true
     },
     "jambo": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.4.0.tgz",
-      "integrity": "sha512-kaBnVbIRqHJt9iYQTLQYOBamej6BjiowHZT8avr5QRZewBGyPs+xokr2lrDSEX8ZHlE9f4KdO3TmFEfwJVEJnA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.5.0.tgz",
+      "integrity": "sha512-sMk/7u5+BjMVuh2elU9MAxoLGRSYm9pLbkaRRN+9zrk0K7V+3TvdzbGo6akmZ5pUlusckVAV5o8Qz4s8s/qwYw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.6",
@@ -4509,6 +4509,7 @@
         "fs-extra": "^8.1.0",
         "glob-to-regexp": "^0.4.1",
         "handlebars": "^4.7.3",
+        "lodash": "^4.17.15",
         "merge-options": "^2.0.0",
         "prompts": "^2.3.1",
         "simple-git": "^1.131.0",
@@ -8147,6 +8148,15 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
+    "xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.8.3"
+      }
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -8166,13 +8176,13 @@
       "dev": true
     },
     "yargs": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.0.tgz",
+      "integrity": "sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==",
       "dev": true,
       "requires": {
         "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
+        "decamelize": "^3.2.0",
         "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
@@ -8181,9 +8191,18 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.1"
+        "yargs-parser": "^18.1.2"
       },
       "dependencies": {
+        "decamelize": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz",
+          "integrity": "sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==",
+          "dev": true,
+          "requires": {
+            "xregexp": "^4.2.4"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",


### PR DESCRIPTION
This is necessary for the Yext CI system to properly update
dependencies. The system relies on the package-lock dependencies rather
than the package.json dependencies. We want to use the latest Jambo for
the deepMerge function (otherwise we get an error on live preview).

J=NONE
TEST=NONE