### PR TITLE
Update button iframe config to match other refactor

### DIFF
--- a/static/js/iframe-overlay/button/button.html
+++ b/static/js/iframe-overlay/button/button.html
@@ -8,11 +8,11 @@
       onMessage: function (message) {
         const buttonEl = document.querySelector('.js-OverlayButton');
         switch (message.type) {
-          case 'overlayConfig':
+          case 'config':
             const config = {
               labelText: '', // TODO (agrow) in a later PR, inject labelText
-              backgroundColor: message.config.button.backgroundColor,
-              foregroundColor: message.config.button.foregroundColor
+              backgroundColor: message.backgroundColor,
+              foregroundColor: message.foregroundColor
             };
 
             window.OverlayButtonJS.applyStyling(


### PR DESCRIPTION
The outer frame messaging was refactored to be consistent across both frames, but in the PR shuffle, updating the event object was missed here.

TEST=manual

Run locally, see button frame update color with as specified in config.