### PR TITLE
Added translation helper to hardcoded text

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -71,7 +71,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
     sectionTitleIconName: "{{{icon}}}",
   {{/if}}
   {{#if iconUrl}}sectionTitleIconUrl: "{{{iconUrl}}}",{{/if}}
-  viewAllText: {{#if viewAllText}}"{{{viewAllText}}}"{{else}}"View All"{{/if}},
+  viewAllText: {{#if viewAllText}}"{{{viewAllText}}}"{{else}}{{ translateJS phrase='View All' context='View is a verb' }}{{/if}},
   {{#if viewMore}}viewMore: {{viewMore}},{{/if}}
   {{#if mapConfig}}
     includeMap: true,


### PR DESCRIPTION
TEST=manual/compile

Run `jambo build` without a translation file; look at output file and see "View All" in place of this translation placeholder.