### PR TITLE
Remove unwanted 40px Accordion card padding

### DIFF
--- a/static/scss/answers/cards/faq-accordion.scss
+++ b/static/scss/answers/cards/faq-accordion.scss
@@ -91,10 +91,6 @@
     font-size: var(--yxt-font-size-md);
     color: var(--yxt-color-text-primary);
     line-height: var(--yxt-line-height-md);
-
-    ul {
-      padding-left: 0;
-    }
   }
 
   &-details-toggle

--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -39,7 +39,6 @@
 
     display: flex;
     flex-direction: column;
-    padding-left: 40px;
   }
 
   li


### PR DESCRIPTION
In faq-accordion.scss, add padding-left: 0; to the &-details ul styling. rich_text_formatting in mixins.scss has padding-left: 40px in the ul styling, so we want to override that.

J=SLAP-513

TEST=manual

Tested on local site to make sure that faq accordion details don't have large padding when details are in a list.