### PR TITLE
Add null check for verticalKey before adding navigation entry

### DIFF
--- a/templates/universal-standard/script/navigation.hbs
+++ b/templates/universal-standard/script/navigation.hbs
@@ -2,6 +2,7 @@ ANSWERS.addComponent('Navigation', Object.assign({}, {
 container: '.js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
+{{#if (any verticalKey (lookup verticalsToConfig 'Universal'))}}
   {
     verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
@@ -22,6 +23,7 @@ verticalPages: [
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}
+{{/if}}
 {{/each}}
 ]
 }, {{{ json componentSettings.Navigation }}}));

--- a/templates/vertical-grid/script/navigation.hbs
+++ b/templates/vertical-grid/script/navigation.hbs
@@ -2,6 +2,7 @@ ANSWERS.addComponent('Navigation', Object.assign({}, {
 container: '.js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
+{{#if (any verticalKey (lookup verticalsToConfig 'Universal'))}}
   {
     verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
@@ -22,6 +23,7 @@ verticalPages: [
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}
+{{/if}}
 {{/each}}
 ]
 }, {{{ json componentSettings.Navigation }}}));

--- a/templates/vertical-map/script/navigation.hbs
+++ b/templates/vertical-map/script/navigation.hbs
@@ -2,6 +2,7 @@ ANSWERS.addComponent('Navigation', Object.assign({}, {
 container: '#js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
+{{#if (any verticalKey (lookup verticalsToConfig 'Universal'))}}
   {
     verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
@@ -22,6 +23,7 @@ verticalPages: [
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}
+{{/if}}
 {{/each}}
 ]
 }, {{{ json componentSettings.Navigation }}}));

--- a/templates/vertical-standard/script/navigation.hbs
+++ b/templates/vertical-standard/script/navigation.hbs
@@ -2,6 +2,7 @@ ANSWERS.addComponent('Navigation', Object.assign({}, {
 container: '.js-answersNavigation',
 verticalPages: [
 {{#each verticalConfigs}}
+{{#if (any verticalKey (lookup verticalsToConfig 'Universal'))}}
   {
     verticalKey: '{{{verticalKey}}}',
     {{#each ../excludedVerticals}}{{#ifeq this ../verticalKey}}hideInNavigation: true,{{/ifeq}}{{/each}}
@@ -22,6 +23,7 @@ verticalPages: [
       {{/with}}
     {{/if}}
   }{{#unless @last}},{{/unless}}
+{{/if}}
 {{/each}}
 ]
 }, {{{ json componentSettings.Navigation }}}));


### PR DESCRIPTION
Add a null check in Navigation to support pages without vTC. This adds support for a page that only has a SearchBar component (most likely with a redirectUrl) for the overlay. 

(As a visual: )
<img width="463" alt="Screen Shot 2020-10-14 at 10 46 25 PM" src="https://user-images.githubusercontent.com/39104038/96070926-203d9e80-0e6f-11eb-9b91-40449c0c1b82.png">

This change requires the Jambo handlebars helper "any" in this PR: https://github.com/yext/jambo/pull/136

TEST=manual

Tested creating a page with `"componentSettings":  {"SearchBar" : "redirectUrl":"answers.yext.com"} and no vTC. Confirm Jambo build succeeded and page rendered as expected.