### PR TITLE
iframe: Fix back navigation on browser history

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -88,8 +88,6 @@ export function generateIFrame(domain, queryParam, urlParam) {
 
   containerEl.appendChild(iframe);
 
-
-
   // For dynamic iFrame resizing
   iFrameResize({
     checkOrigin: false,


### PR DESCRIPTION
Imagine the following situation on an iframe of the answers experience.

Land on an iframe page.
Search A
Search B
Back navigation in browser

You would expect to go back to search A. Instead, you stay on search B.
In fact, any number of back navigations will keep you on search B.
This is because the state is not being replaced (when it is being
replaced in the actual experience). referrerPageUrl and context are
params that always replace history when added in the SDK, change the
iframe to reflect this as well.

Note: hardcoded because we do not have visibility into the SDK
persistentStorage call parameters.

J=SPR-2555
TEST=manual

On a local Jambo site:

Test that you can navigate backwards in history out of a series of
searches in an iframed experience.

Search A
Search B
Search C

Validate you can get back to search A.