### PR TITLE
Use locale for the open status formatter

### DIFF
--- a/cards/multilang-location-standard/component.js
+++ b/cards/multilang-location-standard/component.js
@@ -18,7 +18,7 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(), // The event options for title click analytics
       // subtitle: '', // The sub-header text of the card
-      hours: Formatter.openStatus(profile, '{{ @root.global_config.locale }}'),
+      hours: Formatter.openStatus(profile, document.documentElement.lang),
       // services: [], // Used for a comma delimited list of services for the location
       address: Formatter.address(profile), // The address for the card
       phone: Formatter.nationalizedPhoneDisplay(profile), // The phone number for the card


### PR DESCRIPTION
Pass locale to the open status formatter

Pass document.documentElement.lang to the open status formatter in the multilang-location-standard so that the formatter knows which translations to load

J=none
TEST=manual

Run a jambo build on an internationalized site using the multilang-location-standard and observe the correct translations get loaded