### PR TITLE
universalSectionTemplate: Rename three/two-columns -> grid-three/two-columns

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -20,8 +20,8 @@
   --hh-answers-container-width-filters: 950px;
   --hh-color-gray-1: #dcdcdc;
   --hh-color-gray-2: #fafafa;
-  --hh-three-columns-width: 212px;
-  --hh-two-columns-width: 326px;
+  --hh-universal-grid-three-columns-width: 212px;
+  --hh-universal-grid-two-columns-width: 326px;
 
   // common border variables
   --yxt-border-default: 1px solid var(--yxt-color-borders);

--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -28,8 +28,8 @@
 
 // Universal Section Template styling
 @import "universalsectiontemplates/standard";
-@import "universalsectiontemplates/three-columns";
-@import "universalsectiontemplates/two-columns";
+@import "universalsectiontemplates/grid-three-columns";
+@import "universalsectiontemplates/grid-two-columns";
 
 // Cards styling
 @import "cards/ctas";

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -19,8 +19,8 @@
   --hh-answers-container-width-filters: 950px;
   --hh-color-gray-1: #dcdcdc;
   --hh-color-gray-2: #fafafa;
-  --hh-three-columns-width: 212px;
-  --hh-two-columns-width: 326px;
+  --hh-universal-grid-three-columns-width: 212px;
+  --hh-universal-grid-two-columns-width: 326px;
 
   // common border variables
   --yxt-border-default: 1px solid var(--yxt-color-borders);

--- a/static/scss/answers/universalsectiontemplates/grid-three-columns.scss
+++ b/static/scss/answers/universalsectiontemplates/grid-three-columns.scss
@@ -1,8 +1,8 @@
-/** @define HitchhikerResultsTwoColumns */
+/** @define HitchhikerResultsGridThreeColumns */
 
 @import 'common';
 
