### PR TITLE
Default universal section title to vertical's `displayName`.

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -66,7 +66,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
       cardType: "{{{cardType}}}"
     },
   {{/if}}
-  sectionTitle: {{#if sectionTitle}}"{{{sectionTitle}}}"{{else}}{{#if label}}"{{{label}}}"{{else}}"{{{verticalKey}}}"{{/if}}{{/if}},
+  sectionTitle: {{#if sectionTitle}}"{{{sectionTitle}}}"{{else}}"{{> verticalLabel overridedLabel=label verticalKey=verticalKey fallback=verticalKey}}"{{/if}},
   {{#if icon}}
     sectionTitleIconName: "{{{icon}}}",
   {{/if}}
@@ -97,4 +97,41 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
       });
     },
   {{/if}}
+{{/inline}}
+
+{{!--
+  Prints the vertical label according to specific logic
+  Assumes @root has environment variables and global_config
+  @param overridedLabel The hardcoded label from configuration in repo, meant to supercede defaults
+  @param verticalKey The current vertical key, if it exists
+  @param fallback The fallback for the label if all else doesn't exist
+--}}
+{{#*inline 'verticalLabel'}}
+  {{~#if overridedLabel ~}}
+    {{{overridedLabel}}}
+  {{~ else if
+    (lookup
+      (lookup 
+        (lookup 
+          (lookup
+            @root.env.JAMBO_INJECTED_DATA.answers.experiences
+            @root.global_config.experienceKey)
+          'verticals')
+        verticalKey)
+      'displayName')
+  ~}}
+    {{{lookup
+      (lookup 
+        (lookup 
+          (lookup
+            @root.env.JAMBO_INJECTED_DATA.answers.experiences
+            @root.global_config.experienceKey)
+          'verticals')
+        verticalKey)
+      'displayName'}}}
+  {{~ else if verticalKey ~}}
+    {{{verticalKey}}}
+  {{~ else ~}}
+    {{{fallback}}}
+  {{~/if ~}}
 {{/inline}}


### PR DESCRIPTION
Recently, the `JAMBO_INJECTED_DATA` was updated so that the `displayName` of
each vertical in an experience is provided. We should default to this name
when constructing the vertical's universal section template. As before, if
a `label` or `secionTitleName` has been specified in page configuration, we
will favor those instead.

J=SLAP-887
TEST=manual

Tested the following:

- Set a `label` for a vertical, verified that was used as the section title.
- Set a `sectionTitleName` for a vertical, verified that was used as the
  section title.
- When no `label` or `sectionTitleName` was present, saw the `displayName` from
  the injected data used as the section title.
- If no `diplsayName` was present for the vertical, saw it's `verticalKey` used
  as the section title.