### PR TITLE
iframe: Only replaceState instead of pushState

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -80,16 +80,11 @@ export function generateIFrame(domain, queryParam, urlParam) {
     onMessage: function(messageData) {
       const message = JSON.parse(messageData.message);
       const params = message.params;
-      const replaceHistory = message.replaceHistory;
       iframe.iFrameResizer.resize();
       var currLocation = window.location.href.split('?')[0];
       var newLocation = currLocation + '?' + params;
       if (window.location.href !== newLocation) {
-        if (replaceHistory) {
-          history.replaceState({query: params}, window.document.title, newLocation);
-        } else {
-          history.pushState({query: params}, window.document.title, newLocation);
-        }
+        history.replaceState({query: params}, window.document.title, newLocation);
       }
     }
   }, '#answers-frame');


### PR DESCRIPTION
This is to fix a bug where, when using an iframe of the answers
experience, two history states would be pushed to the browser history.
This is because we use `window.history.pushState` in the SDK. Chrome and
Firefox share the window.history objects between parent and iframe
implementations. Thus, the iframe script and the SDK would previously
push state to the history object.

However, the iframe script still needs to change the state when
verticalUrl and query change (so that we can persist in the parent URL).
To accomplish this, we set it to use replaceState always.

J=SLAP-528
TEST=manual

Test on a client implementation currently experiencing this problem.
Test on a local Jambo HH Theme site linked to latest SDK.

Test that when searching two consecutive searches, only two history
states are added to the Chrome browser history (right click on the back
navigation button). Before there would be four.

Test that basic functionality of clicking through the experience works.
Test that places you generally want to pushState (e.g. applying a
search, applying a filter) have a new history state pushed.
Test that the verticalUrl and query param are still passed into the
parent URL when using an iframe.