### PR TITLE
Add query source to ANSWERS init function

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -35,6 +35,7 @@
       templateBundle: TemplateBundle.default,
       ...injectedConfig,
       ...userConfig,
+      querySource: window.isOverlay ? 'OVERLAY' : 'STANDARD',
       onStateChange: (objParams, stringParams, replaceHistory) => {
         if ('parentIFrame' in window) {
           parentIFrame.sendMessage(JSON.stringify({


### PR DESCRIPTION
TEST=manual
J=SLAP-768

Test locally with the dev/add-analytics-source branch of the SDK and confirm with Raiden that they're seeing the source show up in analytics on their end.