### PR TITLE
Remove results header spacing when results not loaded

### DIFF
--- a/static/scss/answers/collapsible-filters/collapsible-filters.scss
+++ b/static/scss/answers/collapsible-filters/collapsible-filters.scss
@@ -3,6 +3,7 @@
 
 @mixin CollapsibleFilters {
   @include CollapsibleFiltersOverrides;
+
   .Answers {
     &-sortOptions {
       padding: 0;

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -73,7 +73,14 @@
 
   &-resultsHeader {
     display: flex;
-    padding: 8px 0px 4px 8px;
+    padding-left: 8px;
+
+    .yxt-AppliedFilters,
+    .yxt-VerticalResultsCount,
+    .Hitchhiker-FilterLink {
+      margin-top: 8px;
+      margin-bottom: 4px;
+    }
   }
 
   &-verticalResultsCount {


### PR DESCRIPTION
This commit moves the spacing on the results header from Answers-resultsHeader
to the components inside of it, so that the space doesnt render when the results
haven't rendered yet.

TEST=manual

test that a local theme page,
after including the needed sdk change,
does not have the extra space on a page
that hasn't run a search yet