### PR TITLE
Add iframe title attribute

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -103,7 +103,8 @@
         onReady: function() {
           window.parentIFrame.sendMessage(JSON.stringify({
             params: iframeGetSearchParams(),
-            replaceHistory: true
+            replaceHistory: true,
+            pageTitle: document.title
           }));
         },
       };

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -85,6 +85,8 @@ export function generateIFrame(domain, queryParam, urlParam) {
     onMessage: function(messageData) {
       const message = JSON.parse(messageData.message);
       const params = message.params;
+      const pageTitle = message.pageTitle;
+      pageTitle && (iframe.title = pageTitle);
       iframe.iFrameResizer.resize();
       var currLocation = window.location.href.split('?')[0];
       var newLocation = currLocation + '?' + params;


### PR DESCRIPTION
Add the iframe tittle attribute

Use the iFrameResizer sendMessage to send the page title to the parent document so that it can be set on the iframe

J=SLAP-809
TEST=manual

Visually inspect the iframe title attribute and confirm that it is set to the page title as I navigate verticals. Use a screen reader and listen to it read the iframe title (It reads the iframe title when I click on the part of the screen that surrounds the iframe)