### PR TITLE
use isAbsoluteUrl helper to determine absolute urls

### DIFF
--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -12,8 +12,11 @@
 
 {{#*inline 'image'}}
 {{#if card.image}}
-<div class="HitchhikerProductProminentImage-imgWrapper">
-  <img class="HitchhikerProductProminentImage-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <div class="HitchhikerProductProminentImage-imgWrapper">
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  </div>
+  {{/if}}
+{{#if card.tag}}
 </div>
 {{/if}}
 {{/inline}}
@@ -23,7 +26,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -89,7 +92,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -98,7 +101,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -12,8 +12,11 @@
 
 {{#*inline 'image'}}
 {{#if card.image}}
-<div class="HitchhikerProductProminentImage-imgWrapper">
-  <img class="HitchhikerProductProminentImage-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <div class="HitchhikerProductProminentImage-imgWrapper">
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  </div>
+  {{/if}}
+{{#if card.tag}}
 </div>
 {{/if}}
 {{/inline}}
@@ -23,7 +26,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -89,7 +92,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -98,7 +101,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (matches card.image '//' )}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (matches card.url '//' )}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (matches link '//' )}}{{relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (isAbsoluteUrl link)}}{{relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (matches viewDetailsLink '//' )}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (matches link '//' )}}{{relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (isAbsoluteUrl link)}}{{relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (matches viewDetailsLink '//' )}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -35,13 +35,13 @@
     <meta property="og:type" content="website">
     {{#if global_config.logo}}
       <meta property="og:image"
-        content="{{#unless (matches global_config.logo '//' )}}{{relativePath}}/{{/unless}}{{global_config.logo}}" />
+        content="{{#unless (isAbsoluteUrl global_config.logo)}}{{relativePath}}/{{/unless}}{{global_config.logo}}" />
     {{/if}}
     {{#if canonicalUrl}}
       <meta property="og:url"
-        content="{{#unless (matches canonicalUrl '//' )}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
+        content="{{#unless (isAbsoluteUrl canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
       <link rel="canonical"
-        href="{{#unless (matches canonicalUrl '//' )}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
+        href="{{#unless (isAbsoluteUrl canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
     {{else if env.JAMBO_INJECTED_DATA.pages.domains.prod.domain}}
       {{#with env.JAMBO_INJECTED_DATA.pages.domains.prod}}
         <meta property="og:url" content="{{#if isHttps}}https://{{else}}http://{{/if}}{{domain}}">
@@ -56,7 +56,7 @@
 
     {{#if global_config.favicon}}
       <link rel="shortcut icon"
-        href="{{#unless (matches global_config.favicon '//' )}}{{relativePath}}/{{/unless}}{{global_config.favicon}}" />
+        href="{{#unless (isAbsoluteUrl global_config.favicon)}}{{relativePath}}/{{/unless}}{{global_config.favicon}}" />
     {{/if}}
     <script>
       document.addEventListener('DOMContentLoaded', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "A starter answers theme for hitchhikers",
   "scripts": {
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu jest --verbose"

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -64,6 +64,15 @@
           const regex = new RegExp(regexPattern)
           return str && str.match(regex);
         });
+
+        /**
+         * Determine whether a URL is absolute or not.
+         * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com"
+         */
+        ANSWERS.registerHelper('isAbsoluteUrl', function(str) {
+          const absoluteURLRegex = /^(\/|[a-zA-Z]+:)/;
+          return str && str.match(absoluteURLRegex);
+        });
       }
     });
     {{> script/after-init}}

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1363,9 +1363,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true
     },
     "acorn-globals": {
@@ -1635,14 +1635,15 @@
       }
     },
     "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       },
       "dependencies": {
         "bn.js": {
@@ -1800,9 +1801,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -1853,9 +1854,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-      "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
       "dev": true
     },
     "body": {
@@ -1891,32 +1892,12 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "fill-range": "^7.0.1"
       }
     },
     "brorand": {
@@ -1969,34 +1950,26 @@
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-          "dev": true
-        }
       }
     },
     "browserify-sign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
-      "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
         "browserify-rsa": "^4.0.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.3",
         "inherits": "^2.0.4",
         "parse-asn1": "^5.1.5",
         "readable-stream": "^3.6.0",
@@ -2196,9 +2169,9 @@
       }
     },
     "chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2209,46 +2182,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true,
-          "optional": true
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
+        "readdirp": "~3.5.0"
       }
     },
     "chownr": {
@@ -2605,13 +2539,13 @@
       }
     },
     "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "elliptic": "^6.5.3"
       },
       "dependencies": {
         "bn.js": {
@@ -3241,9 +3175,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.2.0.tgz",
-      "integrity": "sha512-S7eiFb/erugyd1rLb6mQ3Vuq+EXHv5cpCkNqqIkYkBgN2QdFnyCZzFBleqwGEx4lgNGYij81BWnCrFNK7vxvjQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -3432,12 +3366,20 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -3459,9 +3401,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true
     },
     "evp_bytestokey": {
@@ -3675,51 +3617,6 @@
         "merge2": "^1.3.0",
         "micromatch": "^4.0.2",
         "picomatch": "^2.2.1"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "fast-json-stable-stringify": {
@@ -3793,26 +3690,12 @@
       "optional": true
     },
     "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "to-regex-range": "^5.0.1"
       }
     },
     "find-cache-dir": {
@@ -4521,6 +4404,26 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -4693,18 +4596,18 @@
       "dev": true
     },
     "i18next": {
-      "version": "19.8.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.8.3.tgz",
-      "integrity": "sha512-eVrqAw2gGGYYJaJMYw4VM1FNFawLD4b84IsoTZMVXeWHaxAM2gyTa34j2Sip15UkBz/LrSxdFJj0Jhlrz7EvHA==",
+      "version": "19.8.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.8.4.tgz",
+      "integrity": "sha512-FfVPNWv+felJObeZ6DSXZkj9QM1Ivvh7NcFCgA8XPtJWHz0iXVa9BUy+QY8EPrCLE+vWgDfV/sc96BgXVo6HAA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.1",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -4713,9 +4616,9 @@
       }
     },
     "i18next-conv": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/i18next-conv/-/i18next-conv-10.0.2.tgz",
-      "integrity": "sha512-KZp+OfvPN50ZQHCiqhVhxA5uowuE6xIZ42M1Mtht87/xh2tp3GJl3ds0wsewhFxQRmHOVWOaq0ZYoK/oHWrbzg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/i18next-conv/-/i18next-conv-10.1.0.tgz",
+      "integrity": "sha512-NI3FQvXp81MZmJaPbjNGzAvLuILzUGCEMikSjk4lEgl3yuWsOKpkWF/9mWWTucB2gRC288zMfhBkNovSlFTp/w==",
       "dev": true,
       "requires": {
         "arrify": "^2.0.1",
@@ -4836,9 +4739,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "iferr": {
@@ -5051,24 +4954,10 @@
       "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -5156,9 +5045,9 @@
       "dev": true
     },
     "jambo": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.7.0.tgz",
-      "integrity": "sha512-hxGDaUamNYUGSddWMAXr9iD5cADpYcHgjxg+R29Kvyklz0dB/32XYOg0Z65kFDt2xE/nleDln9L0XnLJOBmU1A==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.9.2.tgz",
+      "integrity": "sha512-FTJ4LgYokRMzPGobfl0KkFAWd7P+o3FRcPYinfr+MK+PSLSH06dvYlM7Un2YfCgsLtYNqT1TbZHitvhS+b4ZMw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.6",
@@ -5638,24 +5527,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
       }
     },
     "miller-rabin": {
@@ -6414,14 +6292,13 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
+        "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
@@ -7033,9 +6910,9 @@
       }
     },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7708,9 +7585,9 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -8368,16 +8245,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-      "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^3.1.0",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -8440,9 +8317,9 @@
       }
     },
     "timers-browserify": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -8518,13 +8395,12 @@
       }
     },
     "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       }
     },
     "tough-cookie": {
@@ -8701,15 +8577,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.4.tgz",
-      "integrity": "sha512-FyYnoxVL1D6+jDGQpbK5jW6y/2JlVfRfEeQ67BPCUg5wfCjaKOpr2XeceE4QL+MkhxliLtf5EbrMDZgzpt2CNw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.0.tgz",
+      "integrity": "sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA==",
       "dev": true,
       "optional": true
     },
