### PR TITLE
Update color of -yxt-color-brand-hover to dark grey

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -5,7 +5,7 @@
 :root {
   // control colors throughout the theme and SDK
   --yxt-color-brand-primary: #0f70f0;
-  --yxt-color-brand-hover: #0C5ECB;
+  --yxt-color-brand-hover: var(--yxt-color-text-secondary);
   --yxt-color-brand-white: #fff;
   --yxt-color-text-primary: #212121;
   --yxt-color-text-secondary: #757575;

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -4,7 +4,7 @@
 :root {
   // control colors throughout the theme and SDK
   --yxt-color-brand-primary: #0f70f0;
-  --yxt-color-brand-hover: #0C5ECB;
+  --yxt-color-brand-hover: var(--yxt-color-text-secondary);
   --yxt-color-brand-white: #fff;
   --yxt-color-text-primary: #212121;
   --yxt-color-text-secondary: #757575;


### PR DESCRIPTION
Update the hover color to a dark gray. Change --yxt-color-brand-hover to var(--yxt-color-text-secondary).

J=SLAP-508

TEST=manual

Tested on local test site to ensure that hover color has been changed to dark gray.