### PR TITLE
Support static assets for generated pages more than one-level deep in…

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -90,7 +90,7 @@ module.exports = function () {
             {
               loader: path.resolve(__dirname, `./${jamboConfig.dirs.output}/static/webpack/html-asset-loader.js`),
               options: {
-                regex: /\\"([./]*static\/assets\/[^"]*)\\"/g
+                regex: /\\"([\.\/]*static\/assets\/[^"]*)\\"/g
               }
             },
             {


### PR DESCRIPTION
… 'public'.

Previously, the html-asset-loader was used to resolve asset paths that began
with 'static'. This precluded pages more than one layer deep in 'public' from
having their asset paths resolved. Such pages will have asset paths that begin
with some number of '../'s before 'static'.

J=SLAP-641
TEST=manual

Created a test site where I generated pages for 3 different locales. The
page sets for these locales were at various depths in 'public'. Confirmed
that I could see image assets correctly displayed on the page for each locale.