### PR TITLE
Set min-height on nav to help with loading state

### DIFF
--- a/static/scss/answers/overlay/base.scss
+++ b/static/scss/answers/overlay/base.scss
@@ -45,6 +45,7 @@
     }
 
     &-navWrapper {
+      min-height: 0px;
       padding-top: 0;
       background-color: transparent;
       margin-top: -26px;

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -44,6 +44,7 @@
     left: 0;
     border-bottom: 1px solid #dcdcdc;
     background-color: var(--hh-answers-background-color);
+    min-height: 113px;
     width: 100%;
     padding-top: var(--yxt-base-spacing);
     z-index: $nav-wrapper-z-index;


### PR DESCRIPTION
In the overlay, switching tabs loads a new page (as it does outside of the Overlay), however, the loading time is very noticeable. As part of an effort to minimize the visual impact, adding a min-height to navigation so that the border doesn't bounce down from the top of the screen when the SearchBar + Navigation components are injected.

TEST=manual,visual