### PR TITLE
Jambobuild exit code fix

### DIFF
--- a/static/Gruntfile.js
+++ b/static/Gruntfile.js
@@ -37,8 +37,8 @@ module.exports = function (grunt) {
         return;
       }
 
-      stdout && console.log(stdout);
       stderr && console.error(stderr);
+      stdout && console.log(stdout);
       done();
     });
   });


### PR DESCRIPTION
Don't exit with a non-zero exit code when the jambo build prints to stderr

J=SLAP-899
Test=manual

Run `grunt jambobuild` with this change and confirm that the build exits with a exit code of zero, even if jambo printed to stderr