### PR TITLE
Add CSS variable ponyfill to the button iframe

### DIFF
--- a/static/js/overlay/button-frame/button.html
+++ b/static/js/overlay/button-frame/button.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head data-iframe-height="true">
-  <link rel="stylesheet" type="text/css" href="overlay-button.css">
   <script src="overlay-button.js"></script>
+  <link rel="stylesheet" type="text/css" href="overlay-button.css">
   <script>
     window.iFrameResizer = {
       onMessage: window.OverlayButtonJS.onMessage

--- a/static/js/overlay/button-frame/entry.js
+++ b/static/js/overlay/button-frame/entry.js
@@ -1,5 +1,21 @@
 // Import global polyfills
 import 'core-js/stable';
+import cssVars from 'css-vars-ponyfill';
+
+cssVars({
+  onlyLegacy: true,
+  onBeforeSend: (xhr, node, url) => {
+    try {
+      const uriWithCacheBust = new URL(url);
+      const params = new SearchParams(uriWithCacheBust.search);
+      params.set('_', new Date().getTime());
+      uriWithCacheBust.search = params.toString();
+      xhr.open('GET', uriWithCacheBust.toString());
+    } catch (e) {
+      // Catch the error and continue if the URL provided in the asset is not a valid URL
+    }
+  }
+});
 
 // Import all SCSS
 import Scss from '../../../scss/answers/overlay/button/_default.scss';

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -2252,6 +2252,11 @@
       "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
       "dev": true
     },
+    "css-vars-ponyfill": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.4.2.tgz",
+      "integrity": "sha512-kp8Ufs7jJDoaSym1hw/deawtakLJJTAQMB4ZgkdyOwCTJHqEClbpXI910ovQU4Guxt37EcdRiqppG9ihFyCjPQ=="
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",

--- a/static/package.json
+++ b/static/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "bootstrap-sass": "^3.4.1",
     "core-js": "^3.6.5",
+    "css-vars-ponyfill": "^2.3.1",
     "font-awesome": "^4.7.0",
     "iframe-resizer": "^4.1.1",
     "is-mobile": "^2.2.2",


### PR DESCRIPTION
Currently the CSS variable ponyfill lives in the Answers SDK. Since we don't use the Answers SDK in the button iframe, our variables were not being ponyfilled which meant that they weren't working in IE11. Add the ponyfill to the button iframe's JS.

TEST=manual
J=PB-9812

Serve page in IE11, see font family is font family specified in the answers-variables file rather than the default IE11 font.