### PR TITLE
Remove experience key and locale from global config

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -1,10 +1,8 @@
 {
   "sdkVersion": "1.6", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
-  "experienceKey": "<REPLACE ME>",
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
-  "locale": "en", // The default locale for searches. Examples: UK: en-GB, Spanish: es, Spain Spanish: es-ES.
   "logo": "", // The link to the logo for open graph meta tag - og:image.
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer


### PR DESCRIPTION
This was requested by the Hitchhikers since the experienceKeys and locale are now specified in the locale_config.

TEST=manual