### PR TITLE
Remove iframe flicker

### DIFF
--- a/static/js/iframe-overlay/controllers/iframeobserver.js
+++ b/static/js/iframe-overlay/controllers/iframeobserver.js
@@ -30,6 +30,7 @@ export default class IFrameObserver {
       sizeHeight: false,
       autoResize: false,
       scrolling: true,
+      heightCalculationMethod: 'lowestElement',
       onInit: () => {
         this.mediator.onIFrameInteraction(InteractionTypes.INIT);
       },


### PR DESCRIPTION
iFrameResizer has a known flickering issue with some height calculation methods (including the default). Updating to use 'lowestElement' which is flicker-free. Docs: http://davidjbradshaw.github.io/iframe-resizer/

TEST=manual,visual