### PR TITLE
Use localized SDK bundles from given locale

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -6,7 +6,7 @@
 </script>
 <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.css">
 <link rel="stylesheet" type="text/css" href="{{relativePath}}/bundle.css">
-<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#unless (eq sdkBundleLocale 'en')}}{{sdkBundleLocale}}-{{/unless}}answerstemplates.compiled.min.js"></script>
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answerstemplates.compiled.min.js"></script>
 <script>
 {{#babel}}
   function initAnswers() {
@@ -61,5 +61,4 @@
   }
 {{/babel}}
 </script>
-<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#unless (eq sdkBundleLocale 'en')}}{{sdkBundleLocale}}-{{/unless}}answers.min.js" onload="initAnswers()" async></script>
-
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answers.min.js" onload="initAnswers()" async></script>


### PR DESCRIPTION
Add support for an "sdkLocaleOverride" parameter in each locale's param object in the locale_config. Use that param to determine which version of the SDK bundle should be used.

TEST=manual
J=SLAP-633

Tested with the localized-pages branch of jambo and ran `jambo build`. Viewed output .html files for English (no bundle prefix), Spanish (es bundle prefix), and French (Belgium), fr-be (used override here for 'fr') and verified output was as expected.