### PR TITLE
Collapsible Filters Vertical Map SCSS

### DIFF
--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -25,6 +25,7 @@
 @import "templates/universal-standard";
 @import "templates/vertical-standard";
 @import "templates/vertical-grid";
+@import "templates/vertical-map-filters";
 
 // Universal Section Template styling
 @import "universalsectiontemplates/standard";

--- a/static/scss/answers/collapsible-filters/answers-overrides.scss
+++ b/static/scss/answers/collapsible-filters/answers-overrides.scss
@@ -1,0 +1,142 @@
+input[type="radio"] {
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(118, 118, 118);
+  border-radius: 50%;
+}
+
+.yxt-FilterOptions {
+  &-fieldSet {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  &-showToggle {
+    margin-bottom: 2px;
+    margin-top: 2px;
+  }
+
+  &-optionLabel::before {
+    background: white;
+  }
+
+  &-radioButtonInput {
+    margin-right: 10px;
+  }
+
+  &-radioButtonInput:focus {
+    outline: none;
+  }
+
+  &-options {
+    margin-top: 4px;
+    margin-bottom: 4px;
+    padding-left: 4px;
+  }
+
+  &-option {
+    margin-top: 4px;
+  }
+}
+
+@media (max-width: $collapsible-filters-mobile-breakpoint) {
+  .yxt-SortOptions-option,
+  .yxt-FilterOptions-option {
+    margin: 8px 0px;
+  }
+}
+
+.yxt-SortOptions {
+  &-container {
+    padding-left: 4px;
+  }
+
+  &-fieldSet {
+    margin: 0;
+  }
+
+  &-option {
+    align-items: center;
+    margin-top: 4px;
+    margin-bottom: 0px;
+  }
+
+  &-options {
+    margin-top: 8px;
+    margin-bottom: 0px;
+  }
+
+  &-optionLabel {
+    margin-left: 10px;
+  }
+}
+
+.yxt-Facets-container {
+  width: 100%;
+  padding: 0;
+}
+
+.yxt-FilterBox {
+  &-titleContainer {
+    display: none;
+  }
+
+  &-container {
+    padding: 0;
+  }
+
+  &-filter {
+    padding-top: 8px;
+    margin-top: 0;
+    @media (min-width: $collapsible-filters-mobile-breakpoint) {
+      margin-top: 4px;
+    }
+
+    & + & {
+      border-top: none;
+    }
+  }
+
+  &-apply {
+    margin: 0;
+  }
+}
+
+.yxt-AppliedFilters {
+  margin-right: 0;
+}
+
+.yxt-AlternativeVerticals {
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  margin-bottom: 0;
+
+  @media (max-width: $collapsible-filters-mobile-breakpoint) {
+    border-bottom: none;
+  }
+
+  @media (min-width: $collapsible-filters-mobile-breakpoint) {
+    &-noResultsInfo {
+      font-size: 18px;
+    }
+  }
+}
+
+.yxt-Card {
+  margin-bottom: 0;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+}
+
+.yxt-SpellCheck {
+  margin-left: var(--yxt-base-spacing);
+  margin-right: var(--yxt-base-spacing);
+  margin-top: calc(2 * var(--yxt-base-spacing));
+  margin-bottom: calc(2 * var(--yxt-base-spacing));
+}
+
+.yxt-VerticalResultsCount {
+  margin-right: 12px;
+}

--- a/static/scss/answers/collapsible-filters/apply-filters-button.scss
+++ b/static/scss/answers/collapsible-filters/apply-filters-button.scss
@@ -1,0 +1,33 @@
+.yxt-ApplyFiltersButton {
+  width: 100%;
+  font-family: var(--yxt-font-family);
+  font-size: var(--yxt-font-size-md);
+  line-height: var(--yxt-line-height-xs);
+  font-weight: var(--yxt-font-weight-semibold);
+  font-style: normal;
+  color: var(--yxt-color-brand-white);
+  border: 0;
+  border-radius: 3px;
+  background: var(--yxt-color-brand-primary);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  height: 40px;
+  cursor: pointer;
+
+  &:not(:disabled) {
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      background: padding-box $collapsible-filters-hover-color;
+    }
+
+    &:focus {
+      border: var(--yxt-button-focus-border-size) double $collapsible-filters-hover-color;
+    }
+  }
+
+  .yxt-VerticalResultsCount {
+    margin-bottom: 0;
+  }
+}

