### PR TITLE
Add 'defer' attribute to SDK Javascript assets. (#473)

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -4,7 +4,7 @@
     console.error('ERROR: no sdkVersion specified, please specify an sdkVersion in the global_config.');
   }
 </script>
-<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answerstemplates.compiled.min.js"></script>
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answerstemplates.compiled.min.js" defer></script>
 <script>
 {{#babel}}
   function initAnswers() {
@@ -71,4 +71,4 @@
   }
 {{/babel}}
 </script>
-<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answers.min.js" onload="initAnswers()" async></script>
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answers.min.js" onload="initAnswers()" defer></script>


### PR DESCRIPTION
This PR adds the 'defer' attribute to the `script` tags for answers.min.js
and answerstemplates.compiled.min.js. This will ensure that the loading of
these JS assets does not block the browser from creating the DOM. This
attribute, as opposed to `async`, allows us to define an ordering between
the `script`s. The templates must be loaded before the SDK itself.

Note that the 'async' attribute was not added to these `script`s. This is
because they need to be executed in the order mentioned above, after the DOM
is built. Further, having both 'async' and 'defer' allows a browser that does
not support 'async' to fallback to 'defer'. We just always want 'defer'.

J=SLAP-860
TEST=manual

Built a local site with these changes. Did some smoke testing and saw no
problems.