### PR TITLE
verticaltemplates: don't show border line when not present

### DIFF
--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -136,3 +136,7 @@
   }
 }
 
+@mixin vertical_filter_group_bottom_border {
+  border-bottom: var(--yxt-border-default);
+  padding-bottom: 12px;
+}

--- a/static/scss/answers/templates/vertical-grid.scss
+++ b/static/scss/answers/templates/vertical-grid.scss
@@ -98,8 +98,7 @@
       .Answers-filterBox {
         &:not(:last-child) {
           .yxt-FilterBox-container {
-            border-bottom: var(--yxt-border-default);
-            padding-bottom: 12px;
+            @include vertical_filter_group_bottom_border;
           }
         }
       }
@@ -107,11 +106,9 @@
       .Answers-sortOptions {
         &:not(:last-child) {
           .yxt-SortOptions-fieldSet {
-            border-bottom: var(--yxt-border-default);
-            padding-bottom: 12px;
+            @include vertical_filter_group_bottom_border;
           }
         }
-
       }
 
       .yxt-SortOptions-fieldSet {

--- a/static/scss/answers/templates/vertical-standard.scss
+++ b/static/scss/answers/templates/vertical-standard.scss
@@ -45,8 +45,7 @@
     .Answers-filterBox {
       &:not(:last-child) {
         .yxt-FilterBox-container {
-          border-bottom: var(--yxt-border-default);
-          padding-bottom: 12px;
+          @include vertical_filter_group_bottom_border;
         }
       }
     }
@@ -54,11 +53,9 @@
     .Answers-sortOptions {
       &:not(:last-child) {
         .yxt-SortOptions-fieldSet {
-          border-bottom: var(--yxt-border-default);
-          padding-bottom: 12px;
+          @include vertical_filter_group_bottom_border;
         }
       }
-
     }
 
     .yxt-SortOptions-fieldSet {


### PR DESCRIPTION
Before, we would see the border-bottom of the sort options container
when the sort options were not present. Turns out this was more general.
Any component that was not the last component in the filtersWrapper div
would have a border bottom show up if it were not present.

To fix this, we move the border-bottom (and thus bottom padding styling
to the inner div), which only shows up when the component is present).

J=SLAP-753
TEST=manual

Test on a local Jambo site.

Test on a vertical grid and vertical standard
(note this border code  was not in the vertical map layout code).

Make sure you can hit a no results and see no borders on the sort
options and facets components.

Make sure you see borders between the components when the results are
present, though.