### PR TITLE
Fix radio button styling on ios safari

### DIFF
--- a/static/scss/answers/common/base.scss
+++ b/static/scss/answers/common/base.scss
@@ -208,3 +208,13 @@ button
   background: none;
   cursor: pointer;
 }
+
+// Our css reset makes radio buttons look strange on ios safari
+@include bplte(xs) {
+  input[type="radio"] {
+    border-width: 1px;
+    border-style: solid;
+    border-color: rgb(118, 118, 118);
+    border-radius: 50%;
+  }
+}


### PR DESCRIPTION
Our css reset is too prescriptive on ios safari,
and makes radio buttons look like weird squares.

This commit adds some styling on mobile for that case.
It is not an issue on android chrome, for whatever reason.
It looks like border css has no affect on android chrome.

TEST=manual

test that on browserstack and my iphone, the radio buttons
dont look like weird borderless squares