### PR TITLE
Add relative path to page URLs from Jambo

### DIFF
--- a/templates/universal-standard/script/navigation.hbs
+++ b/templates/universal-standard/script/navigation.hbs
@@ -11,14 +11,14 @@ verticalPages: [
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -6,7 +6,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
         {{#if verticalKey}}
           "{{{verticalKey}}}": {
             {{#with (lookup verticalsToConfig verticalKey)}}
-              {{> VerticalConfig verticalKey=../verticalKey pageName=@key pagePath=../url }}
+              {{> VerticalConfig verticalKey=../verticalKey pageName=@key pagePath=../url relativePath=../../relativePath }}
             {{/with}}
           },
         {{/if}}
@@ -19,7 +19,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
           { {{> VerticalConfig verticalKey=@key }} },
           {{#each ../verticalConfigs}}
             {{#ifeq verticalKey @../key}}
-              { {{> VerticalConfig @../this verticalKey=verticalKey pageName=@key pagePath=../url }} },
+              { {{> VerticalConfig @../this verticalKey=verticalKey pageName=@key pagePath=../url relativePath=../../relativePath }} },
             {{/ifeq}}
           {{/each}}
         ),
@@ -37,19 +37,19 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
   {{/if}}
   modifier: "{{{verticalKey}}}",
   {{#if url}}
-    url: "{{{url}}}",
+    url: "{{relativePath}}/{{{url}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        url: "{{{url}}}",
+        url: "{{relativePath}}/{{{url}}}",
       }
     ],
   {{else if pagePath}}
-    url: "{{{pagePath}}}",
+    url: "{{relativePath}}/{{{pagePath}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        pageUrl: "{{{pagePath}}}",
+        pageUrl: "{{relativePath}}/{{{pagePath}}}",
       }
     ],
   {{else if pageName}}

--- a/templates/vertical-grid/script/navigation.hbs
+++ b/templates/vertical-grid/script/navigation.hbs
@@ -11,14 +11,14 @@ verticalPages: [
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-grid/script/verticalresults.hbs
+++ b/templates/vertical-grid/script/verticalresults.hbs
@@ -17,7 +17,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#if iconUrl}}iconUrl: "{{{iconUrl}}}",{{/if}}
         label:
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
@@ -26,7 +26,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}

--- a/templates/vertical-map/script/navigation.hbs
+++ b/templates/vertical-map/script/navigation.hbs
@@ -11,14 +11,14 @@ verticalPages: [
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -17,7 +17,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#if iconUrl}}iconUrl: "{{{iconUrl}}}",{{/if}}
         label:
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
@@ -26,7 +26,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}

--- a/templates/vertical-standard/script/navigation.hbs
+++ b/templates/vertical-standard/script/navigation.hbs
@@ -11,14 +11,14 @@ verticalPages: [
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{else}}
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -17,7 +17,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#if iconUrl}}iconUrl: "{{{iconUrl}}}",{{/if}}
         label:
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}
       }{{#unless @last}},{{/unless}}
       {{else}}
@@ -26,7 +26,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        url: "{{#if url}}{{{url}}}{{else if ../url}}{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
+        url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
       }{{#unless @last}},{{/unless}}
       {{/if}}


### PR DESCRIPTION
TEST=manual

Test with pages using the url format {locale}/{pageName}.{pageExt}, using navigation and switching between index.html and location.html pages then clicking "View More" link from the universal tab. Then test using the url format {locale}/override/{pageName}.{pageExt} doing the same.