### PR TITLE
custom commands: make all methods except execute static

### DIFF
--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -165,7 +165,4 @@ class CardCreator {
     addToPartials(this._customCardsDir);
   }
 }
-module.exports = { 
-  clazz: CardCreator, 
-  factory: jamboConfig => new CardCreator(jamboConfig)
-};
+module.exports = CardCreator;

--- a/commands/directanswercardcreator.js
+++ b/commands/directanswercardcreator.js
@@ -170,7 +170,4 @@ class DirectAnswerCardCreator {
   }
 }
 
-module.exports = {
-  clazz: DirectAnswerCardCreator,
-  factory: jamboConfig => new DirectAnswerCardCreator(jamboConfig)
-};
+module.exports = DirectAnswerCardCreator;


### PR DESCRIPTION
Changes the `card` and `direactanswercard` commands so that all methods
except `execute` are static.

This change is so that the cli will not need to instantiate a
command unless it actually needs to execute it.

The commands now export two things: the class itself and a way to
instantiate the class.

J=SLAP-817
TEST=manual
Used the `card` and `directanswercard` commands in a Jambo repo and
saw that there were no behavior changes.