### PR TITLE
Collapsible Filters: collapse filters when above results (standard/grid)

### DIFF
--- a/static/scss/answers/collapsible-filters/collapsible-filters-templates.scss
+++ b/static/scss/answers/collapsible-filters/collapsible-filters-templates.scss
@@ -1,12 +1,20 @@
 .AnswersVerticalMap.CollapsibleFilters {
   @include CollapsibleFilters;
 
+  .Answers-viewResultsButton {
+    left: 0;
+
+    @include bpgte(sm) {
+      width: 50%;
+    }
+  }
+
   .CollapsibleFilters {
     &-inactive {
       display: none;
     }
 
-    @media (min-width: $container-tablet-base) {
+    @include bpgte(sm) {
       &-inactive.Answers-footer {
         display: flex;
       }
@@ -20,7 +28,7 @@
 
 .AnswersVerticalStandard.CollapsibleFilters,
 .AnswersVerticalGrid.CollapsibleFilters {
-  @media (max-width: $container-tablet-base) {
+  @include bplte(md) {
     @include CollapsibleFilters;
 
     .CollapsibleFilters-inactive {
@@ -34,9 +42,18 @@
     .yxt-SpellCheck {
       padding-top: calc(var(--yxt-base-spacing) * 2);
     }
+
+    .Answers-viewResultsButton {
+      max-width: 700px;
+
+      @include bplte(xs) {
+        max-width: $breakpoint-mobile-max;
+        left: 0;
+      }
+    }
   }
 
-  @media (min-width: $container-tablet-base) {
+  @include bpgte(lg) {
     .Answers-filterLink,
     .Answers-viewResultsButton {
       display: none;

--- a/static/scss/answers/collapsible-filters/collapsible-filters.scss
+++ b/static/scss/answers/collapsible-filters/collapsible-filters.scss
@@ -22,16 +22,11 @@
     &-viewResultsButton {
       position: fixed;
       width: 100%;
-      left: 0;
       bottom: 0;
       padding: 4px 8px;
       background-color: var(--hh-answers-background-color);
       z-index: $nav-wrapper-z-index;
       transition: top 0.4s ease-out;
-
-      @include bpgte(sm) {
-        width: 50%;
-      }
     }
 
     &-filtersWrapper {


### PR DESCRIPTION
On vertical-standard/grid w/collapsible filters, when the page is
<768px wide, we get collapsible filters, and when the page is
>1200px wide we get the filters on the left sidebar. In between that,
the filters go into an intermediate state where they are above the results.
This commit replaces that intermediate state with collapsible filters.

J=SLAP-833
TEST=manual

test that on a vertical standard page with collapsible facets + sort options,
there is no more intermediate state.