### PR TITLE
formatters: Change Google Place ID endpoint for get directions

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -44,10 +44,6 @@ export function emailLink(profile) {
 }
 
 export function getDirectionsUrl(profile, key = 'address') {
-  if (profile.googlePlaceId) {
-    return `https://www.google.com/maps/place/?q=place_id:${profile.googlePlaceId}`;
-  }
-
   const addr = profile[key];
   if (!addr) {
     return '';
@@ -57,7 +53,14 @@ export function getDirectionsUrl(profile, key = 'address') {
   const region = addr.region ? ` ${addr.region}` : ``;
   const rawQuery = `${addr.line1},${line2} ${addr.city},${region} ${addr.postalCode} ${addr.countryCode}`;
   const query = encodeURIComponent(rawQuery);
-  return `https://www.google.com/maps/search/?api=1&query=${query}&output=classic`
+
+  let url = `https://www.google.com/maps/search/?api=1&query=${query}&output=classic`;
+
+  if (profile.googlePlaceId) {
+    url += `&query_place_id=${profile.googlePlaceId}`;
+  }
+
+  return url;
 }
 
 export function toLocalizedDistance(profile, key = 'd_distance', displayUnits) {


### PR DESCRIPTION
Currently we use the place endpoint e.g.
https://www.google.com/maps/place/?q=place_id:ChIJQ_9cLMiXyFYRfcmQy7GHHaw

This works great on desktop and mobile if you paste the link directly.
However, if you click a link with this href and have the Google Maps app
on your mobile device, you get a malformed search on the app.

We change the endpoint to be the standard endpoint for get directions
except we add a query parameter for the place id if it exists.

J=SLAP-846
TEST=manual

Tested on a production site by changing the formatters-internal file
locallly and building. Serve the site locally and try to visit a Get
Directions link on a mobile device for a location with a Place ID. This
should open Google Maps with a listings card for the business at the
right location.