### PR TITLE
Revert open status fixed width

### DIFF
--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -133,7 +133,6 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
 
     @media (min-width: $breakpoint-mobile-max)
     {
-      width: 200px;
       padding-right: calc(var(--hh-location-standard-base-spacing) * 2);
     }
   }


### PR DESCRIPTION
We're going to delay this fix until 1.18. This reverts #514 and #494

J=none
Test=visual

View an answers site with this change and confirm it looks the same as 1.16