### PR TITLE
Remove outline on prompt buttons

### DIFF
--- a/static/scss/answers/overlay/prompt.scss
+++ b/static/scss/answers/overlay/prompt.scss
@@ -23,6 +23,7 @@
     &:focus {
       border: 1px solid #c3c3c3;
       color: var(--yxt-color-text-primary);
+      outline: none;
 
       svg {
         fill: var(--yxt-color-text-primary);


### PR DESCRIPTION
We were previously testing on an older demo branch of the SDK which had a global CSS reset on button focus states. For the prompts button to have expected styling, we need to add that reset back (scoped to the prompt buttons, of course).

TEST=manual,visual