### PR TITLE
Add extension to View More URLs in Universal Results

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -38,7 +38,7 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
         verticalKey: '{{{verticalKey}}}',
         url: '{{{urlWithoutExtension}}}.html',
       }
-    ]
+    ],
   {{/if}}
   {{#if cardType}}
     card: {


### PR DESCRIPTION
In hbs our keys do not have the extension. This means using the raw key as
a url does not work in production where our serving system requires the
correct extension. Our theme assumes the page extension is HTML, so added
it explicitly here.

TEST=manual
Techops 337801

Serve page locally using a webserver that requires the correct extension.
Click View More link and ensure it works. Go to client account in SGS
and make this change to their theme, use Live Preview to verify that the
View More links now work.