### PR TITLE
Update validation rule to have correct logic

### DIFF
--- a/static/js/iframe-overlay/validation/configvalidator.js
+++ b/static/js/iframe-overlay/validation/configvalidator.js
@@ -42,8 +42,7 @@ export default class ConfigValidator {
    * Throws errors or prints warnings if a custom selector is configured and invalid
    */
   _validateCustomSelector() {
-    const isConfiguredCorrectly = this.config.hideDefaultButton && !this.config.customSelector;
-    if (!isConfiguredCorrectly) {
+    if (this.config.hideDefaultButton && !this.config.customSelector) {
       console.warn('If hideDefaultButton is true, we recommend adding a custom selector.');
     }
   }


### PR DESCRIPTION
Previously this warning would always print when `this.config.hideDefaultButton` was true. That isn't desirable behavior, updated to only print if both `this.config.hideDefaultButton` is true AND a custom selector is not specified.

TEST=manual

Run locally, trigger state by specifying only `hideDefaultButton`, see warning disappear if `customSelector` is specified.