### PR TITLE
Open status locale fix

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -412,7 +412,7 @@ export default class Formatters {
    * @param {String} locale The locale for the time string
    * @param {boolean} isTwentyFourHourClock Use 24 hour vs 12 hour formatting for time string
    */
-  static openStatus(profile, locale = 'en-US', isTwentyFourHourClock = false) {
+  static openStatus(profile, locale, isTwentyFourHourClock = false) {
     if (!profile.hours) {
       return '';
     }


### PR DESCRIPTION
Remove the 'en-US' locale default so that the openStaus formatter falls back on the document locale

When `_getDocumentLocale()` was added, it was never being used inside the open status formatter because of the 'en-US' locale default. This PR changes openStatus to fallback on `_getDocumentLocale()` which lets it support multi-lang sites.

J=None
TEST=manual

View an internationalized jambo site and confirm the English, Spanish, and French translations appear depending on the document locale.