### PR TITLE
Update open status styling

### DIFF
--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -14,7 +14,7 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
     {
       flex-direction: column;
 
-      @include bpgte(lg)
+      @media (min-width: $screen-lg-min)
       {
         flex-direction: row;
       }
@@ -34,7 +34,7 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
     {
       flex-direction: column;
 
-      @include bpgte(lg)
+      @media (min-width: $screen-lg-min)
       {
         flex-direction: row;
       }
@@ -44,7 +44,7 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
     {
       margin-left: 0;
 
-      @include bpgte(lg)
+      @media (min-width: $screen-lg-min)
       {
         margin-left: calc(var(--hh-location-standard-base-spacing) / 2);
       }


### PR DESCRIPTION
Improve the scss of the location-standard card

This change serves several purposes:
- It aligns the open status info on the location cards
- It causes long text to wrap within it's own div rather than causing the surrounding divs to wrap
- It allows all the divs to snap at the same time as the page is resized

I used hard-coded pixel values for the div widths because we want the divs to snap as the window is resized rather wrapping the text itself.

The `$screen-lg-min` breakpoint causes the CTAs to wrap a little sooner. This is necessary on vertical-map pages to prevent a horizontal scroll bar from appearing as the window is made smaller.

Some of the SCSS changes are specific to the vertical map page because the breakpoint at 1200px doesn't make sense on the vertical-standard page since the card doesn't resize with the page.

J=SLAP-902
Test=visual

Observe the page and various sizes and with text of various lengths and make sure it looks good. Rose signed off on this styling as well.