### PR TITLE
formatters: _formatHoursForAnswers does not have side effects

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -3,6 +3,8 @@ import { components__address__i18n__addressForCountry } from './address-i18n.js'
 import CtaFormatter from '@yext/cta-formatter';
 import provideOpenStatusTranslation from './open-status-18n';
 
+import cloneDeep from 'lodash.cloneDeep';
+
 /**
  * Contains some of the commonly used formatters for parsing pieces
  * of profile information.
@@ -574,6 +576,7 @@ export default class Formatters {
    * @returns {Object[]}
    */
   static _formatHoursForAnswers(days, timezone) {
+    const formattedDays = cloneDeep(days);
     const daysOfWeek = [
       'SUNDAY',
       'MONDAY',
@@ -583,10 +586,10 @@ export default class Formatters {
       'FRIDAY',
       'SATURDAY',
     ];
-    const holidayHours = days.holidayHours || [];
-    for (let day in days) {
+    const holidayHours = formattedDays.holidayHours || [];
+    for (let day in formattedDays) {
       if (day === 'holidayHours' || day === 'reopenDate') {
-        delete days[day];
+        delete formattedDays[day];
       } else {
         const currentDayName = day.toUpperCase();
         const numberTimezone = this._convertTimezoneToNumber(timezone);
@@ -597,13 +600,13 @@ export default class Formatters {
           let holidayDate = new Date(holiday.date + 'T00:00:00.000');
           if (dayNameToDate.toDateString() == holidayDate.toDateString()) {
             holiday.intervals = this._formatIntervals(holiday.openIntervals);
-            days[day].dailyHolidayHours = holiday;
+            formattedDays[day].dailyHolidayHours = holiday;
           }
         }
 
-        days[day].day = day.toUpperCase();
+        formattedDays[day].day = day.toUpperCase();
 
-        let intervals = days[day].openIntervals;
+        let intervals = formattedDays[day].openIntervals;
         if (intervals) {
           for (let interval of intervals) {
             for (let period in interval) {
@@ -611,13 +614,13 @@ export default class Formatters {
             }
           }
         } else {
-          days[day].openIntervals = [];
+          formattedDays[day].openIntervals = [];
         }
-        days[day].intervals = days[day].openIntervals;
+        formattedDays[day].intervals = formattedDays[day].openIntervals;
       }
     }
 
-    return Object.values(days);
+    return Object.values(formattedDays);
   }
 
   // "-05:00 -> -5

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -4868,6 +4868,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",

--- a/static/package.json
+++ b/static/package.json
@@ -39,6 +39,7 @@
     "font-awesome": "^4.7.0",
     "iframe-resizer": "^4.1.1",
     "libphonenumber-js": "^1.7.51",
+    "lodash.clonedeep": "^4.5.0",
     "remove-files-webpack-plugin": "^1.4.3"
   }
 }


### PR DESCRIPTION
This is to fix a bug where if you pressed the feedback button on a
direct answer card, there would be a console error saying replace is not
a function. This was because we were parsing the time intervals into
numbers and changing the input parameter (the answer). When a user tried
to click on the feedback button, the parameter was already modified into
a number so when it tries to re-render the data, it will try to do a
.replace on a number (not a valid function for the number type). We
change things to not have side effects and instead return a new /deep/
clone of the input answer.

J=SLAP-608
TEST=manual

Test on an experience with a Direct Answer w/ Hours. (Used the Yext
                Answers experience with the query "ny hours").

Test that the direct answer can be seen correctly and when clicking on a
feedback thumbs up input on the direct answer card, the console does not
error and you see the "Thank you for your feedback!" copy.

Test that other direct answers are fine as well (address), even though
this should be isolated to hours direct answers.