### PR TITLE
Add relativePath to card templates

### DIFF
--- a/cards/all.hbs
+++ b/cards/all.hbs
@@ -1,4 +1,4 @@
 let BaseCard = {};
 {{#partialPattern '^cards/(.*)/component'}}
-  {{> (lookup . 'key') }}
+  {{> (lookup . 'key') relativePath=../relativePath }}
 {{/partialPattern}}

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -56,7 +56,8 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
       card: cardData,
       showExcessDetailsToggle: showExcessDetailsToggle,
       truncatedDetails: truncatedDetails,
-      cardName: `{{componentName}}`
+      cardName: `{{componentName}}`,
+      relativePath: `{{relativePath}}`
     });
   }
 

--- a/directanswercards/all.hbs
+++ b/directanswercards/all.hbs
@@ -1,4 +1,4 @@
 let BaseDirectAnswerCard = {};
 {{#partialPattern '^directanswercards/(.*)/component'}}
-  {{> (lookup . 'key') }}
+  {{> (lookup . 'key') relativePath=../relativePath }}
 {{/partialPattern}}

--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -27,7 +27,8 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
       ...cardData,
       feedbackSubmitted: data.feedbackSubmitted,
       isArray: Array.isArray(this.answer.value),
-      cardName: `{{componentName}}`
+      cardName: `{{componentName}}`,
+      relativePath: `{{relativePath}}`
     });
   }
 


### PR DESCRIPTION
Since the card templates are compiled by the SDK's handlebars compiler rather than Jambo, they do not have relative path. Added the relative path from Jambo to the state.

TEST=manual

Generate a site and use relativePath in a card, see it is as expected.