### PR TITLE
Add inner scroll to Autocomplete to allow shorter min height

### DIFF
--- a/static/js/iframe-overlay/constants.js
+++ b/static/js/iframe-overlay/constants.js
@@ -28,7 +28,7 @@ exports.AnimationStyling = {
   BOX_SHADOW_NONE: '0 3px 10px 0 rgba(0,0,0,0)',
   WIDTH_DESKTOP: '445px',
   WIDTH_MOBILE: '100vw',
-  MIN_HEIGHT: 525,
+  MIN_HEIGHT: 450,
   CONTAINER_HEIGHT_TALLER: '100vh',
   MAX_HEIGHT_DESKTOP: 'calc(100% - 32px)',
   MAX_WIDTH_DESKTOP: 'calc(100% - 32px)',

--- a/static/scss/answers/overlay/base.scss
+++ b/static/scss/answers/overlay/base.scss
@@ -39,6 +39,11 @@
     &-resultsWrapper {
       display: none;
     }
+
+    .yxt-AutoComplete {
+      max-height: 180px;
+      overflow-y: scroll;
+    }
   }
 
   &.taller {


### PR DESCRIPTION
TEST=manual,visual

Provide no prompts, see Overlay's height is the minimum (450px). Provide 5 prompts, see that the Overlay's height expanded to fit without scrolling (approx 575px). In shorter state, start typing, see 10 autocomplete options returned which are scrollable after ~5-6, depending on the length of the prompt string.