### PR TITLE
Block multiple initializations

### DIFF
--- a/static/js/iframe-overlay/yextanswersoverlay.js
+++ b/static/js/iframe-overlay/yextanswersoverlay.js
@@ -14,6 +14,11 @@ export default class YextAnswersOverlay {
    * @param {Object} config
    */
   init(config) {
+    if (this._isInitialized()) {
+      console.warn('AnswersOverlay has already been initialized on this page, exiting.');
+      return;
+    }
+
     new ConfigValidator(config).validate()
     const parsedConfig = new OverlayConfig(config);
 
@@ -56,4 +61,6 @@ export default class YextAnswersOverlay {
   }
 }
 
-global.YextAnswersOverlay = new YextAnswersOverlay();
+if (!global.YextAnswersOverlay) {
+  global.YextAnswersOverlay = new YextAnswersOverlay();
+}


### PR DESCRIPTION
Don't allow the Overlay to be initialized twice on the same page, since this results in weird/buggy behavior.

TEST=manual

Test with overlay script once (no change), adding the script tag twice but only initializing once (works), calling init multiple times (works).