### PR TITLE
Add dns-prefetch for sitescdn and font-display: swap

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -14,6 +14,7 @@
     <link rel="dns-prefetch" href="//dynl.mktgcdn.com">
     <link rel="dns-prefetch" href="//dynm.mktgcdn.com">
     <link rel="dns-prefetch" href="//www.google-analytics.com">
+    <link rel="dns-prefetch" href="//assets.sitescdn.net">
     <script>
       document.documentElement.lang = {{#if global_config.locale}}"{{global_config.locale}}"{{else}}'en'{{/if}};
     </script>

--- a/static/scss/answers/common/fonts-default.scss
+++ b/static/scss/answers/common/fonts-default.scss
@@ -39,6 +39,7 @@ $font-weight-light: 300;
   src: url('../../../assets/fonts/opensans-regular-webfont.woff') format("woff");
   font-weight: $font-weight-normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face
@@ -47,6 +48,7 @@ $font-weight-light: 300;
   src: url('../../../assets/fonts/opensans-bold-webfont.woff') format("woff");
   font-weight: $font-weight-bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face
@@ -55,5 +57,6 @@ $font-weight-light: 300;
   src: url('../../../assets/fonts/opensans-semibold-webfont.woff') format("woff");
   font-weight: $font-weight-semibold;
   font-style: normal;
+  font-display: swap;
 }
 

--- a/static/scss/fonts.scss
+++ b/static/scss/fonts.scss
@@ -46,6 +46,7 @@ $font-weight-light: 300;
   src: url('../assets/fonts/opensans-regular-webfont.woff') format("woff");
   font-weight: $font-weight-normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face
@@ -54,6 +55,7 @@ $font-weight-light: 300;
   src: url('../assets/fonts/opensans-bold-webfont.woff') format("woff");
   font-weight: $font-weight-bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face
@@ -62,5 +64,6 @@ $font-weight-light: 300;
   src: url('../assets/fonts/opensans-semibold-webfont.woff') format("woff");
   font-weight: $font-weight-semibold;
   font-style: normal;
+  font-display: swap;
 }
 


### PR DESCRIPTION
dns-prefetching sitescdn, the to perfrom a dns lookup if the browser
has idle time, in theory should only help page speed (outside of
it adding one line of code to the html). Specifying font-display:
swap gives tells the browser it is allowed to use quickly use a
fallback font while loading in a font, and that it has infinite
time to swap in higher priority fonts.

J=SLAP-658
TEST=manual

Used testcafe to run 200 iterations of the page with dns-prefetch
and without dns-prefetch for sitescdn, there was little to no
difference (both averaged around ~800ms startTime for the
yext.answers.verticalQueryResponseRendered performance mark).

Added font-display: swap, and tested that I could still add custom woff
files and specify those are the font.