### PR TITLE
Add answers.js as an alias for the iframe.js

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -22,6 +22,7 @@ module.exports = function () {
     entry: {
       'bundle': `./${jamboConfig.dirs.output}/static/entry.js`,
       'iframe': `./${jamboConfig.dirs.output}/static/js/iframe.js`,
+      'answers': `./${jamboConfig.dirs.output}/static/js/iframe.js`,
       'iframe-prod': `./${jamboConfig.dirs.output}/static/js/iframe-prod.js`,
       'iframe-staging': `./${jamboConfig.dirs.output}/static/js/iframe-staging.js`,
     },


### PR DESCRIPTION
Legacy repositories under AEB would use answers.js as the script to send
to clients. As a result of changing to iframe.js, we should make a
duplicate answers.js that is a copy of iframe.js so clients can refer to
the same file.

J=SPR-2598
TEST=manual

Check an iframe shows with the new answers.js that is the exact same as
the iframe.js experience.