--- a/static/scss/answers/collapsible-filters/filter-panel-toggle.scss
+++ b/static/scss/answers/collapsible-filters/filter-panel-toggle.scss
@@ -1,0 +1,11 @@
+.yxt-FilterPanelToggle {
+  color: var(--yxt-color-brand-primary);
+  font-size: 14px;
+
+  cursor: pointer;
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+    color: $collapsible-filters-hover-color;
+  }
+}

--- a/static/scss/answers/templates/vertical-map-filters.scss
+++ b/static/scss/answers/templates/vertical-map-filters.scss
@@ -1,0 +1,140 @@
+$nav-wrapper-height: 113px;
+$answers-header-height: 44px;
+$apply-filters-button-height: 44px;
+$results-column-height: calc(100vh - #{$nav-wrapper-height} - #{$answers-header-height} - 2px);
+$collapsible-filters-mobile-breakpoint: 768px !default;
+$collapsible-filters-hover-color: #0c5ecb !default;
+
+@import "../collapsible-filters/filter-panel-toggle";
+@import "../collapsible-filters/apply-filters-button";
+
+.AnswersVerticalMapFilters {
+  @import "../collapsible-filters/answers-overrides";
+}
+
+.AnswersVerticalMapFilters .Answers {
+  &-resultsWrapper {
+    display: flex;
+    flex-grow: 1;
+  }
+
+  &-verticalResults {
+    flex-grow: 1;
+  }
+
+  &-resultsColumn {
+    padding-top: 0;
+    display: flex;
+    flex-direction: column;
+    height: $results-column-height;
+    width: 100%;
+    overflow-y: auto;
+    margin-top: $answers-header-height;
+
+    @media (max-width: $collapsible-filters-mobile-breakpoint) {
+      height: auto;
+    }
+  }
+
+  &-sortOptions {
+    padding: 0;
+  }
+
+  &-map {
+    width: 50%;
+    height: 100%;
+    position: fixed;
+    left: 50%;
+    border-left: var(--yxt-border-default);
+
+    @include bplte(xs) {
+      display: none;
+    }
+  }
+
+  &-qaSubmission {
+    background-color: var(--hh-color-gray-2);
+  }
+
+  &-resultsWrapper {
+    margin-top: $nav-wrapper-height;
+    @media (max-width: $collapsible-filters-mobile-breakpoint) {
+      height: auto;
+    }
+  }
+
+  &-resultsAndHeader {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &-resultsAndHeader {
+    @media (min-width: $collapsible-filters-mobile-breakpoint) {
+      width: 50%;
+    }
+  }
+
+  &-filterPanelToggle {
+    margin-left: auto;
+    margin-right: 14px;
+  }
+
+  &-applyFiltersButton {
+    position: fixed;
+    width: calc(50% - 16px);
+    bottom: 0;
+    z-index: 100;
+    background-color: var(--hh-answers-background-color);
+    padding: 0px 8px 4px;
+    left: 0;
+
+    @media (max-width: $collapsible-filters-mobile-breakpoint) {
+      width: 100%;
+    }
+  }
+
+  &-navWrapper {
+    height: $nav-wrapper-height;
+    position: fixed;
+  }
+
+  &-facets {
+    flex-grow: 1;
+  }
+
+  &-footer {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
+  &-header {
+    padding-left: 16px;
+    display: flex;
+    padding-top: 12px;
+    padding-bottom: 8px;
+    top: 0;
+    background: var(--hh-answers-background-color);
+    border-bottom: var(--yxt-border-default);
+
+    position: fixed;
+    margin-top: $nav-wrapper-height;
+    width: 50%;
+    z-index: 100;
+
+    @media (max-width: $collapsible-filters-mobile-breakpoint) {
+      width: 100%;
+    }
+  }
+
+  &-filters {
+    position: relative;
+    z-index: 0;
+    background-color: var(--hh-answers-background-color);
+    flex-direction: column;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 4px;
+    margin-bottom: $apply-filters-button-height;
+  }
+}


### PR DESCRIPTION
This commit adds the scss used in the collapsible filters version of
the vertical map page. Another PR will add scss needed for vertical-standard

TEST=manual

Tested that I can jambo build the vertical-map page with collapsible filters,
with this scss, and that I can add sort options, filterbox, facets, and
qa submission to the page