### PR TITLE
Fix grid card styling in ie11, add mobile styling

### DIFF
--- a/static/scss/answers/templates/vertical-grid.scss
+++ b/static/scss/answers/templates/vertical-grid.scss
@@ -5,6 +5,21 @@
     border: 0;
   }
 
+  .Hitchhiker-2-columns .yxt-Card
+  {
+    width: 50%;
+  }
+
+  .Hitchhiker-3-columns .yxt-Card
+  {
+    width: 33.33%;
+  }
+
+  .Hitchhiker-4-columns .yxt-Card
+  {
+    width: 25%;
+  }
+
   .Hitchhiker-2-columns,
   .Hitchhiker-3-columns,
   .Hitchhiker-4-columns
@@ -16,13 +31,17 @@
       min-width: 0;
       padding-right: calc(var(--yxt-base-spacing) / 4);
       padding-left: calc(var(--yxt-base-spacing) / 4);
+      flex-basis: auto; // reset SDK styling
+
+      @include bplte(xs) {
+        width: 100%;
+      }
     }
 
     .yxt-Card-child
     {
       border: 1px solid var(--hh-color-gray-1);
       display: flex;
-      flex: 1;
     }
 
     .yxt-Results-items
@@ -30,21 +49,6 @@
       display: flex;
       flex-wrap: wrap;
     }
-  }
-
-  .Hitchhiker-2-columns .yxt-Card
-  {
-    flex-basis: 50%;
-  }
-
-  .Hitchhiker-3-columns .yxt-Card
-  {
-    flex-basis: 33.33%;
-  }
-
-  .Hitchhiker-4-columns .yxt-Card
-  {
-    flex-basis: 25%;
   }
 
   .Answers


### PR DESCRIPTION
Before, grid cards in IE11 had small heights and caused content to
squish together. Needed to remove a flex property. It also didn't take 3
columns when removed, had to change to explicit width for IE11. We also
make the mobile version show only one card, even if in grid styling, to
match behavior before the Hitchhiker-3-columns class.

T=336748
J=SPR-2616
TEST=manual

Test to see grid is correctly showing on Chrome. Mobile shows one card,
everything else shows 3 cards (for a 3-column grid) on a new Jambo site.

Test to see in IE11, the grid shows the same as it does on Chrome