### PR TITLE
rename isAbsoluteUrl to isNonRelativeUrl

### DIFF
--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -25,7 +25,7 @@
 {{#if card.image}}
 <div class="HitchhikerFinancialProfessionalLocation-imgWrapper">
   <img class="HitchhikerFinancialProfessionalLocation-img"
-  src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"
+  src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"
   alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
@@ -44,7 +44,7 @@
 <div class="HitchhikerFinancialProfessionalLocation-title">
   {{#if card.url}}
   <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isNonRelativeUrl card.url}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -162,7 +162,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerFinancialProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>
@@ -150,7 +150,7 @@
 <div class="HitchhikerLocationStandard-title">
   {{#if card.titleUrl}}
   <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
-    href="{{#unless (isAbsoluteUrl card.titleUrl)}}{{@root.relativePath}}/{{/unless}}{{card.titleUrl}}"
+    href="{{#unless (isNonRelativeUrl card.titleUrl)}}{{@root.relativePath}}/{{/unless}}{{card.titleUrl}}"
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -14,7 +14,7 @@
         <div class="HitchhikerEventStandard-title">
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
-              href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+              href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
               data-eventtype="TITLE_CLICK"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -88,7 +88,7 @@
 
 {{#*inline 'CTA'}}
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -96,7 +96,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -76,7 +76,7 @@
 
 {{#*inline 'CTA'}}
 <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+   href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
    data-eventtype="{{eventType}}"
    data-eventoptions='{{json eventOptions}}'
    target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -84,7 +84,7 @@
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+      "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
       "iconName": "{{iconName}}"
     }'>
     </div>

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -25,7 +25,7 @@
 {{#if card.image}}
 <div class="HitchhikerFinancialProfessionalLocation-imgWrapper">
   <img class="HitchhikerFinancialProfessionalLocation-img"
-    src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"
+    src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"
     alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
@@ -44,7 +44,7 @@
 <div class="HitchhikerFinancialProfessionalLocation-title">
   {{#if card.url}}
   <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -162,7 +162,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerFinancialProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerJobStandard-imgWrapper">
-  <img class="HitchhikerJobStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerJobStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerJobStandard-title">
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -90,14 +90,14 @@
 {{#*inline 'CTA'}}
 {{#if (all url label)}}
 <div class="HitchhikerJobStandard-{{ctaName}}">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -13,7 +13,7 @@
 <div class="HitchhikerLinkStandard-title">
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -54,7 +54,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerLocationStandard-imgWrapper">
-  <img class="HitchhikerLocationStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerLocationStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -80,7 +80,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerLocationStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -88,7 +88,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>
@@ -150,7 +150,7 @@
 <div class="HitchhikerLocationStandard-title">
   {{#if card.titleUrl}}
   <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
-    href="{{#unless (isAbsoluteUrl card.titleUrl)}}{{@root.relativePath}}/{{/unless}}{{card.titleUrl}}"
+    href="{{#unless (isNonRelativeUrl card.titleUrl)}}{{@root.relativePath}}/{{/unless}}{{card.titleUrl}}"
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -25,7 +25,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerMenuItemStandard-imgWrapper">
-  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerMenuItemStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -34,7 +34,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -109,7 +109,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerMenuItemStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -117,7 +117,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-product-prominentimage-clickable/template.hbs
+++ b/cards/multilang-product-prominentimage-clickable/template.hbs
@@ -1,7 +1,7 @@
 <div class="HitchhikerProductProminentImage {{cardName}}">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImageClickable-link"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
@@ -29,7 +29,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if card.tag}}

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -21,7 +21,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if card.tag}}
@@ -34,7 +34,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -100,7 +100,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -109,7 +109,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/product-prominentimage-clickable/template.hbs
+++ b/cards/product-prominentimage-clickable/template.hbs
@@ -1,7 +1,7 @@
 <div class="HitchhikerProductProminentImageClickable {{cardName}}">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImageClickable-link"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
@@ -29,7 +29,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if (all card.image card.tag) }}

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -21,7 +21,7 @@
 {{/if}}
   {{#if card.image}}
   <div class="HitchhikerProductProminentImage-imgWrapper">
-    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+    <img class="HitchhikerProductProminentImage-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
   </div>
   {{/if}}
 {{#if (all card.image card.tag) }}
@@ -34,7 +34,7 @@
 <div class="HitchhikerProductProminentImage-title">
   {{#if card.url}}
   <a class="HitchhikerProductProminentImage-titleLink"
-    href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+    href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
     data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}'>
@@ -100,7 +100,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductProminentImage-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -109,7 +109,7 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon"
         data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -22,7 +22,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProductStandard-imgWrapper">
-  <img class="HitchhikerProductStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProductStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -31,7 +31,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -87,7 +87,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProductStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target={{#if target}}"{{target}}"{{else}}"_top"{{/if}}
@@ -95,7 +95,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
       </div>
     </div>
     {{/if}}

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -24,7 +24,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalLocation-imgWrapper">
-  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
+  <img class="HitchhikerProfessionalLocation-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}" />
 </div>
 {{/if}}
 {{/inline}}
@@ -41,7 +41,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+  <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -159,7 +159,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalLocation-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -167,7 +167,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'>
       </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -17,7 +17,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerProfessionalStandard-imgWrapper">
-  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
+  <img class="HitchhikerProfessionalStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}"  {{#if card.altText}} alt="{{card.altText}}"{{/if}}/>
 </div>
 {{/if}}
 {{/inline}}
@@ -26,7 +26,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
@@ -126,7 +126,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerProfessionalStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -134,7 +134,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -15,7 +15,7 @@
 {{#*inline 'image'}}
 {{#if card.image}}
 <div class="HitchhikerStandard-imgWrapper">
-  <img class="HitchhikerStandard-img" src="{{#unless (isAbsoluteUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+  <img class="HitchhikerStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
 </div>
 {{/if}}
 {{/inline}}
@@ -25,7 +25,7 @@
 <div class="HitchhikerStandard-title">
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
-     href="{{#unless (isAbsoluteUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      data-eventtype="TITLE_CLICK"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
@@ -91,7 +91,7 @@
 {{#if (all url label)}}
 <div class="HitchhikerStandard-{{ctaName}}">
   <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
-    href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}"
     data-eventoptions='{{json eventOptions}}'
     target="{{#if target}}{{target}}{{else}}_top{{/if}}"
@@ -99,7 +99,7 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (isAbsoluteUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (isNonRelativeUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (isNonRelativeUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -23,7 +23,7 @@
   data-component="IconComponent"
   data-opts='{
     "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
+    "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
   }'
   data-prop="icon"
 ></div>
@@ -35,7 +35,7 @@
 <h2 class="HitchhikerAllFieldsStandard-titleText">
   {{#if link}}
   <a class="HitchhikerAllFieldsStandard-titleLink"
-    href="{{#unless (isAbsoluteUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
+    href="{{#unless (isNonRelativeUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
     data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
@@ -92,7 +92,7 @@
 
 {{#*inline 'value_link'}}
 <a class="HitchhikerAllFieldsStandard-fieldValueLink"
-   href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{{url}}}"
+   href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{{url}}}"
    target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
    {{#if eventOptions}}data-eventoptions='{{{json eventOptions}}}'{{/if}}>
@@ -104,7 +104,7 @@
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerAllFieldsStandard-viewMoreWrapper">
     <a class="HitchhikerAllFieldsStandard-viewMore"
-        href="{{#unless (isAbsoluteUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        href="{{#unless (isNonRelativeUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"
         data-eventoptions='{{{json viewDetailsEventOptions}}}'
         target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
@@ -171,13 +171,13 @@
 {{#*inline 'cta'}}
 {{#if (all url label)}}
 <div class="HitchhikerAllFieldsStandard-cta">
-  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isAbsoluteUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
     data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isAbsoluteUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
+        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
         "iconName": "{{iconName}}"
       }'></div>
     </div>

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -42,13 +42,13 @@
     <meta property="og:type" content="website">
     {{#if global_config.logo}}
       <meta property="og:image"
-        content="{{#unless (isAbsoluteUrl global_config.logo)}}{{relativePath}}/{{/unless}}{{global_config.logo}}" />
+        content="{{#unless (isNonRelativeUrl global_config.logo)}}{{relativePath}}/{{/unless}}{{global_config.logo}}" />
     {{/if}}
     {{#if canonicalUrl}}
       <meta property="og:url"
-        content="{{#unless (isAbsoluteUrl canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
+        content="{{#unless (isNonRelativeUrl canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
       <link rel="canonical"
-        href="{{#unless (isAbsoluteUrl canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
+        href="{{#unless (isNonRelativeUrl canonicalUrl)}}{{relativePath}}/{{/unless}}{{canonicalUrl}}" />
     {{else if env.JAMBO_INJECTED_DATA.pages.domains.prod.domain}}
       {{#with env.JAMBO_INJECTED_DATA.pages.domains.prod}}
         <meta property="og:url" content="{{#if isHttps}}https://{{else}}http://{{/if}}{{domain}}">
@@ -63,7 +63,7 @@
 
     {{#if global_config.favicon}}
       <link rel="shortcut icon"
-        href="{{#unless (isAbsoluteUrl global_config.favicon)}}{{relativePath}}/{{/unless}}{{global_config.favicon}}" />
+        href="{{#unless (isNonRelativeUrl global_config.favicon)}}{{relativePath}}/{{/unless}}{{global_config.favicon}}" />
     {{/if}}
     <script>
       document.addEventListener('DOMContentLoaded', function () {

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -70,7 +70,7 @@
          * Determine whether a URL is absolute or not.
          * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com"
          */
-        ANSWERS.registerHelper('isAbsoluteUrl', function(str) {
+        ANSWERS.registerHelper('isNonRelativeUrl', function(str) {
           const absoluteURLRegex = /^(\/|[a-zA-Z]+:)/;
           return str && str.match(absoluteURLRegex);
         });

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -37,27 +37,27 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
   {{/if}}
   modifier: "{{{verticalKey}}}",
   {{#if url}}
-    url: "{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}",
+    url: "{{#unless (isNonRelativeUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        url: "{{#unless (isAbsoluteUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}",
+        url: "{{#unless (isNonRelativeUrl url)}}{{relativePath}}/{{/unless}}{{{url}}}",
       }
     ],
   {{else if pagePath}}
-    url: "{{#unless (isAbsoluteUrl pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
+    url: "{{#unless (isNonRelativeUrl pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        pageUrl: "{{#unless (isAbsoluteUrl pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
+        pageUrl: "{{#unless (isNonRelativeUrl pagePath)}}{{relativePath}}/{{/unless}}{{{pagePath}}}",
       }
     ],
   {{else if pageName}}
-    url: "{{#unless (isAbsoluteUrl pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
+    url: "{{#unless (isNonRelativeUrl pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
     verticalPages: [ // TODO remove this once the theme version does not support pre-v1.3 of the SDK
       {
         verticalKey: "{{{verticalKey}}}",
-        url: "{{#unless (isAbsoluteUrl pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
+        url: "{{#unless (isNonRelativeUrl pageName)}}{{relativePath}}/{{/unless}}{{{pageName}}}.html",
       }
     ],
   {{/if}}
@@ -70,7 +70,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
   {{#if icon}}
     sectionTitleIconName: "{{{icon}}}",
   {{/if}}
-  {{#if iconUrl}}sectionTitleIconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+  {{#if iconUrl}}sectionTitleIconUrl: "{{#unless (isNonRelativeUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
   viewAllText: {{#if viewAllText}}"{{{viewAllText}}}"{{else}}{{ translateJS phrase='View All' context='View is a verb' }}{{/if}},
   {{#if viewMore}}viewMore: {{viewMore}},{{/if}}
   {{#if mapConfig}}

--- a/templates/vertical-grid/script/verticalresults.hbs
+++ b/templates/vertical-grid/script/verticalresults.hbs
@@ -14,7 +14,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{#unless (isNonRelativeUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
         label: "{{> verticalLabel overridedLabel=label verticalKey=../verticalKey fallback=@key}}",
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}

--- a/templates/vertical-map/script/verticalresults.hbs
+++ b/templates/vertical-map/script/verticalresults.hbs
@@ -14,7 +14,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{#unless (isNonRelativeUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
         label: "{{> verticalLabel overridedLabel=label verticalKey=../verticalKey fallback=@key}}",
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}

--- a/templates/vertical-standard/script/verticalresults.hbs
+++ b/templates/vertical-standard/script/verticalresults.hbs
@@ -14,7 +14,7 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
         {{#with (lookup verticalsToConfig verticalKey)}}
         {{#if isFirst}}isFirst: {{isFirst}},{{/if}}
         {{#if icon}}icon: "{{{icon}}}",{{/if}}
-        {{#if iconUrl}}iconUrl: "{{#unless (isAbsoluteUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
+        {{#if iconUrl}}iconUrl: "{{#unless (isNonRelativeUrl iconUrl)}}{{relativePath}}/{{/unless}}{{{iconUrl}}}",{{/if}}
         label: "{{> verticalLabel overridedLabel=label verticalKey=../verticalKey fallback=@key}}",
         url: "{{#if url}}{{{url}}}{{else if ../url}}{{../../relativePath}}/{{{../url}}}{{else}}{{{@key}}}.html{{/if}}",
         {{/with}}


### PR DESCRIPTION
The hbs helper isAbsoluteUrl was also matching
on urls that only started with a single backslash,
since those don't need {{relativePath}} to be appended
to them. Technically, though, those urls are root-relative urls,
not absolute urls.

TEST=manual

test that a static asset iconUrl in the standard card cta,
and a favicon that points to a static asset, both work