### PR TITLE
Add truthy check for iconUrl in cards before adding prefix

### DIFF
--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -97,7 +97,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -97,7 +97,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -98,7 +98,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -98,7 +98,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -177,7 +177,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -177,7 +177,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>


### PR DESCRIPTION
As-is, there is an issue where the `relativePath` is being prepended to the `iconUrl` in cards even if `iconUrl` is not specified. Updating to only add relative path prefix if iconUrl is present. As part of this, I checked the other relative path prefix additions in this PR (https://github.com/yext/answers-hitchhiker-theme/pull/329) to ensure that they are null checking before adding the relative path prefix.

TEST=manual
J=none

Build jambo site locally, without an iconUrl specified in the events-standard card before change. See icon not present; inspect DOM and see "iconUrl": "/". Build again after change, see icon present, inspect DOM and see "iconUrl": "".

