### PR TITLE
script.hbs: Add JAMBO_INJECTED_DATA fallback for verticalPages label

### DIFF
--- a/templates/universal-standard/script/navigation.hbs
+++ b/templates/universal-standard/script/navigation.hbs
@@ -18,7 +18,6 @@ verticalPages: [
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
         label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
-        label: "{{> verticalLabel overridedLabel=label verticalKey='' fallback=@key}}",
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}

--- a/templates/vertical-grid/script/navigation.hbs
+++ b/templates/vertical-grid/script/navigation.hbs
@@ -17,7 +17,7 @@ verticalPages: [
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        label: "{{> verticalLabel overridedLabel=label verticalKey='' fallback=@key}}",
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}

--- a/templates/vertical-grid/script/verticalresults.hbs
+++ b/templates/vertical-grid/script/verticalresults.hbs
@@ -24,7 +24,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        label: "{{> verticalLabel overridedLabel=label verticalKey='' fallback=@key}}",
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
       }{{#unless @last}},{{/unless}}

--- a/templates/vertical-map/script/navigation.hbs
+++ b/templates/vertical-map/script/navigation.hbs
@@ -17,7 +17,7 @@ verticalPages: [
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        label: "{{> verticalLabel overridedLabel=label verticalKey='' fallback=@key}}",
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -24,7 +24,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        label: "{{> verticalLabel overridedLabel=label verticalKey='' fallback=@key}}",
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
       }{{#unless @last}},{{/unless}}

--- a/templates/vertical-standard/script/navigation.hbs
+++ b/templates/vertical-standard/script/navigation.hbs
@@ -17,7 +17,7 @@ verticalPages: [
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        label: "{{> verticalLabel overridedLabel=label verticalKey='' fallback=@key}}",
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
     {{/if}}

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -24,7 +24,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
       {{#with (lookup verticalsToConfig "Universal")}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        label: "{{> verticalLabel overridedLabel=label verticalKey='' fallback=@key}}",
+        label: {{#if label}}"{{{label}}}"{{else}}"{{{@key}}}"{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
       {{/with}}
       }{{#unless @last}},{{/unless}}


### PR DESCRIPTION
We added new metadata for the JAMBO_INJECTED_DATA in the Yext CI system.
We now want to use displayName as a default value for the vertical label
in verticalPages if it exists.

Because this lookup is farily large, moved to an inline partial.

Note: Ideally, this logic would not be in the handlebars, and the
templating system would be as dumb as possible. However, we are
restricted by how Jambo injects the environment variables and how we
don't use something like Wepback to do this logic in JavaScript.

J=SLAP-804
TEST=manual

Tested on a variety of page types:
vertical-grid
vertical-map
vertical-standard
universal-standard

Logged out which conditional each vertical met in the `jambo build`. The
universal was always hardcoded (as expected). The `events` and `products`
verticals always fellback to the vertical key (as expected) as the
JAMBO_INJECTED_DATA did not have a displayName for either of those
(empty string and undefined respectively). All other verticals correctly
used the displayName (shown in the Navigation tabs for example) as the
JAMBO_INJECTED_DATA had displayName data for them.