### PR TITLE
Gruntfile.js: watch all files except output and node_modules

### DIFF
--- a/static/Gruntfile.js
+++ b/static/Gruntfile.js
@@ -1,22 +1,17 @@
 const webpackConfig = require('./webpack-config');
 const { exec } = require("child_process");
+const jamboConfig = require('./jambo.json');
 
-module.exports = function(grunt) {
+const outputDir = jamboConfig.dirs.output;
+
+module.exports = function (grunt) {
   grunt.initConfig({
     webpack: {
       myConfig: webpackConfig
     },
-      watch: {
-        all: {
-          files: [
-            'cards/**/*.*',
-            'config/**/*.*',
-            'pages/**/*.*',
-            'static/**/*.*',
-            'partials/**/*.*',
-            'layouts/**/*.*',
-            'jambo.json'
-        ],
+    watch: {
+      all: {
+        files: ['**', '!**/node_modules/**', `!${outputDir}/**`],
         tasks: ['jambobuild', 'webpack',],
         options: {
           spawn: false,


### PR DESCRIPTION
If you change your jambo.json output dir, you will still have
to restart your preview (this has always been the case). But you
won't have to update your gruntfile

J=SLAP-775
TEST=manual

test that watching ** will watch all files

test that if I don't include the !node_modules/** line it will watch
node modules

checked that editing files in .git or any files that begin with a period in their name
are not watched (tried .bob, .bob.txt, .gitignore, and .git/description)