### PR TITLE
Never autofocus when parent frame is using mobile width

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -113,7 +113,7 @@
             window.collapseOverlay();
             break;
           case 'expand':
-            window.expandOverlay();
+            window.expandOverlay(message.isMobile);
             break;
           default:
             break;

--- a/overlay/controllers/shape.js
+++ b/overlay/controllers/shape.js
@@ -25,14 +25,16 @@ window.collapseOverlay = function () {
   }
 }
 
-window.expandOverlay = function () {
+window.expandOverlay = function (isMobile) {
   const bodyEl = document.querySelector('body');
 
   if (bodyEl) {
     bodyEl.classList.remove('collapsed');
     bodyEl.classList.add('expanded');
 
-    const inputEl = document.querySelector('.js-yext-query');
-    inputEl && inputEl.focus();
+    if (!isMobile) {
+      const inputEl = document.querySelector('.js-yext-query');
+      inputEl && inputEl.focus();
+    }
   }
 }

--- a/static/js/iframe-overlay/controllers/interactiondirector.js
+++ b/static/js/iframe-overlay/controllers/interactiondirector.js
@@ -97,7 +97,8 @@ export default class InteractionDirector {
    * in the child iFrame and the parts in the parent frame
    */
   forceExpand() {
-    this._sendMessageToIFrame(InteractionTypes.EXPAND);
+    const isMobile = !window.matchMedia("(min-width: 767px)").matches;
+    this._sendMessageToIFrame(InteractionTypes.EXPAND, { isMobile: isMobile });
     this.expando.expand();
   }
 


### PR DESCRIPTION
Part of the Overlay QA is that the Overlay's experience iframe's search bar should not autofocus when the parent frame is in mobile. This is more complicated than a normal media query because the experience iframe always thinks it's mobile-width (because the frame is narrow width-wise). This PR executes the media query in the parent frame when the iframe is expanded and passes an `isMobile` boolean to the experience iframe.

TEST=manual

Open and close the Overlay at desktop width (> 767px), see search input autofocus. Close, then open at mobile screen width. See search input not autofocus.