### PR TITLE
Prevent link interactivity when accordion is collapsed

### DIFF
--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -64,7 +64,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
     let isExpanded = this._container.querySelector(`.${accordionExpandedClass}`);
     contentEl.style.height = `${isExpanded ? contentEl.scrollHeight : 0}px`;
     const linkEls = contentEl.querySelectorAll('a');
-    this._toggleLinksInteractivity(linkEls, isExpanded);
+    this._setLinksInteractivity(linkEls, isExpanded);
 
     const cardEl = this._container.querySelector(accordionCardSelector);
 
@@ -74,7 +74,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
       this.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
       contentEl.style.height = `${isExpanded ? contentEl.scrollHeight : 0}px`;
       contentEl.setAttribute('aria-hidden', isExpanded ? 'false' : 'true');
-      self._toggleLinksInteractivity(linkEls, isExpanded);
+      self._setLinksInteractivity(linkEls, isExpanded);
 
       if (self.analyticsReporter) {
         const event = new ANSWERS.AnalyticsEvent(isExpanded ? 'ROW_EXPAND' : 'ROW_COLLAPSE')
@@ -91,12 +91,13 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
   }
 
   /**
-   * Toggles the interactivity of the link elements in a WCAG-compliant way
+   * Sets the interactivity of the link elements in a WCAG-compliant way based on
+   * whether the link is visible
    *
    * @param {Array<Element>} linkEls
    * @param {boolean} isVisible
    */
-  _toggleLinksInteractivity(linkEls, isVisible) {
+  _setLinksInteractivity(linkEls, isVisible) {
     for (const linkEl of linkEls) {
       linkEl.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
       linkEl.setAttribute('tabindex', isVisible ? '0' : '-1');

--- a/cards/multilang-faq-accordion/component.js
+++ b/cards/multilang-faq-accordion/component.js
@@ -63,6 +63,8 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
     const contentEl = this._container.querySelector(accordionContentSelector);
     let isExpanded = this._container.querySelector(`.${accordionExpandedClass}`);
     contentEl.style.height = `${isExpanded ? contentEl.scrollHeight : 0}px`;
+    const linkEls = contentEl.querySelectorAll('a');
+    this._setLinksInteractivity(linkEls, isExpanded);
 
     const cardEl = this._container.querySelector(accordionCardSelector);
 
@@ -72,6 +74,7 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
       this.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
       contentEl.style.height = `${isExpanded ? contentEl.scrollHeight : 0}px`;
       contentEl.setAttribute('aria-hidden', isExpanded ? 'false' : 'true');
+      self._setLinksInteractivity(linkEls, isExpanded);
 
       if (self.analyticsReporter) {
         const event = new ANSWERS.AnalyticsEvent(isExpanded ? 'ROW_EXPAND' : 'ROW_COLLAPSE')
@@ -85,6 +88,20 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
     });
 
     super.onMount();
+  }
+
+  /**
+   * Sets the interactivity of the link elements in a WCAG-compliant way based on
+   * whether the link is visible
+   *
+   * @param {Array<Element>} linkEls
+   * @param {boolean} isVisible
+   */
+  _setLinksInteractivity(linkEls, isVisible) {
+    for (const linkEl of linkEls) {
+      linkEl.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
+      linkEl.setAttribute('tabindex', isVisible ? '0' : '-1');
+    }
   }
 
   /**


### PR DESCRIPTION
Previously, CTA links were still tabbable when an accordion card is collapsed. This was happening because the FAQ-accordion's content is not invisible (e.g. display: none, visiblity: hidden) when collapsed, rather its height is set to 0. We want to keep the content hidden using height: 0 for animation reasons, so we propagate the `aria-hidden` attribute to the link descendant elements as well as making them un-tabbable with the `tabindex` attribute.

TEST=manual
J=SLAP-808

Set focus state to something more obvious like "background-color: red", then tab through the accordion card's buttons and see each focus without stepping down into invisible links. Open an accordion card using the focused button and the "space" key on my keyboard, then tab and see the link elements focus; "shift-tab" back to the expand/collapse button, hit "space" so the content is no longer visible and then tab again and see the link elements are skipped.