### PR TITLE
Use answer and _top in RTF method calls in FAQ accordion card

### DIFF
--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -16,7 +16,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
     return {
       title: profile.name, // The header text of the card
       // subtitle: '', // The sub-header text of the card
-      details: profile.answer? ANSWERS.formatRichText(profile.answer, "answer", "_top") : null, // The text in the body of the card
+      details: profile.answer ? ANSWERS.formatRichText(profile.answer, "answer", "_top") : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // showMoreDetails: {


### PR DESCRIPTION
Update faq-accordion RTF Target Behavior. Change details to details: profile.answer? ANSWERS.formatRichText(profile.answer, "answer", "_top") : null.

J=SLAP-507

TEST=manual

Tested on local test site to ensure that data-field-name is "answer" for details in faq-accordion card and target behavior for links is "_top".