### PR TITLE
Update spacing for min Overlay state

### DIFF
--- a/static/scss/answers/overlay/base.scss
+++ b/static/scss/answers/overlay/base.scss
@@ -3,13 +3,12 @@
     box-shadow: 0 2px 4px 0 rgba(0,0,0,0.2);
   }
 
-  .Answers-overlaySuggestions {
-    margin: var(--yxt-base-spacing);
-    margin-top: calc(var(--yxt-base-spacing) / 2);
+  .Answers-overlaySuggestions.hidden {
+    display: none;
+  }
 
-    &.hidden {
-      display: none;
-    }
+  .OverlayPromptButtons {
+    padding: var(--yxt-base-spacing);
   }
 
   .Answers-locationBias {

--- a/static/scss/answers/overlay/prompt.scss
+++ b/static/scss/answers/overlay/prompt.scss
@@ -16,7 +16,11 @@
     border: 1px solid #afafaf;
     border-radius: 3px;
     box-shadow: 0 1px 2px 0 rgba(0,0,0,0.15);
-    margin: 12px 0;
+    margin-top: 12px;
+
+    &:first-child {
+      margin-top: 0;
+    }
 
     &:hover,
     &:active,


### PR DESCRIPTION
We were using a lot of margins where we could have used padding, and since margin isn't included in an elements height, the iframe page height is not properly calculated. Update to use padding where possible.

TEST=manual,visual

View min state, see the spacing look equivalent to its appearance before change.