### PR TITLE
Support ie11 with webpack 5

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -30,6 +30,7 @@ module.exports = function () {
 
   return {
     mode: 'production',
+    target: ['web', 'es5'],
     entry: {
       'bundle': `./${jamboConfig.dirs.output}/static/entry.js`,
       'iframe': `./${jamboConfig.dirs.output}/static/js/iframe.js`,


### PR DESCRIPTION
When migrating for webpack 4 to 5, it looks like
we need to add target: 'es5' to get rid of things like
arrow functions.

The webpack 4 to 5 migration page suggests adding
target: ['web', 'es5'] for browsers like ie11
https://webpack.js.org/migrate/5/

From some local testing, it looks like we could get away
with just specifying target: ['es5'] instead of target: ['web', 'es5'].
But it seems more correct to specify 'web' as well, since we're intending
for our code to be run in the browser, and this was also suggested
by the webpack docs.

TEST=manual

test that ie11 works