### PR TITLE
Don't show product tag if no image

### DIFF
--- a/cards/product-prominentimage-clickable/template.hbs
+++ b/cards/product-prominentimage-clickable/template.hbs
@@ -19,7 +19,7 @@
 </div>
 
 {{#*inline 'image'}}
-{{#if card.tag}}
+{{#if (all card.image card.tag) }}
 <div class="HitchhikerProductProminentImage-imageAndTagWrapper">
   <div class="HitchhikerProductProminentImage-tagWrapper">
     <div class="HitchhikerProductProminentImage-tag">
@@ -32,7 +32,7 @@
     <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
-{{#if card.tag}}
+{{#if (all card.image card.tag) }}
 </div>
 {{/if}}
 {{/inline}}

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -11,7 +11,7 @@
 </div>
 
 {{#*inline 'image'}}
-{{#if card.tag}}
+{{#if (all card.image card.tag) }}
 <div class="HitchhikerProductProminentImage-imageAndTagWrapper">
   <div class="HitchhikerProductProminentImage-tagWrapper">
     <div class="HitchhikerProductProminentImage-tag">
@@ -24,7 +24,7 @@
     <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
-{{#if card.tag}}
+{{#if (all card.image card.tag) }}
 </div>
 {{/if}}
 {{/inline}}


### PR DESCRIPTION
Don't show a product tag if there is no image for the product-prominentimage and the product-prominentimage-clickable cards

Before this change, the tag would cover up the card title if no image was present. These cards are not meant to be used without images, however, this change improves the UI in case that someone forgets to add an image.

J=none
Test=manual

Search for some products that don't have images and confirm that the tag doesn't appear unless the product has an image