### PR TITLE
Formatters: fix typo cloneDeep to clonedeep

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -3,7 +3,7 @@ import { components__address__i18n__addressForCountry } from './address-i18n.js'
 import CtaFormatter from '@yext/cta-formatter';
 import provideOpenStatusTranslation from './open-status-18n';
 
-import cloneDeep from 'lodash.cloneDeep';
+import clonedeep from 'lodash.clonedeep';
 
 /**
  * Contains some of the commonly used formatters for parsing pieces
@@ -580,7 +580,7 @@ export default class Formatters {
    * @returns {Object[]}
    */
   static _formatHoursForAnswers(days, timezone) {
-    const formattedDays = cloneDeep(days);
+    const formattedDays = clonedeep(days);
     const daysOfWeek = [
       'SUNDAY',
       'MONDAY',


### PR DESCRIPTION
Fix small typo in lodash.clonedeep import. This typo
caused the webpack build to fail on the live preview images,
but not locally on a mac. This is probably because mac osx
is case insensitive while unix-style systems are case sensitive.

TEST=manual

- run "npx jambo build && grunt webpack" locally
- run "grunt watch" locally and edit a config file
- add this change to a site through sgs and see live preview 
and the custom development build both work