### PR TITLE
Properly format RTF direct answers in the allfields-standard card.

### DIFF
--- a/directanswercards/allfields-standard/component.js
+++ b/directanswercards/allfields-standard/component.js
@@ -12,7 +12,7 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
    */
   dataForRender(type, answer, relatedItem) {
     let isArray = Array.isArray(answer.value);
-    let value, arrayValue, regularValue;
+    let value, arrayValue, regularValue, isRichText;
 
     switch (answer.fieldType) {
       case 'url':
@@ -119,12 +119,14 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
         value = isArray ? arrayValue : regularValue;
         break;
       case 'rich_text':
+        isRichText = true;
         if (isArray) {
           arrayValue = answer.value.map((value) => ANSWERS.formatRichText(value));
         } else {
           regularValue = ANSWERS.formatRichText(answer.value);
         }
         value = isArray ? arrayValue : regularValue;
+        break;
       case 'single_line_text':
       case 'multi_line_text':
       default:
@@ -178,6 +180,7 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
       footerText: 'Was this the answer you were looking for?', // Text to display in the footer
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question', // Screen reader only text for thumbs-down
+      isRichText: isRichText, // If the direct answer is sourced from a rich-text field
     };
   }
 

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -64,7 +64,7 @@
 
 {{#*inline 'answer_value'}}
 {{#if value}}
-<div class="HitchhikerAllFieldsStandard-fieldValue">
+<div class="HitchhikerAllFieldsStandard-fieldValue{{#if isRichText}} HitchhikerAllFieldsStandard-fieldValueRtf{{/if}}">
   {{#if isArray}}
     <ul class="HitchhikerAllFieldsStandard-ul">
     {{#each value}}

--- a/static/scss/answers/directanswercards/allfields-standard.scss
+++ b/static/scss/answers/directanswercards/allfields-standard.scss
@@ -164,6 +164,11 @@
     font-weight: var(--yxt-font-weight-semibold);
   }
 
+  &-fieldValueRtf
+  {
+    @include rich_text_formatting;
+  }
+
   &-fieldValue
   {
     @include Text(


### PR DESCRIPTION
RTF direct answers were not properly formatted. There was a missing 'break'
in the 'rich_text' case which led the code to fall through to the 'default'
block. The default block overwrote the correctly formatted value. Lastly,
we were not including the needed CSS styling for when there was an RTF direct
answer.

To properly apply the styling, I had to add a 'HitchhikerAllFieldStandard-field
ValueRtf' class. I couldn't just add the styling under the 'HitchhikerAllFields
Standard-fieldValue' selector. That would have caused the 'fieldValueLink'
styling to be break as it styles links a bit differently than the RTF mixin.

T=345108
TEST=manual

Made sure the formatting/display was correct for an RTF and a phone # direct
answer.