### PR TITLE
Fix matches helper param order, add missing usages

### DIFF
--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -24,7 +24,9 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerFinancialProfessionalLocation-imgWrapper">
-  <img class="HitchhikerFinancialProfessionalLocation-img" src="{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerFinancialProfessionalLocation-img"
+  src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}"
+  alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +43,8 @@
 {{#if card.title}}
 <div class="HitchhikerFinancialProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink" href="{{card.url}}"
+  <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
+    href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +162,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerFinancialProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>
@@ -149,7 +149,9 @@
 {{#if card.title}}
 <div class="HitchhikerLocationStandard-title">
   {{#if card.titleUrl}}
-  <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title" href="{{card.titleUrl}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
+    href="{{#unless (matches card.titleUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.titleUrl}}"
+    data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -24,7 +24,9 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerFinancialProfessionalLocation-imgWrapper">
-  <img class="HitchhikerFinancialProfessionalLocation-img" src="{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerFinancialProfessionalLocation-img"
+    src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}"
+    alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +43,8 @@
 {{#if card.title}}
 <div class="HitchhikerFinancialProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink" href="{{card.url}}"
+  <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
+    href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +162,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerFinancialProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>
@@ -149,7 +149,9 @@
 {{#if card.title}}
 <div class="HitchhikerLocationStandard-title">
   {{#if card.titleUrl}}
-  <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title" href="{{card.titleUrl}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
+    href="{{#unless (matches card.titleUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.titleUrl}}"
+    data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -13,7 +13,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
 {{/if}}
 {{/inline}}
@@ -23,7 +23,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -89,7 +89,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -98,7 +98,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -13,7 +13,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
 {{/if}}
 {{/inline}}
@@ -23,7 +23,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -89,7 +89,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -98,7 +98,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (matches card.image '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (matches '^(\/|[a-zA-Z]+:)' card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (matches card.url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' link)}}{{relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (matches link '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (matches '^(\/|[a-zA-Z]+:)' viewDetailsLink)}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (matches viewDetailsLink '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (matches '^(\/|[a-zA-Z]+:)' link)}}{{relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (matches link '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (matches '^(\/|[a-zA-Z]+:)' viewDetailsLink)}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (matches viewDetailsLink '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -35,13 +35,13 @@
     <meta property="og:type" content="website">
     {{#if global_config.logo}}
       <meta property="og:image"
-        content="{{#unless (matches '^(\/|[a-zA-Z]+:)' global_config.logo)}}{{relativePath}}/{{/unless}}{{global_config.logo}}" />
+        content="{{#unless (matches global_config.logo '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{global_config.logo}}" />
     {{/if}}
     {{#if canonicalUrl}}
       <meta property="og:url"
-        content="{{#unless (matches '^(\/|[a-zA-Z]+:)' canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
+        content="{{#unless (matches canonicalUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
       <link rel="canonical"
-        href="{{#unless (matches '^(\/|[a-zA-Z]+:)' canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
+        href="{{#unless (matches canonicalUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
     {{else if env.JAMBO_INJECTED_DATA.pages.domains.prod.domain}}
       {{#with env.JAMBO_INJECTED_DATA.pages.domains.prod}}
         <meta property="og:url" content="{{#if isHttps}}https://{{else}}http://{{/if}}{{domain}}">
@@ -56,7 +56,7 @@
 
     {{#if global_config.favicon}}
       <link rel="shortcut icon"
-        href="{{#unless (matches '^(\/|[a-zA-Z]+:)' global_config.favicon)}}{{relativePath}}/{{/unless}}{{global_config.favicon}}" />
+        href="{{#unless (matches global_config.favicon '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{global_config.favicon}}" />
     {{/if}}
     <script>
       document.addEventListener('DOMContentLoaded', function () {

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -37,27 +37,27 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
   {{/if}}
   modifier: "{{{verticalKey}}}",
   {{#if url}}
-    url: "{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{{url}}}",
+    url: "{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{url}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        url: "{{#unless (matches '^(\/|[a-zA-Z]+:)' url)}}{{relativePath}}/{{/unless}}{{{url}}}",
+        url: "{{#unless (matches url '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{url}}}",
       }
     ],
   {{else if pagePath}}
-    url: "{{#unless (matches '^(\/|[a-zA-Z]+:)' pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
+    url: "{{#unless (matches pagePath '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        pageUrl: "{{#unless (matches '^(\/|[a-zA-Z]+:)' pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
+        pageUrl: "{{#unless (matches pagePath '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
       }
     ],
   {{else if pageName}}
-    url: "{{#unless (matches '^(\/|[a-zA-Z]+:)' pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
+    url: "{{#unless (matches pageName '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        url: "{{#unless (matches '^(\/|[a-zA-Z]+:)' pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
+        url: "{{#unless (matches pageName '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
       }
     ],
   {{/if}}
@@ -70,7 +70,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
   {{#if icon}}
     sectionTitleIconName: "{{{icon}}}",
   {{/if}}
-  {{#if iconUrl}}sectionTitleIconUrl: "{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+  {{#if iconUrl}}sectionTitleIconUrl: "{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
   viewAllText: {{#if viewAllText}}"{{{viewAllText}}}"{{else}}{{ translateJS phrase='View All' context='View is a verb' }}{{/if}},
   {{#if viewMore}}viewMore: {{viewMore}},{{/if}}
   {{#if mapConfig}}

--- a/templates/vertical-grid/script/verticalresults.hbs
+++ b/templates/vertical-grid/script/verticalresults.hbs
@@ -14,7 +14,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
         label: 
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -14,7 +14,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
         label: 
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -14,7 +14,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (matches '^(\/|[a-zA-Z]+:)' iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{#unless (matches iconUrl '^(\/|[a-zA-Z]+:)')}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
         label: 
         {{#if label}}"{{{label}}}"{{else}}{{#if ../verticalKey}}"{{{../verticalKey}}}"{{else}}"{{{@key}}}"{{/if}}{{/if}},
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",


### PR DESCRIPTION
The match helper param order was swapped, it should
be regex second. There were also a few urls that
were missing usages of it that needed it, so that was
added in here.

TEST=manual

test that the url http://www.test.com is recognized as absolute