### PR TITLE
formatters: Add formatters-custom for overrides

### DIFF
--- a/static/js/formatters-custom.js
+++ b/static/js/formatters-custom.js
@@ -1,0 +1,9 @@
+/**
+ * The formatters-custom file is a place to define custom formatters or to
+ * override any of the baked-in formatters like phone number formatting.
+ *
+ * e.g. You may write something like below
+ * export function address(profile) {
+ *   return `111 Yext Street`;
+ * }
+ */

--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -1,3 +1,10 @@
+/**
+ * The Formatters are a combination of the internal formatters like
+ * directions/address formatting and the custom formatters defined by the user.
+ * The custom formatters always take precedence if it exists in both internal and 
+ * custom formatters.
+ */
+
 import {
   address,
   phoneLink,
@@ -20,13 +27,14 @@ import {
   openStatus,
   generateCTAFieldTypeLink
 } from './formatters-internal.js';
+import * as CustomFormatters from './formatters-custom.js';
 
 /**
  * Contains some of the commonly used formatters for parsing pieces of profile
  * information. To remove a formatter from the bundle, comment the desired
  * line below.
  */
-const Formatters = {
+let Formatters = {
   address,
   phoneLink,
   phoneDisplay,
@@ -48,5 +56,6 @@ const Formatters = {
   openStatus,
   generateCTAFieldTypeLink
 };
+Formatters = Object.assign(Formatters, CustomFormatters);
 
 export { Formatters as default };


### PR DESCRIPTION
Previously, in order for HHs to override formatters, they would need to
theme override the formatters.js class /and/ reference any new
formatters from some new javascript class. We standardize this process
with the formatters-custom.js file. This new file will be moved to the
top-level static/js where HHs can change it without overriding files.

This file allows a HH to override current formatters as well as define
new ones.

J=SLAP-810
TEST=manual

Tested that with a formatters-custom in js/static of a HH theme
repository, you can write

```
export function address(profile) {
  return `111 Yext Street`;
}
export function newFunction(profile) {
  return 'helllllooooo';
}
```

and you can expect, after a `jambo build` that the addresses all
return the 111 Yext Street string and you can go into the command line
and write HitchhikerJS.Formatteres.newFunction() and get the hello
string.