### PR TITLE
Pagination: hide padding when pagination not present

### DIFF
--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -72,7 +72,9 @@
   }
 
   &-pagination {
-    padding-top: calc(var(--yxt-base-spacing) / 2);
+    .yxt-Pagination {
+      padding-top: calc(var(--yxt-base-spacing) / 2);
+    }
   }
 
   &-resultsHeader {


### PR DESCRIPTION
Padding used to show up even when there was no pagination content. Move
the padding to the div that is present when pagination content is
present.

J=SLAP-752
TEST=manual

Test two verticals: one with few results (Products, in my case) and one
with many results (query `all` on People). Make sure on former, you do
not see a padding on the `Answers-pagination` class. Make sure on latter
you see the padding on the now-present `yxt-Pagination` div.