### PR TITLE
Use negative margins to position filters instead of absolute position

### DIFF
--- a/static/scss/answers/templates/vertical-grid.scss
+++ b/static/scss/answers/templates/vertical-grid.scss
@@ -66,7 +66,7 @@
         padding: 0 var(--yxt-results-header-spacing);
       }
     }
-    
+
     &-filtersAndResults
     {
       display: flex;
@@ -115,9 +115,8 @@
       }
 
       @include bpgte(lg) {
-        position: absolute;
-        top: calc(var(--yxt-base-spacing) * 2);
-        left: calc(-200px - 24px);
+        margin-left: calc(-200px - 24px);
+        margin-right: 24px;
         margin-bottom: 0;
 
         .Answers-facets,

--- a/static/scss/answers/templates/vertical-standard.scss
+++ b/static/scss/answers/templates/vertical-standard.scss
@@ -62,9 +62,8 @@
     }
 
     @include bpgte(lg) {
-      position: absolute;
-      top: calc(var(--yxt-base-spacing) * 2);
-      left: calc(-200px - 24px);
+      margin-left: calc(-200px - 24px);
+      margin-right: 24px;
       margin-bottom: 0;
 
       .Answers-facets,


### PR DESCRIPTION
When the length of the list of filters exceeds the length of the results, it was cut off in the iFrame because our iFrame resizer script did not take absolutely positioned elements into account when calculating height. Used negative margins instead of absolute position to put the filter bar to the left of the results.

TEST=manual,visual
J=T-343753