### PR TITLE
Update iFrame src url format

### DIFF
--- a/static/js/iframe-overlay/controllers/overlay.js
+++ b/static/js/iframe-overlay/controllers/overlay.js
@@ -58,7 +58,7 @@ export default class Overlay {
   _getExperienceUrl() {
     const referrerPageUrl = window.location.href.split('?')[0].split('#')[0];
     const referrerPageUrlParam = '?referrerPageUrl=' + referrerPageUrl;
-    return new InjectedData().getDomain()
+    return new InjectedData().getDomain() + '/'
       + this.config.experiencePath
       + referrerPageUrlParam;
   }


### PR DESCRIPTION
Add missing '/' between iframe domain and path. Add referrerPageUrl param to iframe's src attribute. We do not support query params in the experiencePath config option, so we do not need to check if any other query params currently exist. Per the PM's, the referrerPageUrl should be the current page, not the referrer of this page.

TEST=manual

Run locally, inspect iframe src using Chrome's devtools. See referrerPageUrl passed as a URL param.