### PR TITLE
Hours list IE11 formatting

### DIFF
--- a/static/scss/answers/formatters/hours-table.scss
+++ b/static/scss/answers/formatters/hours-table.scss
@@ -8,6 +8,7 @@
 
   &-day {
     padding-right: 10px;
+    vertical-align: top;
   }
 
   &-intervals {


### PR DESCRIPTION
Fix IE11 formatting for the hours list formatter

When a particular day contains a list of hours, the day should appear next to the top of that list. This is default behavior in chrome, but in ie11, it incorrectly appears next to the bottom of that list. This PR makes this explicit in the CSS so that it also works in IE11

J=None
Test=visual

View the hours list formatter on chrome and observe no difference. Also view it on IE11 and see that the day is now in the right spot