### PR TITLE
bump jambo ver 1.9.4 -> 1.9.6

### DIFF
--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -4273,9 +4273,9 @@
       "dev": true
     },
     "jambo": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.9.4.tgz",
-      "integrity": "sha512-YpwNtdHLVMWkUajnC6FGA3WQNkyA8lnkhyl9hPpNatwFW2RnO1mdlP7NL+ywzz+5fOTzXZ3ZHpgVsH6oi0IDyQ==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.9.6.tgz",
+      "integrity": "sha512-ZPvwJXUblk+rDgl6lhlD4bMs3wpOFanBmcqjeszIDMGVdnIOIcQwgvJ8urUpnRaX2HAXIGB3hCM8OQicYebgiA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.6",

--- a/static/package.json
+++ b/static/package.json
@@ -30,7 +30,7 @@
     "grunt-webpack": "^4.0.0",
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
-    "jambo": "^1.9.4",
+    "jambo": "^1.9.6",
     "jsdom": "^16.4.0",
     "mini-css-extract-plugin": "^0.11.0",
     "node-sass": "^4.13.1",


### PR DESCRIPTION
TEST=manual

test building the dime v1.18 test site,
and also upgrading the theme with the dev/bump-jambo branch