### PR TITLE
Use quotes instead of apostrophes to allow apostrophes in JSON config

### DIFF
--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -2,7 +2,7 @@ BaseCard = typeof(BaseCard) !== 'undefined' ?
   BaseCard :
   {};
 
-BaseCard['{{componentName}}'] = class extends ANSWERS.Component {
+BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
   constructor(config = {}, systemConfig = {}) {
     super(config, systemConfig);
     const data = config.data || {};

--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -2,7 +2,7 @@ BaseDirectAnswerCard = typeof (BaseDirectAnswerCard) !== 'undefined' ?
   BaseDirectAnswerCard :
   {};
 
-BaseDirectAnswerCard['{{componentName}}'] = class extends ANSWERS.Component {
+BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
   constructor(config = {}, systemConfig = {}) {
     super(config, systemConfig);
     let data = config.data || {};

--- a/templates/universal-standard/script/directanswer.hbs
+++ b/templates/universal-standard/script/directanswer.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('DirectAnswer', Object.assign({}, {
-  container: '#js-answersDirectAnswer'
+ANSWERS.addComponent("DirectAnswer", Object.assign({}, {
+  container: "#js-answersDirectAnswer"
 }, {{{ json componentSettings.DirectAnswer }}}));

--- a/templates/universal-standard/script/locationbias.hbs
+++ b/templates/universal-standard/script/locationbias.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('LocationBias', Object.assign({}, {
-  container: '#js-answersLocationBias'
+ANSWERS.addComponent("LocationBias", Object.assign({}, {
+  container: "#js-answersLocationBias"
 }, {{{ json componentSettings.LocationBias }}}));

--- a/templates/universal-standard/script/navigation.hbs
+++ b/templates/universal-standard/script/navigation.hbs
@@ -1,24 +1,24 @@
-ANSWERS.addComponent('Navigation', Object.assign({}, {
-container: '.js-answersNavigation',
+ANSWERS.addComponent("Navigation", Object.assign({}, {
+container: ".js-answersNavigation",
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{else}}
-      {{#with (lookup verticalsToConfig 'Universal')}}
+      {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/universal-standard/script/qasubmission.hbs
+++ b/templates/universal-standard/script/qasubmission.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('QASubmission', Object.assign({}, {
-    container: '.js-answersQASubmission',
+ANSWERS.addComponent("QASubmission", Object.assign({}, {
+    container: ".js-answersQASubmission",
 }, {{{ json componentSettings.QASubmission }}}));

--- a/templates/universal-standard/script/searchbar.hbs
+++ b/templates/universal-standard/script/searchbar.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('SearchBar', Object.assign({}, {
-    container: '.js-answersSearch',
+ANSWERS.addComponent("SearchBar", Object.assign({}, {
+    container: ".js-answersSearch",
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/universal-standard/script/spellcheck.hbs
+++ b/templates/universal-standard/script/spellcheck.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('SpellCheck', Object.assign({}, {
-    container: '.js-answersSpellCheck',
+ANSWERS.addComponent("SpellCheck", Object.assign({}, {
+    container: ".js-answersSpellCheck",
 }, {{{ json componentSettings.SpellCheck }}}));

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -1,10 +1,10 @@
-ANSWERS.addComponent('UniversalResults', Object.assign({}, {
-    container: '.js-answersUniversalResults',
+ANSWERS.addComponent("UniversalResults", Object.assign({}, {
+    container: ".js-answersUniversalResults",
     config: Object.assign({}, {
       {{!-- Map each Vertical config's verticalsToConfig --}}
       {{#each verticalConfigs}}
         {{#if verticalKey}}
-          '{{{verticalKey}}}': {
+          "{{{verticalKey}}}": {
             {{#with (lookup verticalsToConfig verticalKey)}}
               {{> VerticalConfig verticalKey=../verticalKey urlWithoutExtension=@key }}
             {{/with}}
@@ -14,7 +14,7 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
     }, {
       {{!-- Map the Universal config's verticalsToConfig --}}
       {{#each verticalsToConfig}}
-        '{{@key}}': Object.assign(
+        "{{@key}}": Object.assign(
           {},
           { {{> VerticalConfig verticalKey=@key }} },
           {{#each ../verticalConfigs}}
@@ -29,38 +29,38 @@ ANSWERS.addComponent('UniversalResults', Object.assign({}, {
   {{{ json componentSettings.UniversalResults }}}
 ));
 
-{{#*inline 'VerticalConfig'}}
+{{#*inline "VerticalConfig"}}
   {{#if universalSectionTemplate}}
-    template: `{{{read (concat 'universalsectiontemplates/' universalSectionTemplate)}}}`,
+    template: `{{{read (concat "universalsectiontemplates/" universalSectionTemplate)}}}`,
   {{else}}
-    template: `{{{read 'universalsectiontemplates/standard'}}}`,
+    template: `{{{read "universalsectiontemplates/standard"}}}`,
   {{/if}}
-  modifier: '{{{verticalKey}}}',
+  modifier: "{{{verticalKey}}}",
   {{#if urlWithoutExtension}}
-    url: '{{{urlWithoutExtension}}}.html',
+    url: "{{{urlWithoutExtension}}}.html",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
-        verticalKey: '{{{verticalKey}}}',
-        url: '{{{urlWithoutExtension}}}.html',
+        verticalKey: "{{{verticalKey}}}",
+        url: "{{{urlWithoutExtension}}}.html",
       }
     ],
   {{/if}}
   {{#if cardType}}
     card: {
-      cardType: '{{{cardType}}}'
+      cardType: "{{{cardType}}}"
     },
   {{/if}}
-  sectionTitle: {{#if sectionTitle}}'{{{sectionTitle}}}'{{else}}{{#if label}}'{{{label}}}'{{else}}'{{{verticalKey}}}'{{/if}}{{/if}},
+  sectionTitle: {{#if sectionTitle}}"{{{sectionTitle}}}"{{else}}{{#if label}}"{{{label}}}"{{else}}"{{{verticalKey}}}"{{/if}}{{/if}},
   {{#if icon}}
-    sectionTitleIconName: '{{{icon}}}',
+    sectionTitleIconName: "{{{icon}}}",
   {{/if}}
-  {{#if iconUrl}}sectionTitleIconUrl: '{{{iconUrl}}}',{{/if}}
-  viewAllText: {{#if viewAllText}}'{{{viewAllText}}}'{{else}}'View All'{{/if}},
+  {{#if iconUrl}}sectionTitleIconUrl: "{{{iconUrl}}}",{{/if}}
+  viewAllText: {{#if viewAllText}}"{{{viewAllText}}}"{{else}}"View All"{{/if}},
   {{#if viewMore}}viewMore: {{viewMore}},{{/if}}
   {{#if mapConfig}}
     includeMap: true,
     mapConfig: Object.assign({
-      apiKey: HitchhikerJS.getDefaultMapApiKey('{{ mapConfig.mapProvider }}')
+      apiKey: HitchhikerJS.getDefaultMapApiKey("{{ mapConfig.mapProvider }}")
     },
     {{{ json mapConfig }}},
     {{!-- This theme pin config must come after mapConfig in Object.assign --}}

--- a/templates/vertical-grid/script/facets.hbs
+++ b/templates/vertical-grid/script/facets.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('Facets', Object.assign({}, {
-  container: '#js-answersFacets',
+ANSWERS.addComponent("Facets", Object.assign({}, {
+  container: "#js-answersFacets",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-grid/script/filterbox.hbs
+++ b/templates/vertical-grid/script/filterbox.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('FilterBox', Object.assign({}, {
-  container: '#js-answersFilterBox',
+ANSWERS.addComponent("FilterBox", Object.assign({}, {
+  container: "#js-answersFilterBox",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.FilterBox }}}));

--- a/templates/vertical-grid/script/locationbias.hbs
+++ b/templates/vertical-grid/script/locationbias.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('LocationBias', Object.assign({}, {
-  container: '.js-answersLocationBias'
+ANSWERS.addComponent("LocationBias", Object.assign({}, {
+  container: ".js-answersLocationBias"
 }, {{{ json componentSettings.LocationBias }}}));

--- a/templates/vertical-grid/script/navigation.hbs
+++ b/templates/vertical-grid/script/navigation.hbs
@@ -1,24 +1,24 @@
-ANSWERS.addComponent('Navigation', Object.assign({}, {
-container: '.js-answersNavigation',
+ANSWERS.addComponent("Navigation", Object.assign({}, {
+container: ".js-answersNavigation",
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{else}}
-      {{#with (lookup verticalsToConfig 'Universal')}}
+      {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-grid/script/pagination.hbs
+++ b/templates/vertical-grid/script/pagination.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('Pagination', Object.assign({}, {
-  container: '.js-answersPagination',
+ANSWERS.addComponent("Pagination", Object.assign({}, {
+  container: ".js-answersPagination",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-grid/script/qasubmission.hbs
+++ b/templates/vertical-grid/script/qasubmission.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('QASubmission', Object.assign({}, {
-  container: '.js-answersQASubmission',
+ANSWERS.addComponent("QASubmission", Object.assign({}, {
+  container: ".js-answersQASubmission",
 }, {{{ json componentSettings.QASubmission }}}));

--- a/templates/vertical-grid/script/searchbar.hbs
+++ b/templates/vertical-grid/script/searchbar.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('SearchBar', Object.assign({}, {
-  container: '.js-answersSearch',
+ANSWERS.addComponent("SearchBar", Object.assign({}, {
+  container: ".js-answersSearch",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/vertical-grid/script/sortoptions.hbs
+++ b/templates/vertical-grid/script/sortoptions.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('SortOptions', Object.assign({}, {
-  container: '#js-answersSortOptions',
+ANSWERS.addComponent("SortOptions", Object.assign({}, {
+  container: "#js-answersSortOptions",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.SortOptions }}}));

--- a/templates/vertical-grid/script/spellcheck.hbs
+++ b/templates/vertical-grid/script/spellcheck.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('SpellCheck', Object.assign({}, {
-  container: '.js-answersSpellCheck',
+ANSWERS.addComponent("SpellCheck", Object.assign({}, {
+  container: ".js-answersSpellCheck",
 }, {{{ json componentSettings.SpellCheck }}}));

--- a/templates/vertical-grid/script/verticalresults.hbs
+++ b/templates/vertical-grid/script/verticalresults.hbs
@@ -1,32 +1,32 @@
-ANSWERS.addComponent('VerticalResults', Object.assign({}, {
-  container: '.js-answersVerticalResults',
+ANSWERS.addComponent("VerticalResults", Object.assign({}, {
+  container: ".js-answersVerticalResults",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
-    modifier: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
+    modifier: "{{{verticalKey}}}",
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}
       {
-        verticalKey: '{{{verticalKey}}}',
+        verticalKey: "{{{verticalKey}}}",
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        {{#if iconUrl}}iconUrl: '{{{iconUrl}}}',{{/if}}
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{{iconUrl}}}",{{/if}}
         label:
-        {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
       {
-      {{#with (lookup verticalsToConfig 'Universal')}}
+      {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}}
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}}
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}
@@ -34,7 +34,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   ],
   {{#with (lookup verticalsToConfig verticalKey)}}
     card: {
-      {{#if cardType}}cardType: '{{{cardType}}}',{{/if}}
+      {{#if cardType}}cardType: "{{{cardType}}}",{{/if}}
     },
   {{/with}}
 }, {{{ json componentSettings.VerticalResults }}}));

--- a/templates/vertical-map/script/facets.hbs
+++ b/templates/vertical-map/script/facets.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('Facets', Object.assign({}, {
-  container: '#js-answersFacets',
+ANSWERS.addComponent("Facets", Object.assign({}, {
+  container: "#js-answersFacets",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-map/script/filterbox.hbs
+++ b/templates/vertical-map/script/filterbox.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('FilterBox', Object.assign({}, {
-  container: '#js-answersFilterBox',
+ANSWERS.addComponent("FilterBox", Object.assign({}, {
+  container: "#js-answersFilterBox",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.FilterBox }}}));

--- a/templates/vertical-map/script/locationbias.hbs
+++ b/templates/vertical-map/script/locationbias.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('LocationBias', Object.assign({}, {
-  container: '#js-answersLocationBias',
+ANSWERS.addComponent("LocationBias", Object.assign({}, {
+  container: "#js-answersLocationBias",
 }, {{{ json componentSettings.LocationBias }}}));

--- a/templates/vertical-map/script/map.hbs
+++ b/templates/vertical-map/script/map.hbs
@@ -1,13 +1,13 @@
-ANSWERS.addComponent('Map', Object.assign({},
+ANSWERS.addComponent("Map", Object.assign({},
 {
-  container: '#js-answersMap',
+  container: "#js-answersMap",
   apiKey: HitchhikerJS.getDefaultMapApiKey(
     {{#if componentSettings.Map.mapProvider}}
-      '{{componentSettings.Map.mapProvider}}'
+      "{{componentSettings.Map.mapProvider}}"
     {{else}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if mapConfig}}
-          '{{mapConfig.mapProvider}}'
+          "{{mapConfig.mapProvider}}"
         {{/if}}
       {{/with}}
     {{/if}}

--- a/templates/vertical-map/script/navigation.hbs
+++ b/templates/vertical-map/script/navigation.hbs
@@ -1,24 +1,24 @@
-ANSWERS.addComponent('Navigation', Object.assign({}, {
-container: '#js-answersNavigation',
+ANSWERS.addComponent("Navigation", Object.assign({}, {
+container: "#js-answersNavigation",
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{else}}
-      {{#with (lookup verticalsToConfig 'Universal')}}
+      {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-map/script/pagination.hbs
+++ b/templates/vertical-map/script/pagination.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('Pagination', Object.assign({}, {
-  container: '#js-answersPagination',
+ANSWERS.addComponent("Pagination", Object.assign({}, {
+  container: "#js-answersPagination",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-map/script/qasubmission.hbs
+++ b/templates/vertical-map/script/qasubmission.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('QASubmission', Object.assign({}, {
-  container: '#js-answersQASubmission',
+ANSWERS.addComponent("QASubmission", Object.assign({}, {
+  container: "#js-answersQASubmission",
 }, {{{ json componentSettings.QASubmission }}}));

--- a/templates/vertical-map/script/searchbar.hbs
+++ b/templates/vertical-map/script/searchbar.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('SearchBar', Object.assign({}, {
-  container: '#js-answersSearchBar',
+ANSWERS.addComponent("SearchBar", Object.assign({}, {
+  container: "#js-answersSearchBar",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/vertical-map/script/sortoptions.hbs
+++ b/templates/vertical-map/script/sortoptions.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('SortOptions', Object.assign({}, {
-  container: '#js-answersSortOptions',
+ANSWERS.addComponent("SortOptions", Object.assign({}, {
+  container: "#js-answersSortOptions",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.SortOptions }}}));

--- a/templates/vertical-map/script/spellcheck.hbs
+++ b/templates/vertical-map/script/spellcheck.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('SpellCheck', Object.assign({}, {
-  container: '#js-answersSpellCheck',
+ANSWERS.addComponent("SpellCheck", Object.assign({}, {
+  container: "#js-answersSpellCheck",
 }, {{{ json componentSettings.SpellCheck }}}));

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -1,32 +1,32 @@
-ANSWERS.addComponent('VerticalResults', Object.assign({}, {
-  container: '#js-answersVerticalResults',
+ANSWERS.addComponent("VerticalResults", Object.assign({}, {
+  container: "#js-answersVerticalResults",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
-    modifier: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
+    modifier: "{{{verticalKey}}}",
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}
       {
-        verticalKey: '{{{verticalKey}}}',
+        verticalKey: "{{{verticalKey}}}",
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        {{#if iconUrl}}iconUrl: '{{{iconUrl}}}',{{/if}}
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{{iconUrl}}}",{{/if}}
         label:
-        {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
       {
-      {{#with (lookup verticalsToConfig 'Universal')}}
+      {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}}
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}}
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}
@@ -34,7 +34,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   ],
   {{#with (lookup verticalsToConfig verticalKey)}}
     card: {
-      {{#if cardType}}cardType: '{{{cardType}}}',{{/if}}
+      {{#if cardType}}cardType: "{{{cardType}}}",{{/if}}
     },
   {{/with}}
 }, {{{ json componentSettings.VerticalResults }}}));

--- a/templates/vertical-standard/script/facets.hbs
+++ b/templates/vertical-standard/script/facets.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('Facets', Object.assign({}, {
-  container: '#js-answersFacets',
+ANSWERS.addComponent("Facets", Object.assign({}, {
+  container: "#js-answersFacets",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.Facets }}}));

--- a/templates/vertical-standard/script/filterbox.hbs
+++ b/templates/vertical-standard/script/filterbox.hbs
@@ -1,10 +1,10 @@
-ANSWERS.addComponent('FilterBox', Object.assign({}, {
-  container: '#js-answersFilterBox',
+ANSWERS.addComponent("FilterBox", Object.assign({}, {
+  container: "#js-answersFilterBox",
   {{#if componentSettings.FilterBox.verticalKey}}
-    verticalKey: '{{componentSettings.FilterBox.verticalKey}}',
+    verticalKey: "{{componentSettings.FilterBox.verticalKey}}",
   {{else}}
     {{#if verticalKey}}
-      verticalKey: '{{{verticalKey}}}',
+      verticalKey: "{{{verticalKey}}}",
     {{/if}}
   {{/if}}
 }, {{{ json componentSettings.FilterBox }}}));

--- a/templates/vertical-standard/script/filteroptions.hbs
+++ b/templates/vertical-standard/script/filteroptions.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('FilterOptions', Object.assign({}, {
-  container: '#standard-filteroptions-container'
+ANSWERS.addComponent("FilterOptions", Object.assign({}, {
+  container: "#standard-filteroptions-container"
 }, {{{ json componentSettings.FilterOptions }}}));

--- a/templates/vertical-standard/script/locationbias.hbs
+++ b/templates/vertical-standard/script/locationbias.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('LocationBias', Object.assign({}, {
-  container: '.js-answersLocationBias'
+ANSWERS.addComponent("LocationBias", Object.assign({}, {
+  container: ".js-answersLocationBias"
 }, {{{ json componentSettings.LocationBias }}}));

--- a/templates/vertical-standard/script/navigation.hbs
+++ b/templates/vertical-standard/script/navigation.hbs
@@ -1,24 +1,24 @@
-ANSWERS.addComponent('Navigation', Object.assign({}, {
-container: '.js-answersNavigation',
+ANSWERS.addComponent("Navigation", Object.assign({}, {
+container: ".js-answersNavigation",
 verticalPages: [
 {{#each verticalConfigs}}
   {
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
     {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
     {{#if verticalKey}}
       {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{else}}
-      {{#with (lookup verticalsToConfig 'Universal')}}
+      {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-standard/script/pagination.hbs
+++ b/templates/vertical-standard/script/pagination.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('Pagination', Object.assign({}, {
-  container: '.js-answersPagination',
+ANSWERS.addComponent("Pagination", Object.assign({}, {
+  container: ".js-answersPagination",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.Pagination }}}));

--- a/templates/vertical-standard/script/qasubmission.hbs
+++ b/templates/vertical-standard/script/qasubmission.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('QASubmission', Object.assign({}, {
-  container: '.js-answersQASubmission',
+ANSWERS.addComponent("QASubmission", Object.assign({}, {
+  container: ".js-answersQASubmission",
 }, {{{ json componentSettings.QASubmission }}}));

--- a/templates/vertical-standard/script/searchbar.hbs
+++ b/templates/vertical-standard/script/searchbar.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('SearchBar', Object.assign({}, {
-  container: '.js-answersSearch',
+ANSWERS.addComponent("SearchBar", Object.assign({}, {
+  container: ".js-answersSearch",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.SearchBar }}}));

--- a/templates/vertical-standard/script/sortoptions.hbs
+++ b/templates/vertical-standard/script/sortoptions.hbs
@@ -1,6 +1,6 @@
-ANSWERS.addComponent('SortOptions', Object.assign({}, {
-  container: '#js-answersSortOptions',
+ANSWERS.addComponent("SortOptions", Object.assign({}, {
+  container: "#js-answersSortOptions",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
   {{/if}}
 }, {{{ json componentSettings.SortOptions }}}));

--- a/templates/vertical-standard/script/spellcheck.hbs
+++ b/templates/vertical-standard/script/spellcheck.hbs
@@ -1,3 +1,3 @@
-ANSWERS.addComponent('SpellCheck', Object.assign({}, {
-  container: '.js-answersSpellCheck',
+ANSWERS.addComponent("SpellCheck", Object.assign({}, {
+  container: ".js-answersSpellCheck",
 }, {{{ json componentSettings.SpellCheck }}}));

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -1,32 +1,32 @@
-ANSWERS.addComponent('VerticalResults', Object.assign({}, {
-  container: '.js-answersVerticalResults',
+ANSWERS.addComponent("VerticalResults", Object.assign({}, {
+  container: ".js-answersVerticalResults",
   {{#if verticalKey}}
-    verticalKey: '{{{verticalKey}}}',
-    modifier: '{{{verticalKey}}}',
+    verticalKey: "{{{verticalKey}}}",
+    modifier: "{{{verticalKey}}}",
   {{/if}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}
       {
-        verticalKey: '{{{verticalKey}}}',
+        verticalKey: "{{{verticalKey}}}",
         {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
         {{#ifeq ../verticalKey verticalKey}}isActive: true,{{/ifeq}}
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        {{#if iconUrl}}iconUrl: '{{{iconUrl}}}',{{/if}}
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{{iconUrl}}}",{{/if}}
         label:
-        {{#if label}}'{{{label}}}'{{else}}{{#if ../verticalKey}}'{{{../verticalKey}}}'{{else}}'{{{@key}}}'{{/if}}{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}},
+        {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}},
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
       {
-      {{#with (lookup verticalsToConfig 'Universal')}}
+      {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
-        {{#if icon}}icon: '{{{icon}}}',{{/if}}
-        label: {{#if label}}'{{{label}}}'{{else}}'{{{@key}}}'{{/if}},
-        url: {{#if url}}'{{{url}}}'{{else}}'{{{@key}}}.html'{{/if}}
+        {{#if icon}}icon: "{{{icon}}}",{{/if}}
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
+        url: {{#if url}}"{{{url}}}"{{else}}"{{{@key}}}.html"{{/if}}
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}
@@ -34,7 +34,7 @@ ANSWERS.addComponent('VerticalResults', Object.assign({}, {
   ],
   {{#with (lookup verticalsToConfig verticalKey)}}
     card: {
-      {{#if cardType}}cardType: '{{{cardType}}}',{{/if}}
+      {{#if cardType}}cardType: "{{{cardType}}}",{{/if}}
     },
   {{/with}}
 }, {{{ json componentSettings.VerticalResults }}}));


### PR DESCRIPTION
Since we're putting raw configuration directly into a string bounded by
single quotes, "'", single quotes in the configuration (e.g. apostrophes)
cause JS syntax errors. To fix this, we've opted to switch to quotation
marks. Some of the changes in this PR are specifically to resolve the
configuration issue, and others are to ensure that the code is uniform to
make it more intuitive to continue to use quotation marks as we maintain
this code.

TEST=manual

Generate a page with each of the four templates: vertical-standard,
vertical-map, vertical-grid, universal-standard. Add every component
and add config for each config option mapped by the theme, using
apostrophes. Run npx jambo build && grunt webpack && serve, and
view page in browser without JS errors.