### PR TITLE
Allow empty search by default in vertical templates config

### DIFF
--- a/templates/vertical-grid/page-config.json
+++ b/templates/vertical-grid/page-config.json
@@ -29,7 +29,8 @@
     },
     **/
     "SearchBar": {
-      "placeholderText": "Search" // The placeholder text in the answers search bar
+      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "allowEmptySearch": true // Allows users to submit an empty search in the searchbar
     },
     "VerticalResults": {
       "noResults": {

--- a/templates/vertical-map/page-config.json
+++ b/templates/vertical-map/page-config.json
@@ -29,7 +29,8 @@
     },
     **/
     "SearchBar": {
-      "placeholderText": "Search" // The placeholder text in the answers search bar
+      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "allowEmptySearch": true // Allows users to submit an empty search in the searchbar
     },
     "VerticalResults": {
       "noResults": {

--- a/templates/vertical-standard/page-config.json
+++ b/templates/vertical-standard/page-config.json
@@ -29,7 +29,8 @@
     },
     **/
     "SearchBar": {
-      "placeholderText": "Search" // The placeholder text in the answers search bar
+      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "allowEmptySearch": true // Allows users to submit an empty search in the searchbar
     },
     "VerticalResults": {
       "noResults": {


### PR DESCRIPTION
TEST=manual
J=SLAP-568

Use `jambo page` command to generate page with updated template. Add vertical key, run `jambo build && grunt webpack`. View page in browser, hit enter with empty search and see search is triggered.