### PR TITLE
Expose --yxt-filter-options-options-max-height css var

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -40,6 +40,7 @@
   --yxt-searchbar-button-background-color-hover: white;
   --yxt-searchbar-button-background-color-active: white;
   --yxt-searchbar-button-text-color-hover: #0f70f0;
+  --yxt-filter-options-options-max-height: none;
 }
 
 // breakpoint variables for use in media queries within the theme styling

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -39,6 +39,7 @@
   --yxt-searchbar-button-background-color-hover: white;
   --yxt-searchbar-button-background-color-active: white;
   --yxt-searchbar-button-text-color-hover: #0f70f0;
+  --yxt-filter-options-options-max-height: none;
 }
 
 // breakpoint variables for use in media queries within the theme styling


### PR DESCRIPTION
This css variable was added to the sdk, but not exposed in the
hitchhiker theme, so anybody who wanted to use it would have
to manually type it out.

TEST=manual

Tested that if I add this variable to answers-variables.scss
in SGS, and change it to 200px, I will see inner scroll for long facets.