### PR TITLE
vertical-map css tweaks (from Collapsible Filters)

### DIFF
--- a/static/scss/answers/templates/vertical-map.scss
+++ b/static/scss/answers/templates/vertical-map.scss
@@ -1,13 +1,6 @@
 .AnswersVerticalMap
 {
-  .yxt-Card
-  {
-    margin-bottom: 0;
-    border-left: none;
-    border-right: none;
-    border-top: none;
-  }
-
+  .yxt-Card,
   .yxt-AlternativeVerticals
   {
     margin-bottom: 0;


### PR DESCRIPTION
This commit adds some styling tweaks to vertical-map
that were identified during collapsible filters qa.
Namely it removes the teeth-gap between cards on vertical map,
and also removes the extra border around no results

TEST=manual

test that things look the way Rose + Jeremy agreed on