### PR TITLE
Add postimport script

### DIFF
--- a/postimport.js
+++ b/postimport.js
@@ -8,7 +8,7 @@ const themeName = 'answers-hitchhiker-theme';
 const themeDir = path.join('themes', themeName);
 copyTopLevelStaticFiles(themeDir);
 // npm install needed for things like comment-json
-spawnSync('npm', ['install'], { stdio: 'inherit'} );
+spawnSync('npm', ['install'], { stdio: 'inherit' });
 
 const { assign, stringify } = require('comment-json');
 
@@ -34,7 +34,7 @@ function copyTopLevelStaticFiles(themeDir) {
     'webpack-config.js',
   ];
   const themeStaticDir = path.join(themeDir, 'static');
-  syncContents(themeStaticDir, '', packageJsonFiles)
+  syncContents(themeStaticDir, '', packageJsonFiles);
 }
 
 /**
@@ -73,7 +73,7 @@ function copyStaticFiles(themeDir) {
     !fs.existsSync(dir) && fs.mkdirSync(dir);
   });
   const themeStaticDir = path.join(themeDir, 'static');
-  syncContents(themeStaticDir, 'static', scssFiles)
+  syncContents(themeStaticDir, 'static', scssFiles);
 }
 
 /**
@@ -86,7 +86,7 @@ function jamboOverrideLayoutFiles() {
     'layouts/header.hbs',
     'layouts/footer.hbs',
     'layouts/headincludes.hbs',
-  ]
+  ];
   files.forEach(filePath => {
     spawnSync('npx', ['jambo', 'override', '--path', filePath], { stdio: 'inherit' })
   });


### PR DESCRIPTION
This is a script that will be automatically be run after jambo import.
An npm install is run after copying over the theme's package and package-lock
.json files. This is so that the script can have access to comment-json.
Otherwise, comment-json would already have to be present in node_modules,
either through a local jambo (which doesn't work if using a globally
installed jambo) or some other way.

J=SLAP-833
TEST=manual

check that all needed files are copied over, the
defaultTheme in jambo.json is updated, locale_config
and global_config are copied to config/, and layout
files are jambo overridden properly (added to
jambo.json partials and copied over)