### PR TITLE
Fix spacing and shrinking in ordinal/title of location cards

### DIFF
--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -18,6 +18,7 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
     border-radius: 50%;
     margin-top: calc(var(--hh-location-standard-base-spacing) * 1/4);
     margin-right: calc(var(--hh-location-standard-base-spacing) * 3/4);
@@ -67,6 +68,8 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
   &-distance
   {
     font-style: italic;
+    white-space: nowrap;
+    padding-left: 4px;
   }
 
   &-subtitle

--- a/static/scss/answers/cards/professional-location.scss
+++ b/static/scss/answers/cards/professional-location.scss
@@ -48,6 +48,7 @@ $professional-location-ordinal-dimensions: 18px !default;
   }
 
   &-ordinal {
+    flex-shrink: 0;
     padding-top: 3px;
     border-radius: 50%;
     margin-top: calc(var(--hh-professional-location-spacing) / 4);
@@ -91,7 +92,8 @@ $professional-location-ordinal-dimensions: 18px !default;
   &-distance
   {
     font-style: italic;
-    margin-left: auto;
+    white-space: nowrap;
+    padding-left: 4px;
   }
 
   &-cardDetails


### PR DESCRIPTION
TEST=manual
J=SLAP-516, SLAP-517

Locally test using the location-standard and professional-location cards with an ordinal and a large title. See distance not wrap, space between the title and distance, and ordinal not shrink.

