### PR TITLE
Collapsible Filters SCSS

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -25,6 +25,9 @@
   --hh-universal-section-title-text-color: var(--yxt-color-text-primary);
   --hh-universal-section-title-background: var(--yxt-color-background-highlight);
   --hh-universal-section-title-icon: var(--yxt-color-brand-primary);
+  --hh-nav-wrapper-height: 113px;
+  --hh-view-results-button-height: 40px;
+  --hh-view-results-button-padding-top: 4px;
 
   // common border variables
   --yxt-border-default: 1px solid var(--yxt-color-borders);

--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -49,3 +49,6 @@
 // HH files
 @import "../answers";
 
+// Styling for CollapsibleFilters
+@import "collapsible-filters/collapsible-filters.scss";
+

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -24,6 +24,9 @@
   --hh-universal-section-title-text-color: var(--yxt-color-text-primary);
   --hh-universal-section-title-background: var(--yxt-color-background-highlight);
   --hh-universal-section-title-icon: var(--yxt-color-brand-primary);
+  --hh-nav-wrapper-height: 113px;
+  --hh-view-results-button-height: 40px;
+  --hh-view-results-button-padding-top: 4px;
 
   // common border variables
   --yxt-border-default: 1px solid var(--yxt-color-borders);

--- a/static/scss/answers/collapsible-filters/base.scss
+++ b/static/scss/answers/collapsible-filters/base.scss
@@ -1,0 +1,61 @@
+// Overrides for SDK filter components
+@import 'sdk-filter-overrides';
+
+// Styling for Theme components
+@import 'filter-panel-toggle';
+@import 'view-results-button';
+
+.CollapsibleFilters-inactive {
+  display: none;
+}
+
+.Answers-resultsHeader {
+  position: sticky;
+  top: var(--hh-nav-wrapper-height);
+  background: var(--hh-answers-background-color);
+  border-bottom: var(--yxt-border-default);
+  order: 1;
+}
+
+.Answers-filtersWrapper {
+  order: 2;
+}
+
+.Answers-results {
+  order: 3;
+}
+
+.Answers-filterPanelToggle {
+  margin-left: auto;
+  margin-right: 14px;
+}
+
+.Answers-viewResultsButton {
+  position: fixed;
+  width: calc(50% - 16px);
+  bottom: 0;
+  z-index: 100;
+  background-color: var(--hh-answers-background-color);
+  padding: 0px 8px var(--hh-view-results-button-padding-top);
+  left: 0;
+
+  @media (max-width: $container-tablet-base) {
+    width: 100%;
+  }
+}
+
+.Answers-filtersWrapper {
+  padding-left: 16px;
+  padding-right: 16px;
+
+  @include bplte(xs) {
+    margin-bottom: calc(var(--hh-view-results-button-height) + var(--hh-view-results-button-padding-top));
+  }
+}
+
+input[type="radio"] {
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(118, 118, 118);
+  border-radius: 50%;
+}

--- a/static/scss/answers/collapsible-filters/collapsible-filters.scss
+++ b/static/scss/answers/collapsible-filters/collapsible-filters.scss
@@ -1,0 +1,36 @@
+$collapsible-filters-hover-color: #0c5ecb !default;
+
+.CollapsibleFilters {
+  &.AnswersVerticalMap {
+    @import "base.scss";
+
+    @media (min-width: $container-tablet-base) {
+      .Answers-resultsHeader {
+        top: 0;
+      }
+    }
+  }
+
+  &.AnswersVerticalStandard,
+  &.AnswersVerticalGrid {
+    @media (max-width: $container-tablet-base) {
+      // Styling for the collapsible filters panel, and the applied filters header
+      @import "base.scss";
+
+      .Answers-resultsWrapper {
+        padding-top: 0;
+      }
+
+      .yxt-SpellCheck {
+        padding-top: calc(var(--yxt-base-spacing) * 2);
+      }
+    }
+
+    @media (min-width: $container-tablet-base) {
+      .Answers-filterPanelToggle,
+      .Answers-viewResultsButton {
+        display: none;
+      }
+    }
+  }
+}

--- a/static/scss/answers/collapsible-filters/filter-panel-toggle.scss
+++ b/static/scss/answers/collapsible-filters/filter-panel-toggle.scss
@@ -1,0 +1,11 @@
+.yxt-FilterPanelToggle {
+  color: var(--yxt-color-brand-primary);
+  font-size: 14px;
+
+  cursor: pointer;
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+    color: $collapsible-filters-hover-color;
+  }
+}

