### PR TITLE
Fix image distortion issues 

### DIFF
--- a/static/scss/answers/cards/job-standard.scss
+++ b/static/scss/answers/cards/job-standard.scss
@@ -27,6 +27,7 @@
   &-imgWrapper
   {
     display: flex;
+    align-items: flex-start;
     width: 6.25rem;
     margin-right: 1rem;
   }

--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -23,6 +23,7 @@
   &-imgWrapper
   {
     display: flex;
+    align-items: flex-start;
     width: 100%;
     flex-shrink: 0;
   }


### PR DESCRIPTION
Fix image distortion in job-standard and product-prominentimage cards. Added align-items: flex-start to imgWrapper styling to prevent images from stretching to fit the imgWrapper.

J=SLAP-510

TEST=manual

Tested on local test site to make sure image distortion is fixed.