### PR TITLE
Standardize order of CTA props in data for render

### DIFF
--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -29,8 +29,8 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
       // image: '', // The URL of the image to display on the card
       showOrdinal: true, // If the ordinal should be displayed on the card
       CTA1: { // The primary call to action for the card
-        iconName: 'phone', // The icon to use for the CTA
         label: 'Call', // The label of the CTA
+        iconName: 'phone', // The icon to use for the CTA
         url: Formatter.phoneLink(profile), // The URL a user will be directed to when clicking
         target: '_top', // If the URL will be opened in a new tab, etc.
         eventType: 'TAP_TO_CALL', // Type of Analytics event fired when clicking the CTA

--- a/cards/multilang-location-standard/component.js
+++ b/cards/multilang-location-standard/component.js
@@ -29,8 +29,8 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
       // image: '', // The URL of the image to display on the card
       showOrdinal: true, // If the ordinal should be displayed on the card
       CTA1: { // The primary call to action for the card
-        iconName: 'phone', // The icon to use for the CTA
         label: {{ translateJS phrase='Call' context='Call is a verb' }}, // The label of the CTA
+        iconName: 'phone', // The icon to use for the CTA
         url: Formatter.phoneLink(profile), // The URL a user will be directed to when clicking
         target: '_top', // If the URL will be opened in a new tab, etc.
         eventType: 'TAP_TO_CALL', // Type of Analytics event fired when clicking the CTA


### PR DESCRIPTION
All of the cards except location-standard have the label listed above the icon in the dataForRender return value.

J=SLAP-820
TEST=manual

Serve site using the location-standard card and confirm that the CTA's phone icon and label still appear.