### PR TITLE
Make vertical name all caps in alternative verticals

### DIFF
--- a/static/scss/answers/legacy-aeb/lanswers-overrides.scss
+++ b/static/scss/answers/legacy-aeb/lanswers-overrides.scss
@@ -52,3 +52,7 @@
   padding: 0;
   margin: 0;
 }
+
+.yxt-AlternativeVerticals-suggestionLink--copyLabel {
+  text-transform: uppercase;
+}


### PR DESCRIPTION
TEST=manual

On local test site, search using a query that has no results for the given query but results for another vertical. I used the term "people" on the locations tab. See the vertical "people" as a suggested vertical, and confirm that vertical name is all caps.