--- a/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
+++ b/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
@@ -1,0 +1,94 @@
+.yxt-FilterOptions {
+  &-fieldSet {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  &-showToggle {
+    margin-bottom: 2px;
+    margin-top: 2px;
+  }
+
+  &-optionLabel::before {
+    background: white;
+  }
+
+  &-radioButtonInput {
+    margin-right: 10px;
+  }
+
+  &-radioButtonInput:focus {
+    outline: none;
+  }
+
+  &-options {
+    margin-top: 4px;
+    margin-bottom: 4px;
+    padding-left: 4px;
+  }
+
+  &-option {
+    margin-top: 4px;
+  }
+}
+
+@media (max-width: $container-tablet-base) {
+  .yxt-SortOptions-option,
+  .yxt-FilterOptions-option {
+    margin: 8px 0px;
+  }
+}
+
+.yxt-SortOptions {
+  &-container {
+    padding-left: 4px;
+  }
+
+  &-fieldSet {
+    margin: 0;
+  }
+
+  &-option {
+    align-items: center;
+    margin-top: 4px;
+    margin-bottom: 0px;
+  }
+
+  &-options {
+    margin-top: 8px;
+    margin-bottom: 0px;
+  }
+
+  &-optionLabel {
+    margin-left: 10px;
+  }
+}
+
+.yxt-Facets-container {
+  width: 100%;
+  padding: 0;
+}
+
+.yxt-FilterBox {
+  &-titleContainer {
+    display: none;
+  }
+
+  &-container {
+    padding: 0;
+  }
+
+  &-filter {
+    padding-top: 8px;
+    margin-top: 0;
+    border-top: none;
+
+    @media (min-width: $container-tablet-base) {
+      margin-top: 4px;
+    }
+  }
+
+  &-apply {
+    margin: 0;
+  }
+}

--- a/static/scss/answers/collapsible-filters/view-results-button.scss
+++ b/static/scss/answers/collapsible-filters/view-results-button.scss
@@ -1,0 +1,33 @@
+.yxt-ViewResultsButton {
+  width: 100%;
+  font-family: var(--yxt-font-family);
+  font-size: var(--yxt-font-size-md);
+  line-height: var(--yxt-line-height-xs);
+  font-weight: var(--yxt-font-weight-semibold);
+  font-style: normal;
+  color: var(--yxt-color-brand-white);
+  border: 0;
+  border-radius: 3px;
+  background: var(--yxt-color-brand-primary);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  height: var(--hh-view-results-button-height);
+  cursor: pointer;
+
+  &:not(:disabled) {
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      background: padding-box $collapsible-filters-hover-color;
+    }
+
+    &:focus {
+      border: var(--yxt-button-focus-border-size) double $collapsible-filters-hover-color;
+    }
+  }
+
+  .yxt-VerticalResultsCount {
+    margin-bottom: 0;
+  }
+}

--- a/static/scss/answers/templates/vertical-grid.scss
+++ b/static/scss/answers/templates/vertical-grid.scss
@@ -59,8 +59,10 @@
 
     &-resultsWrapper
     {
+      display: flex;
       flex-grow: 1;
       padding-top: calc(var(--yxt-base-spacing) * 2);
+      flex-direction: column;
 
       .yxt-ResultsHeader {
         padding: 0 var(--yxt-results-header-spacing);
@@ -71,11 +73,6 @@
     {
       display: flex;
       flex-direction: column;
-
-      @include bpgte(lg)
-      {
-        flex-direction: row;
-      }
     }
 
     &-filtersWrapper {
@@ -115,6 +112,7 @@
       }
 
       @include bpgte(lg) {
+        position: absolute;
         margin-left: calc(-200px - 24px);
         margin-right: 24px;
         margin-bottom: 0;

--- a/static/scss/answers/templates/vertical-map.scss
+++ b/static/scss/answers/templates/vertical-map.scss
@@ -1,3 +1,22 @@
+.AnswersVerticalMap
+{
+  .yxt-Card
+  {
+    margin-bottom: 0;
+    border-left: none;
+    border-right: none;
+    border-top: none;
+  }
+
+  .yxt-AlternativeVerticals
+  {
+    margin-bottom: 0;
+    border-left: none;
+    border-right: none;
+    border-top: none;
+  }
+}
+
 .AnswersVerticalMap .Answers
 {
   &-resultsWrapper
@@ -22,6 +41,12 @@
   {
     padding-top: 0;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+
+    @include bpgte(sm) {
+      max-height: calc(100vh - var(--hh-nav-wrapper-height));
+    }
 
     &--withFilters
     {
@@ -44,7 +69,7 @@
     @include bpgte(sm)
     {
       width: 50%;
-      height: 950px;
+      min-height: 950px;
       overflow-y: auto;
     }
   }
@@ -67,8 +92,8 @@
   &-map
   {
     width: 50%;
-    height: 100%;
     min-height: 950px;
+    border-left: var(--yxt-border-default);
 
     @include bplte(xs)
     {

--- a/static/scss/answers/templates/vertical-standard.scss
+++ b/static/scss/answers/templates/vertical-standard.scss
@@ -6,8 +6,10 @@
 
   &-resultsWrapper
   {
+    display: flex;
     flex-grow: 1;
     padding-top: calc(var(--yxt-base-spacing) * 2);
+    flex-direction: column;
 
     .yxt-ResultsHeader {
       padding: 0 var(--yxt-results-header-spacing);
@@ -18,11 +20,6 @@
   {
     display: flex;
     flex-direction: column;
-
-    @include bpgte(lg)
-    {
-      flex-direction: row;
-    }
   }
 
   &-filtersWrapper {
@@ -62,6 +59,7 @@
     }
 
     @include bpgte(lg) {
+      position: absolute;
       margin-left: calc(-200px - 24px);
       margin-right: 24px;
       margin-bottom: 0;

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -45,6 +45,7 @@
     border-bottom: 1px solid #dcdcdc;
     background-color: var(--hh-answers-background-color);
     width: 100%;
+    height: var(--hh-nav-wrapper-height);
     padding-top: var(--yxt-base-spacing);
     z-index: 99;
   }


### PR DESCRIPTION
This PR contains the styling required for collapsible filters.
This includes
* styling for the ViewResultsButton and FilterPanelToggle
components
* sticky results header (always on vertical-map, and sticky on mobile
for vertical-grid and vertical-standard),
* styling overrides for SDK filter styling when using CollapsibleFilters
* removal of teeth gap from cards on vertical map
* removal of border and margin-bottom from noresults on vertical map

Tested that I can add a vertical-map, vertical-standard, and vertical-grid with factory settings
tested without CollapsibleFilters scss class
* with facets
* without facets

tested with CollapsibleFilters scss class
* with facets and collapsible filters
* without facets

also check adding spell check and qa submission (spell check looks funny but it looked funny before as well)