### PR TITLE
Add focus state to RTF links

### DIFF
--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -76,7 +76,12 @@
     text-decoration: underline;
 
     &:hover {
-      text-decoration: none
+      text-decoration: none;
+    }
+
+    &:focus {
+      background: var(--yxt-color-text-secondary);
+      border-radius: 4px;
     }
   }
 


### PR DESCRIPTION
TEST=manual
J=SLAP-589

See RTF mixin used on the faq-accordion card; use that card in the FAQs vertical of the rosetest experience. View in browser, force focus state using devtools. See styling applied.