### PR TITLE
sticky view results button in iframe qa

### DIFF
--- a/static/scss/answers/collapsible-filters/collapsible-filters.scss
+++ b/static/scss/answers/collapsible-filters/collapsible-filters.scss
@@ -21,17 +21,16 @@
 
     &-viewResultsButton {
       position: fixed;
-      width: 50%;
+      width: 100%;
       left: 0;
       bottom: 0;
       padding: 4px 8px;
       background-color: var(--hh-answers-background-color);
       z-index: $nav-wrapper-z-index;
-      transition: all 0.3s ease-out;
+      transition: top 0.4s ease-out;
 
-      @media (max-width: $container-tablet-base) {
-        width: 100%;
-        margin-left: none;
+      @include bpgte(sm) {
+        width: 50%;
       }
     }
 


### PR DESCRIPTION
Did some quick QA with @rosiegrant.

This changes the update duration from 0.3s to 0.4s and
fixes a bug in the view results button media query
(it was using a slightly different width than vertical-map.scss)
and removes invalid css property value `margin-left: none`

J=SLAP-805
TEST=visual