### PR TITLE
Default JAMBO_INJECTED_DATA to null

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -51,9 +51,9 @@ module.exports = function () {
       new MiniCssExtractPlugin({ filename: '[name].css' }),
       ...htmlPlugins,
       new InlineAssetHtmlPlugin(),
-      new webpack.EnvironmentPlugin(
-        ['JAMBO_INJECTED_DATA']
-      ),
+      new webpack.EnvironmentPlugin({
+        JAMBO_INJECTED_DATA: null
+      }),
       new RemovePlugin({
         after: {
           root: `${jamboConfig.dirs.output}`,


### PR DESCRIPTION
Default JAMBO_INJECTED_DATA to null

Since Webpack 5, a webpack build will throw an error if an environment variable does not have a value or a default. This causes builds to fail when building locally when JAMBO_INJECTED_DATA is not set. Defaulting to null resolves this issue.

J=none
Test=manual

Build a site locally and confirm that it now builds when JAMBO_INJECTED_DATA is not set