### PR TITLE
Remove conditional button hiding logic in Overlay

### DIFF
--- a/static/js/overlay/parent-frame/controllers/overlay.js
+++ b/static/js/overlay/parent-frame/controllers/overlay.js
@@ -36,7 +36,7 @@ export default class Overlay {
     const mediator = new ActionDirector({
       iframeEl: document.querySelector(`#${Selectors.IFRAME_ID}`),
       buttonFrameEl: document.querySelector(`#${Selectors.BUTTON_FRAME_ID}`),
-      hideButtonWhenCollapsed: this.config.hideDefaultButton,
+      shouldShowButton: !this.config.hideDefaultButton,
       iframeBackground: this.config.iframeBackground,
       alignment: this.config.alignment
     });

--- a/static/js/overlay/parent-frame/dom/expando.js
+++ b/static/js/overlay/parent-frame/dom/expando.js
@@ -19,7 +19,7 @@ export default class Expando {
     /**
      * @type {boolean}
      */
-    this._hideButtonWhenCollapsed = config.hideButtonWhenCollapsed;
+    this._shouldShowButton = config.shouldShowButton;
 
     /**
      * @type {boolean}
@@ -54,7 +54,7 @@ export default class Expando {
     this.shrink();
     this.collapse();
 
-    if (!this._hideButtonWhenCollapsed) {
+    if (this._shouldShowButton) {
       this._stylist.showButton();
     }
   }
@@ -68,10 +68,6 @@ export default class Expando {
     }
     this._isExpanded = false;
     this._stylist.applyCollapsedStyling();
-
-    if (this._hideButtonWhenCollapsed) {
-      this._stylist.hideButton();
-    }
     this._collapseCallback();
   }
 
@@ -83,10 +79,6 @@ export default class Expando {
       return;
     }
     this._isExpanded = true;
-
-    if (this._hideButtonWhenCollapsed) {
-      this._stylist.showButton();
-    }
     this._stylist.applyExpandedStyling(this._isTaller);
 
     this._expandCallback();

--- a/static/js/overlay/parent-frame/dom/stylist.js
+++ b/static/js/overlay/parent-frame/dom/stylist.js
@@ -144,15 +144,6 @@ export default class Stylist {
   }
 
   /**
-   * Adds styling to hide the button
-   */
-  hideButton() {
-    this._buttonFrameEl.style['opacity'] = '0';
-    this._buttonFrameEl.style['z-index'] = AnimationStyling.ZINDEX_HIDDEN;
-    this._buttonFrameEl.style['pointer-events'] = 'none';
-  }
-
-  /**
    * Sets the size of the button
    *
    * @param {Object}


### PR DESCRIPTION
Previously, with the "hideDefaultButton" config option set to true, we would conditionally hide or show the button based on the Overlay's expanded/collapsed state. Removing that logic to always hide the button if "hideDefaultButton" is true.

TEST=manual

Use custom selector and set hideDefaultButton to true. Click the custom button selector and see Overlay open and close without button appearing at all.