### PR TITLE
Access alignment config after null check in Overlay

### DIFF
--- a/static/js/overlay/parent-frame/models/overlayconfig.js
+++ b/static/js/overlay/parent-frame/models/overlayconfig.js
@@ -69,12 +69,6 @@ export default class OverlayConfig {
     };
 
     /**
-     * Where to align the overlay, can be 'left' or 'right'
-     * @type {String}, either 'left' or 'right'
-     */
-    this.alignment = config.button.alignment === 'left' ? 'left' : 'right',
-
-    /**
      * Configuration for the button.
      */
     config.button = config.button || {};
@@ -96,6 +90,12 @@ export default class OverlayConfig {
        */
       foregroundColor: config.button.color.foreground || '#FFFFFF',
     };
+
+    /**
+     * Where to align the overlay, can be 'left' or 'right'
+     * @type {String}, either 'left' or 'right'
+     */
+    this.alignment = config.button.alignment === 'left' ? 'left' : 'right',
 
     /**
      * Configuration for the panel.


### PR DESCRIPTION
Previously we were trying to access the config.button.alignment before we determined whether or not config.button was present. Updated to access alignment after the config.button is null checked.

TEST=manual

Specify no button config, see no JS error about accessing properties of undefined config.button.