### PR TITLE
removed line break before "extends"

### DIFF
--- a/cards/product-prominentimage-clickable/component.js
+++ b/cards/product-prominentimage-clickable/component.js
@@ -1,7 +1,6 @@
 {{> cards/card_component componentName='product-prominentimage-clickable' }}
 
-class product_prominentimage_clickableCardComponent
-  extends BaseCard['product-prominentimage-clickable'] {
+class product_prominentimage_clickableCardComponent extends BaseCard['product-prominentimage-clickable'] {
 
   constructor(config = {}, systemConfig = {}) {
     super(config, systemConfig);


### PR DESCRIPTION
Fambo card regex breaks if you have a multiline card class declaration

https://yext.slack.com/archives/C3VE1T8AW/p1605898112242100