### PR TITLE
Remove scrollbars within button

### DIFF
--- a/static/scss/answers/overlay/button/base.scss
+++ b/static/scss/answers/overlay/button/base.scss
@@ -1,3 +1,4 @@
 body {
   margin: 0;
+  overflow: hidden;
 }


### PR DESCRIPTION
The button resizes from ~64px to a larger size when the overlay expands and collapses. This is because when the overlay is collapsed, there can be label text like "Questions?", but when the overlay is expanded the button is always the same size. When the button is animating between its smaller and larger states, some browsers try to display scroll bars, which we do not want. Hide overflow to avoid seeing scroll bars.

TEST=manual,visual
J=PB-9812

Test on Firefox with button label text, expand and collapse button and see no scroll bars.