### PR TITLE
Fix open status 0:00pm bug for non-English locales

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -843,7 +843,12 @@ export default class Formatters {
     let time = new Date();
     time.setHours(Math.floor(yextTime / 100));
     time.setMinutes(yextTime % 100);
-    return time.toLocaleString(locale, { hour: 'numeric', minute: 'numeric', hour12: !twentyFourHourClock })
+
+    return time.toLocaleString(locale, {
+      hour: 'numeric',
+      minute: 'numeric',
+      hourCycle: twentyFourHourClock ? 'h24' : 'h12'
+    });
   }
 
   /**


### PR DESCRIPTION
Use` hourCycle` instead of `hour12` option in the Date.prototype.toLocaleString() call. Options are documented [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat). For some reason, for locales with a default 24 hour time, when using `hour12: true`, noon shows as 0:00 pm. 

TEST=manual
J=SLAP-631

Use rosetest experience with a business opening at noon today. Change computer timezone to before 12:00 pm. Use formatter with 'es' locale - confirm the bug "Closed · Opens at 0:00 p. m.". After making this change, view card, confirm that the hours show as "Closed · Opens at 12:00 p. m.". Test with the "isTwentyFourHourClock=true" case, see "Closed · Opens at 12:00". Test with the English locale, see "Closed · Opens at 12:00 PM"