### PR TITLE
Overlay bug fixes

### DIFF
--- a/static/js/overlay/button-frame/button.js
+++ b/static/js/overlay/button-frame/button.js
@@ -27,7 +27,7 @@ export default class OverlayButtonJS {
         const buttonSize = buttonEl.getBoundingClientRect();
         OverlayButtonJS.notifyParentFrame(new IFrameMessage(ActionTypes.BUTTON_READY, {
           height: buttonSize.height,
-          width: buttonSize.width
+          width: config.labelText ? buttonSize.width : AnimationStyling.DEFAULT_BUTTON_SIZE
         }));
         break;
       case ActionTypes.COLLAPSE:

--- a/templates/universal-standard/script/searchbar.hbs
+++ b/templates/universal-standard/script/searchbar.hbs
@@ -1,6 +1,6 @@
 const overlayConfig = {
   customHooks: {
-    onSubmit: function (query) {
+    onConductSearch: function (query) {
       window.Overlay.grow();
     },
     onClearSearch: function () {

--- a/templates/vertical-grid/script/searchbar.hbs
+++ b/templates/vertical-grid/script/searchbar.hbs
@@ -1,6 +1,6 @@
 const overlayConfig = {
   customHooks: {
-    onSubmit: function (query) {
+    onConductSearch: function (query) {
       window.Overlay.grow();
     },
     onClearSearch: function () {

--- a/templates/vertical-map/script/searchbar.hbs
+++ b/templates/vertical-map/script/searchbar.hbs
@@ -1,6 +1,6 @@
 const overlayConfig = {
   customHooks: {
-    onSubmit: function (query) {
+    onConductSearch: function (query) {
       window.Overlay.grow();
     },
     onClearSearch: function () {

--- a/templates/vertical-standard/script/searchbar.hbs
+++ b/templates/vertical-standard/script/searchbar.hbs
@@ -1,6 +1,6 @@
 const overlayConfig = {
   customHooks: {
-    onSubmit: function (query) {
+    onConductSearch: function (query) {
       window.Overlay.grow();
     },
     onClearSearch: function () {


### PR DESCRIPTION
Per this PR: yext/answers#1168, the hook "onSubmit" was renamed to "onConductSearch". There was also a bug that was always using the button's max-width (100%) rather than the default button width when no text was present.

TEST=manual

Test locally using a newly generated HH test site with the theme and v1.7 of the Answers SDK. Serve, conduct search via buttons and via autocomplete.