### PR TITLE
Support absolute URL for favicon

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -51,7 +51,7 @@
     {{/if}}
 
     {{#if global_config.favicon}}
-      <link rel="shortcut icon" href="../{{global_config.favicon}}">
+      <link rel="shortcut icon" href="{{global_config.favicon}}">
     {{/if}}
     <script src="bundle.js"></script>
     {{#if global_config.googleAnalyticsId}}

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -94,7 +94,7 @@ module.exports = function () {
             {
               loader: path.resolve(__dirname, `./${jamboConfig.dirs.output}/static/webpack/html-asset-loader.js`),
               options: {
-                regex: /\\"(static\/assets\/[^"]*)\\"/g
+                regex: /\\"([./]*static\/assets\/[^"]*)\\"/g
               }
             },
             {


### PR DESCRIPTION
This PR fixes a bug that has been present since theme version v1.4.2 where the favicon path in source wouldn't be replaced with the hashed path. It also allows the favicon URL reference in global_config to be an absolute URL. 

TEST=manual
J=SLAP-626

Serve jambo site locally with a favicon using the Yext corporate site's favicon 
```json
"favicon": "//www.yext.com/wp-content/themes/yext/img/icons/favicon-seal.png"
```
Then again with a favicon as a local file in the static/assets directory.
```
"favicon": "static/assets/images/favicon.png"
```
Also tested with Verizon Jambo site. 
