### PR TITLE
collapsible filters: fix viewresultsbutton ie11 css

### DIFF
--- a/static/scss/answers/collapsible-filters/collapsible-filters-templates.scss
+++ b/static/scss/answers/collapsible-filters/collapsible-filters-templates.scss
@@ -57,10 +57,13 @@
 
     .Answers-viewResultsButton {
       max-width: 700px;
+      left: 50%;
+      transform: translateX(-50%);
 
       @include bplte(xs) {
         max-width: $breakpoint-mobile-max;
         left: 0;
+        transform: none;
       }
     }
   }


### PR DESCRIPTION
Without this css, in ie11 between screen widths
768px to 1200px the view results button will be
far off to the right side of the screen (ie11 only).

J=SLAP-930
TEST=manual

test that in chrome/ie11, view results button is centered
in this 768-1200px state

check that when screen < 768px the button still looks correct
(full width and fixed to bottom of screen)