### PR TITLE
Use Google Place Id for Get Directions formatter if available

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -48,6 +48,10 @@ export default class Formatters {
     }
 
     static getDirectionsUrl(profile, key = 'address') {
+        if (profile.googlePlaceId) {
+          return `https://www.google.com/maps/place/?q=place_id:${profile.googlePlaceId}`;
+        }
+
         const addr = profile[key];
         if (!addr) {
           return '';


### PR DESCRIPTION
TEST=manual
J=SLAP-586

Test using an AFT site. Found an entity with a Google Place Id, then used the Google docs to find the proper URL format: "https://www.google.com/maps/place/?q=place_id:[[GOOGLE PLACE ID]]". Tested locally and saw that Google Place Id was used when present and URL properly linked to GMB listing. Tested on a location without a Google Place Id and saw the address being used.