### PR TITLE
Add translations for 'View All' text

### DIFF
--- a/translations/es.po
+++ b/translations/es.po
@@ -90,3 +90,8 @@ msgstr "Llama"
 msgctxt "RSVP is a verb"
 msgid "RSVP"
 msgstr "RSVP"
+
+#: templates/universal-standard/script/universalresults.js:74
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Ver todos"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -90,3 +90,8 @@ msgstr "Appelle"
 msgctxt "RSVP is a verb"
 msgid "RSVP"
 msgstr "RSVP"
+
+#: templates/universal-standard/script/universalresults.js:74
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Voir tout"


### PR DESCRIPTION
TEST=manual
J=SLAP-645

Run `jambo build` for a site configured to generate French and Spanish universal pages. Add a vertical to the universal page's vTC and see the translated "View All" text appear.