### PR TITLE
Fix Overlay overlapping issue

### DIFF
--- a/static/js/overlay/parent-frame/dom/dominjector.js
+++ b/static/js/overlay/parent-frame/dom/dominjector.js
@@ -52,6 +52,7 @@ export default class DomInjector {
     const iframeContainerEl = document.createElement('div');
     iframeContainerEl.id = Selectors.OVERLAY_CONTAINER_ID;
     iframeContainerEl.style['position'] = 'fixed';
+    iframeContainerEl.style['z-index'] = AnimationStyling.ZINDEX_FRONTMOST;
     iframeContainerEl.style['bottom'] = AnimationStyling.BASE_SPACING;
     iframeContainerEl.style[this.alignment] = AnimationStyling.BASE_SPACING;
     iframeContainerEl.style['max-width'] = AnimationStyling.MAX_WIDTH_DESKTOP;


### PR DESCRIPTION
Previously, the elements within the overlay container had a z-index values but the container itself didn't. This was causing issues where the container could be under other items on the page. Add zindex to the container.

TEST=manual
J=PB-9812

Reproduce issue on Krispy Kreme site - see menu labels appear on top of the overlay. Test after change and see overlay is on top of all other elements.