### PR TITLE
Add config option to control iframe background

### DIFF
--- a/static/js/iframe-overlay/constants.js
+++ b/static/js/iframe-overlay/constants.js
@@ -25,6 +25,5 @@ exports.AnimationStyling = {
   BOX_SHADOW_NONE: '0 3px 10px 0 rgba(0,0,0,0)',
   WIDTH_DESKTOP: '445px',
   WIDTH_MOBILE: 'calc(100% - 32px)',
-  HEIGHT_TALLER: 'calc(100% - 32px)',
-  BACKGROUND_COLOR_NORMAL: '#eeeff0',
+  HEIGHT_TALLER: 'calc(100% - 32px)'
 };

--- a/static/js/iframe-overlay/controllers/interactiondirector.js
+++ b/static/js/iframe-overlay/controllers/interactiondirector.js
@@ -21,7 +21,7 @@ export default class InteractionDirector {
     /**
      * @type {Expando}
      */
-    this.expando = new Expando();
+    this.expando = new Expando(iframeConfig.iframeBackground);
 
     /**
      * @type {boolean}

--- a/static/js/iframe-overlay/controllers/overlay.js
+++ b/static/js/iframe-overlay/controllers/overlay.js
@@ -32,7 +32,8 @@ export default class Overlay {
       button: this.config.button,
       panel: this.config.panel,
       prompts: this.config.prompts,
-      hideDefaultButton: this.config.hideDefaultButton
+      hideDefaultButton: this.config.hideDefaultButton,
+      iframeBackground: this.config.iframeBackground
     });
     this._attachObservers(mediator);
 

--- a/static/js/iframe-overlay/dom/expando.js
+++ b/static/js/iframe-overlay/dom/expando.js
@@ -4,7 +4,7 @@ import { ActionTypes, AnimationStyling, Selectors } from '../constants';
  * Expando is responsible for handling the resizing of the Overlay.
  */
 export default class Expando {
-  constructor() {
+  constructor(iframeBackground) {
     /**
      * @type {Element}
      */
@@ -24,6 +24,11 @@ export default class Expando {
      * @type {boolean}
      */
     this._isTaller = true;
+
+    /**
+     * @type {string}
+     */
+    this._iframeBackground = iframeBackground;
 
     /**
      * @type {function}
@@ -67,7 +72,7 @@ export default class Expando {
     this._isExpanded = false;
 
     this._iframeEl.scrolling = 'no';
-    this._iframeEl.style['background-color'] = 'transparent';
+    this._iframeEl.style['background'] = 'transparent';
     this._iframeEl.style['transition'] = `background-color ${AnimationStyling.FADE_TIMING}`;
     this._iframeEl.style['transition-delay'] = '0s';
 
@@ -93,7 +98,7 @@ export default class Expando {
     this._iframeEl.scrolling = 'yes';
     this._iframeEl.style['transition'] = `background-color ${AnimationStyling.FADE_TIMING}`;
     this._iframeEl.style['transition-delay'] = AnimationStyling.SIZE_TIMING;
-    this._iframeEl.style['background-color'] = AnimationStyling.BACKGROUND_COLOR_NORMAL;
+    this._iframeEl.style['background'] = this._iframeBackground;
 
     this._iframeWrapperEl.style['transition'] = `box-shadow ${AnimationStyling.SIZE_TIMING}`;
     this._iframeWrapperEl.style['transition-delay'] = AnimationStyling.SIZE_TIMING;

--- a/static/js/iframe-overlay/models/overlayconfig.js
+++ b/static/js/iframe-overlay/models/overlayconfig.js
@@ -11,6 +11,12 @@ export default class OverlayConfig {
     this.experiencePath = config.experiencePath || 'index.html';
 
     /**
+     * The CSS rule for the background of the iframe
+     * @type {String}
+     */
+    this.iframeBackground = config.background || '#EEEFF0';
+
+    /**
      * List of prompts, each prompt has the following properties:
      * {
      *   text: "View all banks",     // Required


### PR DESCRIPTION
The iframe background color needs to be configurable. A basic integration could include customizing this color. A more advanced user may want to add a repeating background pattern. This is being applied to the iframe element in the corporate page's DOM, so we can't use the CSS variables in the theme.

TEST=manual

Add custom background color, see iframe background color update.