### PR TITLE
Add relative path to asset paths after hashing

### DIFF
--- a/static/webpack/html-asset-loader.js
+++ b/static/webpack/html-asset-loader.js
@@ -32,7 +32,7 @@ module.exports = function loader(source) {
   source = source.replace(regex, function(match, group1) {
     const variableName = `___HTML_ASSET_LOADER_MATCH_${matchNumber}___`;
     const requirePath = loaderUtils.stringifyRequest(this, loaderUtils.urlToRequest(group1));
-    const relativePath = requirePath.substring(1, requirePath.indexOf('s')); // TODO this is a hack
+    const relativePath = requirePath.substring(1, requirePath.indexOf('static')); // TODO this is a hack
     const importString = `var ${variableName} = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___('${relativePath}', require(${requirePath}));`;
 
     matchNumber += 1;


### PR DESCRIPTION
For localized pages, the site's HTML files can live in nested directories under the output directory. However, the hashed assets always live top-level. Currently, our webpack hashing plugin assumes the HTML src is top-level. Update to insert the path to the HTML file from the root output directory.

TEST=manual