### PR TITLE
Add view more passthrough from vTC on universal

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -50,7 +50,7 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
   {{/if}}
   {{#if iconUrl}}sectionTitleIconUrl: '{{{iconUrl}}}',{{/if}}
   viewAllText: {{#if viewAllText}}'{{{viewAllText}}}'{{else}}'View All'{{/if}},
-  viewMore: {{viewMore}},
+  {{#if viewMore}}viewMore: {{viewMore}},{{/if}}
   {{#if mapConfig}}
     includeMap: true,
     mapConfig: Object.assign({


### PR DESCRIPTION
TEST=manual

Add viewMore: false in my JSON vTC for a vertical. View universal page in browser, run query with results for that vertical and see results render without the viewMore link.