### PR TITLE
Allow absolute path in global_config logo

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -33,7 +33,7 @@
     {{/if}}
     <meta property="og:type" content="website">
     {{#if global_config.logo}}
-      <meta property="og:image" content="../{{global_config.logo}}">
+      <meta property="og:image" content="{{global_config.logo}}">
     {{/if}}
     {{#if canonicalUrl}}
       <meta property="og:url" content="{{canonicalUrl}}">


### PR DESCRIPTION
This works for the reasons described in this PR (doing the same thing for the favicon): https://github.com/yext/answers-hitchhiker-theme/pull/323

TEST=manual
J=SLAP-668

Use absolute path in global_config for logo:
```
"logo": "//www.yext.com/wp-content/themes/yext/img/icons/favicon-seal.png"
```
Then test with relative path in global_config for logo:
```
"logo": "static/assets/images/favicon.png"
```