### PR TITLE
universalsectiontemplates: Add click analytics to view all link

### DIFF
--- a/universalsectiontemplates/grid-three-columns.hbs
+++ b/universalsectiontemplates/grid-three-columns.hbs
@@ -57,7 +57,11 @@
 {{#*inline "viewMore"}}
   {{#if _config.isUniversal}}
     <div class="HitchhikerResultsGridThreeColumns-viewMore">
-      <a class="HitchhikerResultsGridThreeColumns-viewMoreLink" href="{{ verticalURL }}">
+      <a class="HitchhikerResultsGridThreeColumns-viewMoreLink" 
+         href="{{ verticalURL }}"
+         data-eventtype="VERTICAL_VIEW_ALL"
+         data-eventoptions='{{eventOptions}}'
+      >
         <div class="HitchhikerResultsGridThreeColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
         <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
       </a>

--- a/universalsectiontemplates/grid-two-columns.hbs
+++ b/universalsectiontemplates/grid-two-columns.hbs
@@ -57,7 +57,11 @@
 {{#*inline "viewMore"}}
   {{#if _config.isUniversal}}
     <div class="HitchhikerResultsGridTwoColumns-viewMore">
-      <a class="HitchhikerResultsGridTwoColumns-viewMoreLink" href="{{ verticalURL }}">
+      <a class="HitchhikerResultsGridTwoColumns-viewMoreLink" 
+         href="{{ verticalURL }}"
+         data-eventtype="VERTICAL_VIEW_ALL"
+         data-eventoptions='{{eventOptions}}'
+      >
         <div class="HitchhikerResultsGridTwoColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
         <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
       </a>

--- a/universalsectiontemplates/standard.hbs
+++ b/universalsectiontemplates/standard.hbs
@@ -57,7 +57,11 @@
 {{#*inline "viewMore"}}
   {{#if _config.isUniversal}}
     <div class="HitchhikerResultsStandard-viewMore">
-      <a class="HitchhikerResultsStandard-viewMoreLink" href="{{ verticalURL }}">
+      <a class="HitchhikerResultsStandard-viewMoreLink"
+         href="{{ verticalURL }}"
+         data-eventtype="VERTICAL_VIEW_ALL"
+         data-eventoptions='{{eventOptions}}'
+      >
         <div class="HitchhikerResultsStandard-viewMoreLabel">{{_config.viewMoreLabel}}</div>
         <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
       </a>


### PR DESCRIPTION
Previously, the Yext Answers analytics were omitted for the View All
links. Add the event information so Yext Answers analytics are run again
for clicks on the View All.

J=SLAP-720
TEST=manual

Test on standard, grid-two-columns, grid-three-columns: Click on a View
More on a vertical section in the Universal Results pages fires an event
in the Network tab for analytics with the event options.

Also verify in DOM that the data-eventoptions and data-eventtype
attributes exist on the view all link <a> tag