### PR TITLE
Rename foreground to text in Overlay config

### DIFF
--- a/static/js/overlay/parent-frame/models/overlayconfig.js
+++ b/static/js/overlay/parent-frame/models/overlayconfig.js
@@ -88,7 +88,7 @@ export default class OverlayConfig {
        * The foreground color of the button, accepts hex or rgb.
        * @type {String}
        */
-      foregroundColor: config.button.color.foreground || '#FFFFFF',
+      foregroundColor: config.button.color.text || '#FFFFFF',
     };
 
     /**
@@ -127,7 +127,7 @@ export default class OverlayConfig {
        * The foreground color of the panel, accepts hex or rgb.
        * @type {String}
        */
-      foregroundColor: config.panel.color.foreground || '#FFFFFF',
+      foregroundColor: config.panel.color.text || '#FFFFFF',
     };
   }
 }


### PR DESCRIPTION
Renamed to more closely match CSS convention. Established naming for colors are "color" and "background-color"; since "foreground-color" is not a norm we are removing it in favor of "text".

TEST=manual

Confirm that the color of the text/icon can still be updated with the new config name "text".