### PR TITLE
Use toLocalizedDistance() for non-multilang cards

### DIFF
--- a/cards/financial-professional-location/component.js
+++ b/cards/financial-professional-location/component.js
@@ -36,7 +36,7 @@ class financial_professional_locationCardComponent extends BaseCard['financial-p
         showLessText: 'Show less' // Label when toggle will hide truncated text
       },
       // Distance from the user’s or inputted location
-      distance: Formatter.toMiles(profile),
+      distance: Formatter.toLocalizedDistance(profile),
       // The primary CTA of the card
       CTA1: {
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label

--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -23,7 +23,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
       address: Formatter.address(profile), // The address for the card
       phone: Formatter.nationalizedPhoneDisplay(profile), // The phone number for the card
       phoneEventOptions: this.addDefaultEventOptions(), // The analytics event options for phone clicks
-      distance: Formatter.toMiles(profile), // Distance from the user’s or inputted location
+      distance: Formatter.toLocalizedDistance(profile), // Distance from the user’s or inputted location
       // details: profile.description, // The description for the card, displays below the address and phone
       // altText: '', // The alt-text of the displayed image
       // image: '', // The URL of the image to display on the card

--- a/cards/professional-location/component.js
+++ b/cards/professional-location/component.js
@@ -36,7 +36,7 @@ class professional_locationCardComponent extends BaseCard['professional-location
         showLessText: 'Show less' // Label when toggle will hide truncated text
       },
       // Distance from the user’s or inputted location
-      distance: Formatter.toMiles(profile),
+      distance: Formatter.toLocalizedDistance(profile),
       // The primary CTA of the card
       CTA1: {
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label


### PR DESCRIPTION
Update the following cards to use` toLocalizedDistance()` instead of `toMiles()`:
- location-standard
- professional-location
- financial-professional-location

J=SLAP-814
TEST=manual

Test the cards with the locale 'es' and observe localized distances