### PR TITLE
Add hover, active, and focus styling to clickable product card

### DIFF
--- a/static/scss/answers/cards/product-prominentimage-clickable.scss
+++ b/static/scss/answers/cards/product-prominentimage-clickable.scss
@@ -13,7 +13,6 @@
   &:focus,
   &:active,
   &:hover {
-    box-shadow: 0px 1px 10px 0px rgba(55, 55, 55, 0.2);
     transition: 0.2s all;
   }
 
@@ -25,6 +24,7 @@
   &:focus,
   &:active {
     top: 0px;
+    box-shadow: 0px 1px 10px 0px rgba(55, 55, 55, 0.2);
   }
 
 


### PR DESCRIPTION
TEST=manual,visual
Mocks: https://app.abstract.com/projects/82822983-52d5-4d0e-a87d-de836751caca/branches/master/commits/latest/files/C640B75D-F98D-4CF7-93E7-1AE08D634ACC/layers/5761B3DF-C59A-4A1C-B678-5E1876DFE8B1?collectionId=1445415a-65e1-4398-abb6-5213dcc72b27&collectionLayerId=ab17b858-bbd5-4b87-ae10-15b6eed298da

Make change, then serve site with product-prominentimage-clickable card. Hover over card with mouse, see styling apply. Force active and focus state using developer tools in the browser and see styling applied.