### PR TITLE
Add `@root.` prefix to {{relativePath}} in all cards/dacards templates

### DIFF
--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -25,7 +25,7 @@
 {{#if card.image}}
 <div class="HitchhikerFinancialProfessionalLocation-imgWrapper">
   <img class="HitchhikerFinancialProfessionalLocation-img"
-  src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"
+  src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"
   alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
@@ -44,7 +44,7 @@
 <div class="HitchhikerFinancialProfessionalLocation-title">
   {{#if card.url}}
   <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isAbsoluteUrl card.url}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -162,7 +162,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerFinancialProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>
@@ -150,7 +150,7 @@
 <div class="HitchhikerLocationStandard-title">
   {{#if card.titleUrl}}
   <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
-    href="{{#unless (isAbsoluteUrl card.titleUrl)}}{{relativePath}}/{{/unless}}{{card.titleUrl}}"
+    href="{{#unless (isAbsoluteUrl card.titleUrl)}}{{@root.relativePath}}/{{/unless}}{{card.titleUrl}}"
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -25,7 +25,7 @@
 {{#if card.image}}
 <div class="HitchhikerFinancialProfessionalLocation-imgWrapper">
   <img class="HitchhikerFinancialProfessionalLocation-img"
-    src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"
+    src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"
     alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
@@ -44,7 +44,7 @@
 <div class="HitchhikerFinancialProfessionalLocation-title">
   {{#if card.url}}
   <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -162,7 +162,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerFinancialProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>
@@ -150,7 +150,7 @@
 <div class="HitchhikerLocationStandard-title">
   {{#if card.titleUrl}}
   <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
-    href="{{#unless (isAbsoluteUrl card.titleUrl)}}{{relativePath}}/{{/unless}}{{card.titleUrl}}"
+    href="{{#unless (isAbsoluteUrl card.titleUrl)}}{{@root.relativePath}}/{{/unless}}{{card.titleUrl}}"
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-product-prominentimage-clickable/template.hbs
+++ b/cards/multilang-product-prominentimage-clickable/template.hbs
@@ -1,7 +1,7 @@
 <div class="HitchhikerProductProminentImage {{cardName}}">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImageClickable-link"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
@@ -29,7 +29,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if card.tag}}

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -21,7 +21,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if card.tag}}
@@ -34,7 +34,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -100,7 +100,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -109,7 +109,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/product-prominentimage-clickable/template.hbs
+++ b/cards/product-prominentimage-clickable/template.hbs
@@ -1,7 +1,7 @@
 <div class="HitchhikerProductProminentImageClickable {{cardName}}">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImageClickable-link"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
@@ -29,7 +29,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if (all card.image card.tag) }}

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -21,7 +21,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if (all card.image card.tag) }}
@@ -34,7 +34,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -100,7 +100,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -109,7 +109,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (isAbsoluteUrl link)}}{{relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (isAbsoluteUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (isAbsoluteUrl link)}}{{relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (isAbsoluteUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>


### PR DESCRIPTION
Certains cards reference {{relativePath}} inside of
an inline partial, like a CTA partial (see the standard card)
Since relativePath is passed into all cards at the root context,
through the SDK's setState(), all cards will have relativePath
as part of their root context.

TEST=manual

in the standard card:
test that I can create a custom card, and add a hardcoded cta
with an iconUrl pointing to a static asset

test that relative links still work in the standard card cta