### PR TITLE
Fix Overlay button width

### DIFF
--- a/static/scss/answers/overlay/button/_default.scss
+++ b/static/scss/answers/overlay/button/_default.scss
@@ -4,7 +4,7 @@
 @import "../../common/fonts-default";
 @import "../../../fonts";
 @import "../../common/mixins";
-@import "../../common/base";
+@import "./base";
 @import "../../module";
 
 @import "./button";

--- a/static/scss/answers/overlay/button/base.scss
+++ b/static/scss/answers/overlay/button/base.scss
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/static/scss/answers/overlay/button/button.scss
+++ b/static/scss/answers/overlay/button/button.scss
@@ -1,12 +1,10 @@
 .OverlayButton {
-  min-width: 64px;
-  min-height: 64px;
-  max-width: 100%;
-  max-height: 100%;
+  display: flex;
   font-family: var(--yxt-font-family);
   cursor: pointer;
   overflow: hidden;
   padding: 20px;
+  border: none;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
Some of the CSS resets for body styling from our generic base.scss file were causing issues with the button's styling, so we do not import that file for the button frame any longer. Removed extraneous width CSS that was causing weird width calculation issues as well. 

TEST=manual
J=PB-9812

Reproduce issue on Krispy Kreme site - see button fill max-width. Test after change and see button frame is sized based on content.