@@ -8977,21 +8853,21 @@
       }
     },
     "watchpack": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-      "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "watchpack-chokidar2": "^2.0.1"
       }
     },
     "watchpack-chokidar2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+      "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9028,6 +8904,37 @@
           "dev": true,
           "optional": true
         },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
         "chokidar": {
           "version": "2.1.8",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -9047,6 +8954,31 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "fsevents": {
@@ -9093,6 +9025,50 @@
             "binary-extensions": "^1.0.0"
           }
         },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -9130,6 +9106,17 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
         }
       }
     },
@@ -9140,9 +9127,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-      "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+      "version": "4.44.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+      "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
@@ -9153,7 +9140,7 @@
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
+        "enhanced-resolve": "^4.3.0",
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",
@@ -9166,10 +9153,103 @@
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
         "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.1",
+        "watchpack": "^1.7.4",
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -9179,6 +9259,16 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           }
         }
       }

--- a/static/package.json
+++ b/static/package.json
@@ -29,7 +29,7 @@
     "grunt-webpack": "^3.1.3",
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
-    "jambo": "^1.7.0",
+    "jambo": "^1.9.2",
     "jsdom": "^16.4.0",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.13.1",

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -37,27 +37,27 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
   {{/if}}
   modifier: "{{{verticalKey}}}",
   {{#if url}}
-    url: "{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{{url}}}",
+    url: "{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        url: "{{#unless (matches url '//' )}}{{relativePath}}/{{/unless}}{{{url}}}",
+        url: "{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}",
       }
     ],
   {{else if pagePath}}
-    url: "{{#unless (matches pagePath '//' )}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
+    url: "{{#unless (isAbsoluteUrl pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        pageUrl: "{{#unless (matches pagePath '//' )}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
+        pageUrl: "{{#unless (isAbsoluteUrl pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
       }
     ],
   {{else if pageName}}
-    url: "{{#unless (matches pageName '//' )}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
+    url: "{{#unless (isAbsoluteUrl pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        url: "{{#unless (matches pageName '//' )}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
+        url: "{{#unless (isAbsoluteUrl pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
       }
     ],
   {{/if}}
@@ -70,7 +70,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
   {{#if icon}}
     sectionTitleIconName: "{{{icon}}}",
   {{/if}}
-  {{#if iconUrl}}sectionTitleIconUrl: "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+  {{#if iconUrl}}sectionTitleIconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
   viewAllText: {{#if viewAllText}}"{{{viewAllText}}}"{{else}}{{ translateJS phrase='View All' context='View is a verb' }}{{/if}},
   {{#if viewMore}}viewMore: {{viewMore}},{{/if}}
   {{#if mapConfig}}

--- a/templates/vertical-grid/script/verticalresults.hbs
+++ b/templates/vertical-grid/script/verticalresults.hbs
@@ -14,8 +14,8 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
-        label:
+        {{#if iconUrl}}iconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        label: 
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -14,8 +14,8 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
-        label:
+        {{#if iconUrl}}iconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        label: 
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -14,8 +14,8 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (matches iconUrl '//' )}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
-        label:
+        {{#if iconUrl}}iconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        label: 
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}


### PR DESCRIPTION
This commit adds the isAbsoluteUrl helper to determine urls,
and updates the regex we were using to also detect urls of the
 mailto:slapshot@gmail.com. It cherrypicks #475 

TEST=manual

test that I can build a vertical standard page