### PR TITLE
Add a second head includes partial at the bottom of head tag

### DIFF
--- a/layouts/headincludesafteranswersjs.hbs
+++ b/layouts/headincludesafteranswersjs.hbs
@@ -1,0 +1,1 @@
+{{!-- Add any script tags here that should be included in the <head> after the JS bundle --}}

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    {{> layouts/headincludes }}
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
@@ -95,7 +96,7 @@
       };
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>
-    {{> layouts/headincludes }}
+    {{> layouts/headincludesafteranswersjs }}
 	</head>
   <body>
     {{#if global_config.googleTagManagerId}}


### PR DESCRIPTION
HH's were unable to use helper functions that they needed like "isStaging()" in the current headincludes partial since it exists before the bundle.js was included. This headincludes is the final thing in the < head > tag, and is imported after the bundle.js.

TEST=manual