### PR TITLE
Fix location search bar on mobile

### DIFF
--- a/templates/vertical-map/markup/searchbar.hbs
+++ b/templates/vertical-map/markup/searchbar.hbs
@@ -1,1 +1,1 @@
-<div class="Answers-searchBar js-answersSearchBar" id="js-answersSearchBar"></div>
+<div class="Answers-search js-answersSearch" id="js-answersSearchBar"></div>

--- a/templates/vertical-map/script/searchbar.hbs
+++ b/templates/vertical-map/script/searchbar.hbs
@@ -1,5 +1,5 @@
 ANSWERS.addComponent("SearchBar", Object.assign({}, {
-  container: "#js-answersSearchBar",
+  container: ".js-answersSearch",
   {{#if verticalKey}}
     verticalKey: "{{{verticalKey}}}",
   {{/if}}


### PR DESCRIPTION
Fix the location search bar so that the padding is correct on mobile

The class Answers-searchBar didn't have any padding which was making the search bar hit the edges of the screen on mobile on the location-standard template. This PR fixes that.

The other templates use the CSS class rather than the ID when adding the component, so I updated location-standard to match that as well.

J=SLAP-803
TEST=manual

Confirm that the search bar now looks good on mobile