### PR TITLE
ios radio button styling

### DIFF
--- a/static/scss/answers/common/base.scss
+++ b/static/scss/answers/common/base.scss
@@ -106,7 +106,7 @@ input
   text-decoration: none;
 }
 
-/* Default radio button styling for ios safari */
+/* Default radio button styling for ios */
 input[type='radio']
 {
   border-width: 1px;


### PR DESCRIPTION
This commit adds radio button styling on ios safari/chrome.
Our css reset wipes out the radio button styling on ios
and turns them into square boxes, and for whatever reason
this is only an issue on ios. I originally tried updating
our css reset to be `input:not([type='radio'])` instead of
just `input` but this actually increases the specificity of
the reset and has unintended consequences (like weird searchbar
spacing)

J=SLAP-877
TEST=manual

tested that on desktop: safari, chrome, firefox, ie11 (browserstack)
and android, radio button styling has not changed

tested that on ios safari/chrome the radio buttons look like radio buttons