### PR TITLE
theme: add describe function for custom commands

### DIFF
--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -47,7 +47,7 @@ class CardCreator {
    *                   all available cards
    */
   describe() {
-    const cardPaths = this._getCards();
+    const cardPaths = this._getCardPaths();
     return {
       displayName: 'Add Card',
       params: {
@@ -67,9 +67,9 @@ class CardCreator {
   }
 
   /**
-   * @returns {Array<string>} the names of the available cards
+   * @returns {Array<string>} the paths of the available cards
    */
-  _getCards() {
+  _getCardPaths() {
     if (!this.defaultTheme || !this.themesDir) {
       return [];
     }

--- a/commands/directanswercardcreator.js
+++ b/commands/directanswercardcreator.js
@@ -47,7 +47,7 @@ class DirectAnswerCardCreator {
    *                   all available direct answer cards
    */
   describe() {
-    const directAnswerCardPaths = this._getDirectAnswerCards();
+    const directAnswerCardPaths = this._getDirectAnswerCardPaths();
     return {
       displayName: 'Add Direct Answer Card',
       params: {
@@ -67,9 +67,9 @@ class DirectAnswerCardCreator {
   }
 
   /**
-   * @returns {Array<string>} the names of the available direct answer cards
+   * @returns {Array<string>} the paths of the available direct answer cards
    */
-  _getDirectAnswerCards() {
+  _getDirectAnswerCardPaths() {
     if (!this.defaultTheme || !this.themesDir) {
       return [];
     }


### PR DESCRIPTION
Adds a `describe()` function for the card and directanswercard
custom commands in the HH theme.

J=SLAP-600
TEST=manual
Ran `jambo describe` and saw that the output for card and
directanswercard return the correct information.