### PR TITLE
Update theme version to v1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.11.0",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.11.0",
+  "version": "1.10.2",
   "description": "A starter answers theme for hitchhikers",
   "scripts": {
     "test": "jest"

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.11.0",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.11.0",
+  "version": "1.10.2",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {


### PR DESCRIPTION
Included in this release:
- Properly format RTF direct answers in the allfields-standard card.
- Rename three/two-columns universal section templates to grid-three/two-columns
- Fixed facet bug that occurred when using the back button in an iFrame