### PR TITLE
Support localized iframe experiences

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -4,6 +4,7 @@ export function generateIFrame(domain, queryParam, urlParam) {
   var isLocalHost = window.location.host.split(':')[0] === 'localhost';
   var containerEl = document.querySelector('#answers-container');
   var iframe = document.createElement('iframe');
+  var pathToIndex = containerEl.dataset.path;
   iframe.allow = 'geolocation';
 
   domain = domain || '';
@@ -14,14 +15,18 @@ export function generateIFrame(domain, queryParam, urlParam) {
     var paramString = window.location.search;
     paramString = paramString.substr(1, paramString.length);
 
+    // Decode ASCII forward slash to avod repeat encodings on page refreshes
+    paramString = paramString.replace("%2F", "/");
+
     // Parse the params out of the URL
     var params = paramString.split('&'),
                  verticalUrl;
     var referrerPageUrl = document.referrer.split('?')[0].split('#')[0];
 
-    // Default for localhost is index.html, empty o/w
-    if (isLocalHost) {
-      verticalUrl = 'index.html';
+    if (pathToIndex) {
+      verticalUrl = pathToIndex;
+    } else if (isLocalHost) {
+      verticalUrl = 'index.html'; // Default for localhost is index.html, empty o/w
     }
 
     // Don't include the verticalUrl or raw referrerPageUrl in the frame src


### PR DESCRIPTION
Support a data-path attribute on the div with `id="answers-container"` to support localized iframe experiences

The data-path should be a path to the index file of a localized answers site. For example, if the French experience is located in the "fr" folder of "public" or "desktop", the data-path should be "fr/index.html". If a Spanish site was built with a URL override such as `"{pageName}.{locale}.{pageExt}"`, the data-path should be "index.es.html". If data-path attribute is not specified, the iframe behavior is the same and will load the default experience.

J=SLAP-722
TEST=manual

Run an internationalized jambo site with an iframe test and confirm the data path works for "fr/index.html" and "index.es.html". Test multiple refreshes to confirm the iframe never breaks.