### PR TITLE
Add overlay suggestions partial by default to universal

### DIFF
--- a/layouts/overlay-suggestions.hbs
+++ b/layouts/overlay-suggestions.hbs
@@ -1,0 +1,4 @@
+<div class="Answers-overlaySuggestions js-Answers-overlaySuggestions hidden">
+  {{> overlay/markup/prompt-buttons }}
+  {{!-- Any other custom HTML could go here. --}}
+</div>

--- a/templates/universal-standard/page.html.hbs
+++ b/templates/universal-standard/page.html.hbs
@@ -18,6 +18,7 @@
           {{> templates/universal-standard/markup/navigation }}
         </div>
       </div>
+      {{> layouts/overlay-suggestions }}
       <div class="Answers-container Answers-resultsWrapper">
         {{> templates/universal-standard/markup/spellcheck }}
         {{> templates/universal-standard/markup/directanswer }}


### PR DESCRIPTION
This partial is harmless when the page is not inside the Overlay (no config from the parent frame  Iwill be injected unless the Overlay script is on it). Per Rose, this should be here by default, HH's can remove if they don't want it there -- but like I said, it doesn't hurt anything.

TEST=manual

Add new page using jambo page command, see partial is present. Use this path for overlay and see provided prompts appear.