### PR TITLE
Default locale_config.json fix

### DIFF
--- a/locale_config.json
+++ b/locale_config.json
@@ -9,7 +9,7 @@
     }
   },
   "urlFormat": {
-    "baseLocale": "{pageName}.{pageExt}",
-    "default": "{locale}/{pageName}.{pageExt}"
+    "baseLocale": "{locale}/{pageName}.{pageExt}",
+    "default": "{pageName}.{pageExt}"
   }
 }


### PR DESCRIPTION
Update the locale_config template to match v1.7 of Jambo

We swapped the URL format config options in Jambo which makes these defaults incorrect. Swap them here to match Jambo.

J=None
TEST=Manual

Build the Yanswers site with the locale config arranged like this. Observe the German site available from /de, and the English site available from the root index