### PR TITLE
Update grunt watch to watch all files in layouts/ and jambo.json

### DIFF
--- a/static/Gruntfile.js
+++ b/static/Gruntfile.js
@@ -6,41 +6,48 @@ module.exports = function(grunt) {
     webpack: {
       myConfig: webpackConfig
     },
-	  watch: {
-		  all: {
-		    files: ['cards/**/*.*', 'config/**/*.*', 'pages/**/*.*', 'static/**/*.*', 'partials/**/*.*'],
-		    tasks: ['jambobuild', 'webpack',],
-		    options: {
-		      spawn: false,
-		    },
-		  },
-		},
+      watch: {
+        all: {
+          files: [
+            'cards/**/*.*',
+            'config/**/*.*',
+            'pages/**/*.*',
+            'static/**/*.*',
+            'partials/**/*.*',
+            'layouts/**/*.*',
+            'jambo.json'
+        ],
+        tasks: ['jambobuild', 'webpack',],
+        options: {
+          spawn: false,
+        },
+      },
+    },
   });
 
   grunt.loadNpmTasks('grunt-webpack');
   grunt.loadNpmTasks('grunt-contrib-watch');
 
   grunt.registerTask('jambobuild', 'Jambo build.',
-  	function() {
-	  	// Force task into async mode and grab a handle to the "done" function.
-	  	var done = this.async();
-	  	// Run some sync stuff.
-	  	grunt.log.writeln('Processing task...');
-	  	// And some async stuff.
-	  	exec('npx jambo build', (error, stdout, stderr) => {
-		    if (error) {
-		        console.log(`error: ${error.message}`);
-		        done(false);
-		        return;
-		    }
-		    if (stderr) {
-		        console.log(`stderr: ${stderr}`);
-		        done(false);
-		        return;
-		    }
-		    console.log(`${stdout}`);
-		    done();
-			});
-		}
-	);
+  function() {
+    // Force task into async mode and grab a handle to the "done" function.
+    var done = this.async();
+    // Run some sync stuff.
+    grunt.log.writeln('Processing task...');
+    // And some async stuff.
+    exec('npx jambo build', (error, stdout, stderr) => {
+      if (error) {
+        console.log(`error: ${error.message}`);
+        done(false);
+        return;
+      }
+      if (stderr) {
+        console.log(`stderr: ${stderr}`);
+        done(false);
+        return;
+      }
+      console.log(`${stdout}`);
+      done();
+    });
+  });
 }


### PR DESCRIPTION
The grunt watch is slightly out of date, and does not watch the
layouts folder or the jambo.json config

T=https://yext.slack.com/archives/C016ZKY42CF/p1599059924012100
TEST=manual

Made these changes to a local jambo site, saw that updating jambo.json
and also layouts/ would kick off the watch task