### PR TITLE
cards: Use registerTemplate to register template for cards

### DIFF
--- a/cards/event-standard/component.js
+++ b/cards/event-standard/component.js
@@ -6,15 +6,6 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/event-standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -57,6 +48,15 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
         // ariaLabel: '',
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/event-standard';
   }
 }
 

--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -6,15 +6,6 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/faq-accordion';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -94,6 +85,15 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
     });
 
     super.onMount();
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/faq-accordion';
   }
 }
 

--- a/cards/job-standard/component.js
+++ b/cards/job-standard/component.js
@@ -6,15 +6,6 @@ class job_standardCardComponent extends BaseCard['job-standard'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/job-standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -48,6 +39,15 @@ class job_standardCardComponent extends BaseCard['job-standard'] {
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/job-standard';
   }
 }
 

--- a/cards/link-standard/component.js
+++ b/cards/link-standard/component.js
@@ -6,15 +6,6 @@ class link_standardCardComponent extends BaseCard['link-standard'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/link-standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -36,6 +27,15 @@ class link_standardCardComponent extends BaseCard['link-standard'] {
       // },
       details: profile.htmlSnippet, // The text in the body of the card
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/link-standard';
   }
 }
 

--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -6,15 +6,6 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/location-standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -56,6 +47,15 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
         // ariaLabel: '',
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/location-standard';
   }
 }
 

--- a/cards/menuitem-standard/component.js
+++ b/cards/menuitem-standard/component.js
@@ -6,15 +6,6 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/menuitem-standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -63,6 +54,15 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
         // ariaLabel: '',
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/menuitem-standard';
   }
 }
 

--- a/cards/product-prominentimage/component.js
+++ b/cards/product-prominentimage/component.js
@@ -6,15 +6,6 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/product-prominentimage';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -58,6 +49,15 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
         // ariaLabel: '',
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/product-prominentimage';
   }
 }
 

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -6,15 +6,6 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/product-standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -63,6 +54,15 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
         // ariaLabel: '',
       },
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/product-standard';
   }
 }
 

--- a/cards/professional-location/component.js
+++ b/cards/professional-location/component.js
@@ -6,15 +6,6 @@ class professional_locationCardComponent extends BaseCard['professional-location
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/professional-location';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -66,6 +57,15 @@ class professional_locationCardComponent extends BaseCard['professional-location
         // ariaLabel: ''
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/professional-location';
   }
 }
 

--- a/cards/professional-standard/component.js
+++ b/cards/professional-standard/component.js
@@ -6,15 +6,6 @@ class professional_standardCardComponent extends BaseCard['professional-standard
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/professional-standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -63,6 +54,15 @@ class professional_standardCardComponent extends BaseCard['professional-standard
         // ariaLabel: ''
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/professional-standard';
   }
 }
 

--- a/cards/standard/component.js
+++ b/cards/standard/component.js
@@ -6,15 +6,6 @@ class standardCardComponent extends BaseCard['standard'] {
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'cards/standard';
-  }
-
-  /**
    * This returns an object that will be called `card`
    * in the template. Put all mapping logic here.
    *
@@ -58,6 +49,15 @@ class standardCardComponent extends BaseCard['standard'] {
         // ariaLabel: '',
       }
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/standard';
   }
 }
 

--- a/directanswercards/allfields-standard/component.js
+++ b/directanswercards/allfields-standard/component.js
@@ -6,15 +6,6 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
   }
 
   /**
-   * The template to render
-   * @returns {string}
-   * @override
-   */
-  static defaultTemplateName (config) {
-    return 'directanswercards/allfields-standard';
-  }
-
-  /**
    * @param type the type of direct answer
    * @param answer the full answer returned from the API, corresponds to response.directAnswer.answer.
    * @param relatedItem profile of the related entity for the direct answer
@@ -188,6 +179,15 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question', // Screen reader only text for thumbs-down
     };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'directanswercards/allfields-standard';
   }
 }
 


### PR DESCRIPTION
Note: this changes requires v1.3.4+, v1.4.5+, v1.5.2+

Instead of setting the template (and requiring a handlebars compilation
per card init), we register the template first to pre-compile the card
handlebars. This is to save the browser from unnecessary work,
especially as the number of result cards increases.

We also register the directanswers card, as this gets re-compiled with
every subsequent mount from a search.

J=SLAP-518
TEST=manual

Test all cards to make sure you see their card handlebars still
rendering.

allfields-standard

event-standard
faq-accordion
job-standard
link-standard
location-standard
menuitem-standard
product-prominentimage
product-standard
professional-location
professional-standard
standard