### PR TITLE
Add key param to the openStatus formatter

### DIFF
--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -391,15 +391,16 @@ export default class Formatters {
    * Returns a string, a formatted representation of the open hours status
    * for the given profile.
    * @param {Object} profile The profile information of the entity
-   * @param {String} locale The locale for the time string
+   * @param {String} key Indicates which profile property to use for hours
    * @param {boolean} isTwentyFourHourClock Use 24 hour vs 12 hour formatting for time string
+   * @param {String} locale The locale for the time string
    */
-  static openStatus(profile, locale = 'en-US', isTwentyFourHourClock = false) {
-    if (!profile.hours) {
+  static openStatus(profile, key = 'hours', isTwentyFourHourClock = false, locale = 'en-US') {
+    if (!profile[key]) {
       return '';
     }
 
-    const days = this._formatHoursForAnswers(profile.hours, profile.timeZoneUtcOffset);
+    const days = this._formatHoursForAnswers(profile[key], profile.timeZoneUtcOffset);
     if (days.length === 0) {
       return '';
     }


### PR DESCRIPTION
Add key param to the openStatus formatter

Add the key param as the second parameter. Move locale from the second param to the last param. Do this to make sure that you can specify isTwentyFourHours without needing to specify the locale, and the hours filed without needing to call out isTwentyFourHours + locale.

The openStatus formatter method signature was approved by Rose.

J=SLAP-630
TEST=manual

Run a jambo build and confirm that the formatter works when we only supply the first profile param. Supply hours data on a different key in the profile and point the formatter to that and confirm it works
