### PR TITLE
Update the price formatter and have all Product cards use it. (#476)

### DIFF
--- a/cards/multilang-product-prominentimage-clickable/component.js
+++ b/cards/multilang-product-prominentimage-clickable/component.js
@@ -33,7 +33,7 @@ class multilang_product_prominentimage_clickableCardComponent
       url: cardUrl, // If the card is a clickable link, set URL here
       target: '_top', // If the card URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      subtitle: profile.price && profile.price.value ? profile.price.value : '', // The sub-header text of the card
+      subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card, Warning: cannot contain links

--- a/cards/multilang-product-prominentimage/component.js
+++ b/cards/multilang-product-prominentimage/component.js
@@ -24,7 +24,7 @@ class multilang_product_prominentimageCardComponent extends BaseCard['multilang-
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      subtitle: profile.price && profile.price.value ? profile.price.value : '', // The sub-header text of the card
+      subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card

--- a/cards/multilang-product-standard/component.js
+++ b/cards/multilang-product-standard/component.js
@@ -26,7 +26,7 @@ class multilang_product_standardCardComponent extends BaseCard['multilang-produc
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       titleEventOptions: this.addDefaultEventOptions(),
-      subtitle: profile.price && profile.price.value ? profile.price.value : '', // The sub-header text of the card
+      subtitle: Formatter.price(profile.price), // The sub-header text of the card
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.

--- a/cards/product-prominentimage-clickable/component.js
+++ b/cards/product-prominentimage-clickable/component.js
@@ -33,7 +33,7 @@ class product_prominentimage_clickableCardComponent
       url: cardUrl, // If the card is a clickable link, set URL here
       target: '_top', // If the card URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      subtitle: profile.price && profile.price.value ? `$${profile.price.value}` : '', // The sub-header text of the card
+      subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card, Warning: cannot contain links

--- a/cards/product-prominentimage/component.js
+++ b/cards/product-prominentimage/component.js
@@ -24,7 +24,7 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      subtitle: profile.price && profile.price.value ? `$${profile.price.value}` : '', // The sub-header text of the card
+      subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -26,7 +26,7 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       titleEventOptions: this.addDefaultEventOptions(),
-      subtitle: profile.price && profile.price.value ? `$${profile.price.value}` : '', // The sub-header text of the card
+      subtitle: Formatter.price(profile.price), // The sub-header text of the card
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -537,7 +537,7 @@ export function generateCTAFieldTypeLink(cta) {
 export function price(fieldValue, locale) {
   const localeForFormatting = locale || _getDocumentLocale() || 'en';
   const price = fieldValue.value && parseInt(fieldValue.value);
-  const currencyCode = fieldValue.currencyCode;
+  const currencyCode = fieldValue.currencyCode && fieldValue.currencyCode.split('-')[0];
   if (!price || isNaN(price) || !currencyCode) {
     console.warn(`No price or currency code in the price fieldValue object: ${fieldValue}`);
     return fieldValue.value;

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -55,7 +55,7 @@ describe('Formatters', () => {
   describe('price', () => {
     const priceField = {
       value: '100',
-      currencyCode: 'USD'
+      currencyCode: 'USD-US Dollar'
     };
     it('Formats a price in USD', () => {
       const price = Formatters.price(priceField, 'en');
@@ -71,12 +71,12 @@ describe('Formatters', () => {
     });
 
     it('Formats a price in EUR', () => {
-      priceField.currencyCode = 'EUR';
+      priceField.currencyCode = 'EUR-Euro';
       const price = Formatters.price(priceField);
       expect(price).toEqual('€100.00');
     });
     it('Formats a price in EUR with a non-en locale', () => {
-      priceField.currencyCode = 'EUR';
+      priceField.currencyCode = 'EUR-Euro';
       const price = Formatters.price(priceField, 'fr');
       expect(price).toEqual('100,00 €');
     });
@@ -89,7 +89,7 @@ describe('Formatters', () => {
       expect(price).toBeUndefined();
       expect(consoleWarn).toHaveBeenCalled();
 
-      price = Formatters.price({currencyCode: 'USD'});
+      price = Formatters.price({currencyCode: 'USD-US Dollar'});
       expect(price).toBeUndefined();
       expect(consoleWarn).toHaveBeenCalled();
 
@@ -102,7 +102,7 @@ describe('Formatters', () => {
       const consoleWarn = jest.spyOn(console, 'warn')
         .mockImplementation();
 
-      const price = Formatters.price({value: 'String', currencyCode: 'USD'});
+      const price = Formatters.price({value: 'String', currencyCode: 'USD-US Dollar'});
       expect(price).toEqual('String');
       expect(consoleWarn).toHaveBeenCalled();
     });


### PR DESCRIPTION
It turns out that LiveAPI returns currencyCode with the display name appended.
As an example, it returns 'USD-US Dollars' instead of just 'USD'. We need to
update our price formatter to account for this. This PR also ensures that the
various Product cards use the new formatter.

J=SLAP-785
TEST=auto, manual

Updated the formatter's unit tests. Created a local site using the various
Product cards and verified that price was formatted properly.