### PR TITLE
collapsible filters: only register sticky listeners on vertical map

### DIFF
--- a/static/js/collapsible-filters/interactions.js
+++ b/static/js/collapsible-filters/interactions.js
@@ -10,10 +10,9 @@ export default class Interactions {
     this.searchBarContainer = document.getElementById('js-answersSearchBar');
     this.resultsColumn = document.querySelector('.js-answersResultsColumn');
     this.inactiveCssClass = 'CollapsibleFilters-inactive';
-    this.resultsWrapper = document.querySelector('.js-answersResultsWrapper');
-    this.stickyButton = document.getElementById('js-answersViewResultsButton');
+    this.resultsWrapper = document.querySelector('.js-answersResultsWrapper')
+      || document.querySelector('.Answers-resultsWrapper');
     this.parentIFrame = ('parentIFrame' in window) && parentIFrame;
-    this.stickifyViewResultsButton();
   }
 
   /**
@@ -23,6 +22,7 @@ export default class Interactions {
    * outside of the iframe, otherwise it will register its own listeners.
    */
   stickifyViewResultsButton() {
+    this.stickyButton = document.getElementById('js-answersViewResultsButton');
     if (this.parentIFrame) {
       this.parentIFrame.getPageInfo(parentPageInfo => {
         this.parentPageInfo = parentPageInfo;

--- a/templates/vertical-map/collapsible-filters/page-setup.js
+++ b/templates/vertical-map/collapsible-filters/page-setup.js
@@ -12,8 +12,13 @@ const collapsibleFiltersInteractions = new CollapsibleFilters.Interactions({
   filterEls: document.querySelectorAll('.js-answersFiltersWrapper'),
   resultEls: document.querySelectorAll('.js-answersResults,.js-answersFooter') 
 });
+
 // When a search is made with the searchbar, collapse the filters.
 collapsibleFiltersInteractions.registerCollapseFiltersOnSearchbarSearch();
+
+// The vertical-map page template uses Collapsible Filters on a desktop width,
+// so the view results button needs sticky behavior
+collapsibleFiltersInteractions.stickifyViewResultsButton();
 
 // Register an instance of CollapsibleFilters.FacetsDecorator,
 // to decorate the Facets component with


### PR DESCRIPTION
Noticed on yanswers that the sticky results button listener was
throwing an error for getBoundingRect() not being found.
This was happening because collapsible filters was looking
for a .js-answersResultsWrapper class, which is not present
on vertical-standard/grid pages, or older vertical-map pages.

Only vertical-map needs the sticky results button listeners,
so the registration of these listeners was moved into the page-setup
of the vertical map page.

This commit also updates cfilters to fall back to .Answers-resultsWrapper,
for easier integration with older page templates. I felt this was necessary
because adding the .js-answersResultsWrapper class was not listed in the
Collapsible Filters integration instructions.

J=SLAP-863
TEST=manual

Tested that the yanswers experience will no longer throw getBoundingClientRect()
not found errors
checked on local maps page that view results button is still sticky