### PR TITLE
Location page address width

### DIFF
--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -130,11 +130,11 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
   &-core
   {
     margin-top: calc(var(--hh-location-standard-base-spacing) / 2);
-    min-width: 150px;
+    min-width: 160px;
 
     @media (min-width: $breakpoint-mobile-max)
     {
-      max-width: 25%;
+      max-width: 33%;
       margin-right: calc(var(--hh-location-standard-base-spacing) * 2);
     }
   }


### PR DESCRIPTION
Tweak the CSS so that long addresses on location cards don't push the hours list below the address

Adding the max-width causes the address to wrap rather than pushing the hours list below the address. The min-width prevents the width of the address from getting too small when the browser window is small but not yet at the mobile breakpoint. I also switched the padding right to margin right because padding right would sometimes create a lot of whitespace when the address wrapped.

J=none
Test=visual

View a location page as I resize it from mobile to full-screen. Test long addresses and confirm they wrap at reasonable spots.