### PR TITLE
Add margin-right to filter radio buttons

### DIFF
--- a/static/scss/answers/legacy-aeb/lanswers-overrides.scss
+++ b/static/scss/answers/legacy-aeb/lanswers-overrides.scss
@@ -58,5 +58,5 @@
 }
 
 .yxt-FilterOptions-radioButtonInput {
-  margin: 3px 3px 0px 5px;
+  margin-right: 3px;
 }


### PR DESCRIPTION
The theme css reset takes away the browser's default radio button margin,
which the sdk was relying on.

J=SLAP-511
TEST=manual

Add this line to in SGS, see that live preview shows regular looking
radio buttons. Also tested this in a jambo site locally.