### PR TITLE
Use relativePath for bundle.css

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -105,7 +105,7 @@
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>
     <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.css">
-    <link rel="stylesheet" type="text/css" href="bundle.css">
+    <link rel="stylesheet" type="text/css" href="{{relativePath}}/bundle.css">
 	</head>
   <body>
     {{#if global_config.googleTagManagerId}}


### PR DESCRIPTION
This change was lost in a rebase, since bundle.css was moved
from core.hbs into html.hbs .

J=SLAP-773
TEST=manual

found while upgrading the diageo i18n repo, tested that
the es/* pages have styling again