-.HitchhikerResultsTwoColumns
+.HitchhikerResultsGridThreeColumns
 {
   @include universal-standard;
 
@@ -17,8 +17,8 @@
     {
       @media (min-width: $breakpoint-mobile-min) {
         margin: 8px;
-        flex-basis: var(--hh-two-columns-width);
-        max-width: var(--hh-two-columns-width);
+        flex-basis: var(--hh-universal-grid-three-columns-width);
+        max-width: var(--hh-universal-grid-three-columns-width);
         border: var(--yxt-border-default);
       }
     }

--- a/static/scss/answers/universalsectiontemplates/grid-two-columns.scss
+++ b/static/scss/answers/universalsectiontemplates/grid-two-columns.scss
@@ -1,8 +1,8 @@
-/** @define HitchhikerResultsThreeColumns */
+/** @define HitchhikerResultsGridTwoColumns */
 
 @import 'common';
 
-.HitchhikerResultsThreeColumns
+.HitchhikerResultsGridTwoColumns
 {
   @include universal-standard;
 
@@ -17,8 +17,8 @@
     {
       @media (min-width: $breakpoint-mobile-min) {
         margin: 8px;
-        flex-basis: var(--hh-three-columns-width);
-        max-width: var(--hh-three-columns-width);
+        flex-basis: var(--hh-universal-grid-two-columns-width);
+        max-width: var(--hh-universal-grid-two-columns-width);
         border: var(--yxt-border-default);
       }
     }

--- a/universalsectiontemplates/grid-three-columns.hbs
+++ b/universalsectiontemplates/grid-three-columns.hbs
@@ -3,7 +3,7 @@
     {{> noResults}}
   {{/if}}
   {{#if resultsPresent}}
-    <section class="HitchhikerResultsTwoColumns HitchhikerResultsTwoColumns--{{_config.modifier}} HitchhikerResultsTwoColumns--universal">
+    <section class="HitchhikerResultsGridThreeColumns HitchhikerResultsGridThreeColumns--{{_config.modifier}} HitchhikerResultsGridThreeColumns--universal">
       {{> header}}
       {{> map}}
       {{> results}}
@@ -20,34 +20,34 @@
 
 
 {{#*inline "header"}}
-  <div class="HitchhikerResultsTwoColumns-title">
+  <div class="HitchhikerResultsGridThreeColumns-title">
     {{#if iconIsBuiltIn}}
       <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
     {{else}}
       <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
     {{/if}}
-    <div class="HitchhikerResultsTwoColumns-titleLabel">{{_config.title}}</div>
+    <div class="HitchhikerResultsGridThreeColumns-titleLabel">{{_config.title}}</div>
   </div>
   <div data-component="ResultsHeader"></div>
 {{/inline}}
 
 {{#*inline "results"}}
-  <div class="HitchhikerResultsTwoColumns-items js-HitchhikerResultsTwoColumns-items">
+  <div class="HitchhikerResultsGridThreeColumns-items js-HitchhikerResultsGridThreeColumns-items">
     {{#each results}}
-      <div class="HitchhikerResultsTwoColumns-Card HitchhikerResultsTwoColumns-Card--universal"
+      <div class="HitchhikerResultsGridThreeColumns-Card HitchhikerResultsGridThreeColumns-Card--universal"
         data-component="Card"
         data-opts='{ "_index": {{@index}} }'>
       </div>
     {{/each}}
     {{#each placeholders}}
-      <div class="HitchhikerResultsTwoColumns-Card-placeholder" aria-hidden="true"></div>
+      <div class="HitchhikerResultsGridThreeColumns-Card-placeholder" aria-hidden="true"></div>
     {{/each}}
   </div>
 {{/inline}}
 
 {{#*inline "map"}}
   {{#if _config.includeMap}}
-    <div class="HitchhikerResultsTwoColumns-map"
+    <div class="HitchhikerResultsGridThreeColumns-map"
           data-component="Map"
           data-prop="map">
     </div>
@@ -56,9 +56,9 @@
 
 {{#*inline "viewMore"}}
   {{#if _config.isUniversal}}
-    <div class="HitchhikerResultsTwoColumns-viewMore">
-      <a class="HitchhikerResultsTwoColumns-viewMoreLink" href="{{ verticalURL }}">
-        <div class="HitchhikerResultsTwoColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
+    <div class="HitchhikerResultsGridThreeColumns-viewMore">
+      <a class="HitchhikerResultsGridThreeColumns-viewMoreLink" href="{{ verticalURL }}">
+        <div class="HitchhikerResultsGridThreeColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
         <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
       </a>
     </div>

--- a/universalsectiontemplates/grid-two-columns.hbs
+++ b/universalsectiontemplates/grid-two-columns.hbs
@@ -3,7 +3,7 @@
     {{> noResults}}
   {{/if}}
   {{#if resultsPresent}}
-    <section class="HitchhikerResultsThreeColumns HitchhikerResultsThreeColumns--{{_config.modifier}} HitchhikerResultsThreeColumns--universal">
+    <section class="HitchhikerResultsGridTwoColumns HitchhikerResultsGridTwoColumns--{{_config.modifier}} HitchhikerResultsGridTwoColumns--universal">
       {{> header}}
       {{> map}}
       {{> results}}
@@ -20,34 +20,34 @@
 
 
 {{#*inline "header"}}
-  <div class="HitchhikerResultsThreeColumns-title">
+  <div class="HitchhikerResultsGridTwoColumns-title">
     {{#if iconIsBuiltIn}}
       <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
     {{else}}
       <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
     {{/if}}
-    <div class="HitchhikerResultsThreeColumns-titleLabel">{{_config.title}}</div>
+    <div class="HitchhikerResultsGridTwoColumns-titleLabel">{{_config.title}}</div>
   </div>
   <div data-component="ResultsHeader"></div>
 {{/inline}}
 
 {{#*inline "results"}}
-  <div class="HitchhikerResultsThreeColumns-items js-HitchhikerResultsThreeColumns-items">
+  <div class="HitchhikerResultsGridTwoColumns-items js-HitchhikerResultsGridTwoColumns-items">
     {{#each results}}
-      <div class="HitchhikerResultsThreeColumns-Card HitchhikerResultsThreeColumns-Card--universal"
+      <div class="HitchhikerResultsGridTwoColumns-Card HitchhikerResultsGridTwoColumns-Card--universal"
         data-component="Card"
         data-opts='{ "_index": {{@index}} }'>
       </div>
     {{/each}}
     {{#each placeholders}}
-      <div class="HitchhikerResultsThreeColumns-Card-placeholder" aria-hidden="true"></div>
+      <div class="HitchhikerResultsGridTwoColumns-Card-placeholder" aria-hidden="true"></div>
     {{/each}}
   </div>
 {{/inline}}
 
 {{#*inline "map"}}
   {{#if _config.includeMap}}
-    <div class="HitchhikerResultsThreeColumns-map"
+    <div class="HitchhikerResultsGridTwoColumns-map"
           data-component="Map"
           data-prop="map">
     </div>
@@ -56,9 +56,9 @@
 
 {{#*inline "viewMore"}}
   {{#if _config.isUniversal}}
-    <div class="HitchhikerResultsThreeColumns-viewMore">
-      <a class="HitchhikerResultsThreeColumns-viewMoreLink" href="{{ verticalURL }}">
-        <div class="HitchhikerResultsThreeColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
+    <div class="HitchhikerResultsGridTwoColumns-viewMore">
+      <a class="HitchhikerResultsGridTwoColumns-viewMoreLink" href="{{ verticalURL }}">
+        <div class="HitchhikerResultsGridTwoColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
         <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
       </a>
     </div>


### PR DESCRIPTION
We rename the three-columns and two-columns universalSectionTemplate
names with a prefix grid in anticipation that there will be other column
template names.

J=SLAP-582
TEST=manual

Test on a local jambo site with universalSectionTemplate
grid-two-columns and grid-three-columns. Check to see no regressions in
styling or functionality.