### PR TITLE
Update caniuse dependency

### DIFF
--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1860,9 +1860,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001090",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001090.tgz",
-      "integrity": "sha512-QzPRKDCyp7RhjczTPZaqK3CjPA5Ht2UnXhZhCI4f7QiB5JK6KEuZBxIzyWnB3wO4hgAj4GMRxAhuiacfw0Psjg==",
+      "version": "1.0.30001164",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
+      "integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg==",
       "dev": true
     },
     "caseless": {
@@ -7001,12 +7001,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.66"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001157",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz",
-          "integrity": "sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.592",

--- a/static/package.json
+++ b/static/package.json
@@ -43,18 +43,18 @@
   },
   "dependencies": {
     "bootstrap-sass": "^3.4.1",
+    "comment-json": "^3.0.2",
     "core-js": "^3.6.5",
     "css-vars-ponyfill": "^2.3.1",
+    "file-system": "^2.2.2",
     "font-awesome": "^4.7.0",
+    "fs-extra": "^8.1.0",
     "iframe-resizer": "^4.1.1",
     "is-mobile": "^2.2.2",
     "libphonenumber-js": "^1.7.51",
     "lodash.clonedeep": "^4.5.0",
-    "remove-files-webpack-plugin": "^1.4.3",
-    "comment-json": "^3.0.2",
-    "file-system": "^2.2.2",
-    "fs-extra": "^8.1.0",
-    "merge-options": "^2.0.0"
+    "merge-options": "^2.0.0",
+    "remove-files-webpack-plugin": "^1.4.3"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Updating the `caniuse` dependency since we are getting a warning that it is out of date. This PR also alphabetizes our package.json.

TEST=manual

Build and serve a site locally with this change, confirm that nothing looks suspiciously broken.