### PR TITLE
collapsible-filters: center View All Results button

### DIFF
--- a/static/scss/answers/collapsible-filters/collapsible-filters.scss
+++ b/static/scss/answers/collapsible-filters/collapsible-filters.scss
@@ -21,10 +21,9 @@
 
     &-viewResultsButton {
       position: fixed;
-      width: calc(50% - var(--yxt-base-spacing));
+      width: 50%;
       left: 0;
       bottom: 0;
-      margin-left: 2px;
       padding: 4px 8px;
       background-color: var(--hh-answers-background-color);
       z-index: $nav-wrapper-z-index;


### PR DESCRIPTION
Previously, the View All Results button for collapsible filters had more
spacing on the right hand side. Change the button width to be the same
width as the rest of the results container. Also remove an offsetting
margin.

J=SLAP-751
TEST=manual

Test that the View x Results button on a collapsible filter in a
vertical-grid vertical page is centered in the vertical results
container.