### PR TITLE
Fix bug that ignored componentSettings.Navigation configuration.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A starter answers theme for hitchhikers",
   "scripts": {
     "test": "jest"

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {

--- a/templates/universal-standard/script/navigation.hbs
+++ b/templates/universal-standard/script/navigation.hbs
@@ -24,4 +24,4 @@ verticalPages: [
   }{{#unless @last}},{{/unless}}
 {{/each}}
 ]
-}, {{{ json componentSettings.navigation }}}));
+}, {{{ json componentSettings.Navigation }}}));

--- a/templates/vertical-grid/script/navigation.hbs
+++ b/templates/vertical-grid/script/navigation.hbs
@@ -24,4 +24,4 @@ verticalPages: [
   }{{#unless @last}},{{/unless}}
 {{/each}}
 ]
-}, {{{ json componentSettings.navigation }}}));
+}, {{{ json componentSettings.Navigation }}}));

--- a/templates/vertical-map/script/navigation.hbs
+++ b/templates/vertical-map/script/navigation.hbs
@@ -24,4 +24,4 @@ verticalPages: [
   }{{#unless @last}},{{/unless}}
 {{/each}}
 ]
-}, {{{ json componentSettings.navigation }}}));
+}, {{{ json componentSettings.Navigation }}}));

--- a/templates/vertical-standard/script/navigation.hbs
+++ b/templates/vertical-standard/script/navigation.hbs
@@ -24,4 +24,4 @@ verticalPages: [
   }{{#unless @last}},{{/unless}}
 {{/each}}
 ]
-}, {{{ json componentSettings.navigation }}}));
+}, {{{ json componentSettings.Navigation }}}));


### PR DESCRIPTION
The Theme expected the NavigationComponent's settings to be located in
componentSettings.navigation, as opposed to componentSettings.Navigation. This
was confusing to the HHs since all other entries in componentSettings are
capitalized. This issue was present in the navigation script partial for all
page templates.

TEST=manual

Made a page from each type of template. Added componentSettings.Navigation
configuration. Saw that configuration applied correctly on each page.