### PR TITLE
Fix resultsHeader and filters order

### DIFF
--- a/templates/vertical-grid/page.html.hbs
+++ b/templates/vertical-grid/page.html.hbs
@@ -23,17 +23,17 @@
       </div>
     </div>
     <div class="Answers-container Answers-resultsWrapper Hitchhiker-3-columns">
+      <div class="Answers-resultsHeader js-answersResultsHeader">
+        {{> templates/vertical-grid/markup/verticalresultscount }}
+        {{> templates/vertical-grid/markup/appliedfilters }}
+        {{!-- {{> templates/vertical-grid/collapsible-filters/markup }} --}}
+      </div>
       <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
       {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
         {{!-- {{> templates/vertical-grid/markup/sortoptions }} --}}
         {{!-- {{> templates/vertical-grid/markup/filterbox }} --}}
         {{!-- {{> templates/vertical-grid/markup/facets }} --}}
       {{!-- </div> --}}
-      <div class="Answers-resultsHeader js-answersResultsHeader">
-        {{> templates/vertical-grid/markup/verticalresultscount }}
-        {{> templates/vertical-grid/markup/appliedfilters }}
-        {{!-- {{> templates/vertical-grid/collapsible-filters/markup }} --}}
-      </div>
       <div class="Answers-results js-answersResults">
         {{> templates/vertical-grid/markup/spellcheck }}
         {{> templates/vertical-grid/markup/verticalresults }}

--- a/templates/vertical-standard/page.html.hbs
+++ b/templates/vertical-standard/page.html.hbs
@@ -23,17 +23,17 @@
       </div>
     </div>
     <div class="Answers-container Answers-resultsWrapper">
+      <div class="Answers-resultsHeader js-answersResultsHeader">
+        {{> templates/vertical-standard/markup/verticalresultscount }}
+        {{> templates/vertical-standard/markup/appliedfilters }}
+        {{!-- {{> templates/vertical-standard/collapsible-filters/markup }} --}}
+      </div>
       <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
       {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
         {{!-- {{> templates/vertical-standard/markup/sortoptions }} --}}
         {{!-- {{> templates/vertical-standard/markup/filterbox }} --}}
         {{!-- {{> templates/vertical-standard/markup/facets }} --}}
       {{!-- </div> --}}
-      <div class="Answers-resultsHeader js-answersResultsHeader">
-        {{> templates/vertical-standard/markup/verticalresultscount }}
-        {{> templates/vertical-standard/markup/appliedfilters }}
-        {{!-- {{> templates/vertical-standard/collapsible-filters/markup }} --}}
-      </div>
       <div class="Answers-results js-answersResults">
         {{> templates/vertical-standard/markup/spellcheck }}
         {{> templates/vertical-standard/markup/verticalresults }}


### PR DESCRIPTION
The order css property was removed in #344,
which was being used to visually reorder elements. That PR only
updated the vertical-map page.html.hbs, and not the other 2
page templates (it should have).

TEST=manual

See that without this change, on vertical-standard/grid, the results
header is not sticky with CollapsibleFilters on mobile.
See that after swapping the order, the results header is correctly
sticky on mobile with the CollapsibleFilters css class.