### PR TITLE
Paths relative to jambo output directory in webpack html loader

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -90,7 +90,6 @@ module.exports = function () {
             {
               loader: path.resolve(__dirname, `./${jamboConfig.dirs.output}/static/webpack/html-asset-loader.js`),
               options: {
-                absolutePathToOutputDirectory: path.resolve(__dirname, jamboConfig.dirs.output),
                 regex: /\\"(static\/assets\/[^"]*)\\"/g
               }
             },

--- a/static/webpack/html-asset-loader.js
+++ b/static/webpack/html-asset-loader.js
@@ -23,7 +23,7 @@ module.exports = function loader(source) {
   let matchNumber = 0;
   const imports = [];
   const regex = options.regex;
-  const getUrlImport = `var ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___ = require("${options.absolutePathToOutputDirectory}/../node_modules/html-loader/dist/runtime/getUrl.js")`;
+  const getUrlImport = `var ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___ = require("html-loader/dist/runtime/getUrl.js")`;
 
   source = source.replace(regex, function(match, group1) {
     const variableName = `___HTML_ASSET_LOADER_MATCH_${matchNumber}___`;


### PR DESCRIPTION
When HTML pages are not in the top-level of the output directory, these paths may change.

TEST=manual

Test with the localized-pages branch of jambo that generates pages with arbitrary paths in the output directory.
