### PR TITLE
html-asset-loader: handle trailing escapes, single quotes, relativePath in card templates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,24 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Run Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1400,6 +1400,12 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
+    "@yext/cta-formatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@yext/cta-formatter/-/cta-formatter-1.0.0.tgz",
+      "integrity": "sha512-PWMTmGSundx7gfy9C+7OdxwBaqKwcJjZbl+z41sTeqlG1IpvP7xMkbRXfMEt9nyj5v2QNTEkUYrTDiOq7K61sA==",
+      "dev": true
+    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -1733,6 +1739,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2261,6 +2273,12 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -2600,10 +2618,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.67.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2812,12 +2827,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
     },
     "import-local": {
       "version": "3.0.2",
@@ -3725,11 +3734,28 @@
         "type-check": "~0.3.2"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.6.tgz",
+      "integrity": "sha512-Ob419L88HxP3iVXPMI1Z/146izHrUPcV70ClnoP9WyNBgdy6mtlkCxx4ewMDmCzsdY5D4diDOUz8kboqLdKBoQ==",
+      "dev": true
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "loader-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      }
     },
     "locate-path": {
       "version": "5.0.0",
@@ -3744,6 +3770,12 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.sortby": {
@@ -5398,6 +5430,16 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "underscore.string": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -5497,6 +5539,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,17 @@
   "devDependencies": {
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
+    "@yext/cta-formatter": "^1.0.0",
     "babel-jest": "^25.5.1",
     "comment-json": "^4.1.0",
     "cross-env": "^7.0.2",
     "full-icu": "^1.3.1",
     "jest": "^25.5.2",
-    "simple-git": "^2.24.0"
+    "libphonenumber-js": "^1.9.6",
+    "loader-utils": "^2.0.0",
+    "lodash.clonedeep": "^4.5.0",
+    "simple-git": "^2.24.0",
+    "underscore.string": "^3.3.5"
   },
   "jest": {
     "verbose": true,
@@ -34,6 +39,9 @@
     ],
     "testMatch": [
       "<rootDir>/tests/**/*.js"
+    ],
+    "testPathIgnorePatterns": [
+      "/fixtures/"
     ]
   }
 }

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -125,9 +125,6 @@ module.exports = function () {
           use: [
             {
               loader: path.resolve(__dirname, `./${jamboConfig.dirs.output}/static/webpack/html-asset-loader.js`),
-              options: {
-                regex: /\\"([./]*static\/assets\/[^"]*)\\"/g
-              }
             },
             {
               loader: 'html-loader',

--- a/tests/static/webpack/html-asset-loader/fixtures/output/htmlAttribute.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/output/htmlAttribute.js
@@ -1,0 +1,11 @@
+
+    var ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___ = function(staticAssetModule) {
+      const getHashedPath = require("html-loader/dist/runtime/getUrl.js");
+      return getHashedPath(staticAssetModule);
+    }
+var ___HTML_ASSET_LOADER_MATCH_0___ = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___(require('static/assets/chizuru.gif'));
+var ___HTML_ASSET_LOADER_MATCH_1___ = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___(require('static/assets/chizuru.gif'));
+// Module
+var code = "<img src=\"" + ___HTML_ASSET_LOADER_MATCH_0___ + "\"> <img src=\"../" + ___HTML_ASSET_LOADER_MATCH_1___ + "\">";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/fixtures/output/registerTemplate.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/output/registerTemplate.js
@@ -1,0 +1,10 @@
+
+    var ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___ = function(staticAssetModule) {
+      const getHashedPath = require("html-loader/dist/runtime/getUrl.js");
+      return getHashedPath(staticAssetModule);
+    }
+var ___HTML_ASSET_LOADER_MATCH_0___ = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___(require('static/assets/chizuru.gif'));
+// Module
+var code = "<script> ANSWERS.registerTemplate(\"cards/test-name\",\"<img src=\\\"{{@root.relativePath}}/" + ___HTML_ASSET_LOADER_MATCH_0___ + "\\\">\");</script> ";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/fixtures/output/singleQuotes.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/output/singleQuotes.js
@@ -1,0 +1,11 @@
+
+    var ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___ = function(staticAssetModule) {
+      const getHashedPath = require("html-loader/dist/runtime/getUrl.js");
+      return getHashedPath(staticAssetModule);
+    }
+var ___HTML_ASSET_LOADER_MATCH_0___ = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___(require('static/assets/chizuru.gif'));
+var ___HTML_ASSET_LOADER_MATCH_1___ = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___(require('static/assets/chizuru.gif'));
+// Module
+var code = "<script> ANSWERS.registerTemplate(\"cards/test-name\",\"<img src='" + ___HTML_ASSET_LOADER_MATCH_0___ + "'>\\n<img src='../../" + ___HTML_ASSET_LOADER_MATCH_1___ + "'>\");</script> ";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/fixtures/output/stringInJs.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/output/stringInJs.js
@@ -1,0 +1,11 @@
+
+    var ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___ = function(staticAssetModule) {
+      const getHashedPath = require("html-loader/dist/runtime/getUrl.js");
+      return getHashedPath(staticAssetModule);
+    }
+var ___HTML_ASSET_LOADER_MATCH_0___ = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___(require('static/assets/chizuru.gif'));
+var ___HTML_ASSET_LOADER_MATCH_1___ = ___HTML_ASSET_LOADER_GET_SOURCE_FROM_IMPORT___(require('static/assets/chizuru.gif'));
+// Module
+var code = "<script> var b=\"" + ___HTML_ASSET_LOADER_MATCH_0___ + "\";var c=\"../../../" + ___HTML_ASSET_LOADER_MATCH_1___ + "\";</script> ";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/fixtures/source/htmlAttribute.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/source/htmlAttribute.js
@@ -1,0 +1,4 @@
+// Module
+var code = "<img src=\"static/assets/chizuru.gif\"> <img src=\"../static/assets/chizuru.gif\">";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/fixtures/source/registerTemplate.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/source/registerTemplate.js
@@ -1,0 +1,4 @@
+// Module
+var code = "<script> ANSWERS.registerTemplate(\"cards/test-name\",\"<img src=\\\"{{@root.relativePath}}/static/assets/chizuru.gif\\\">\");</script> ";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/fixtures/source/singleQuotes.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/source/singleQuotes.js
@@ -1,0 +1,4 @@
+// Module
+var code = "<script> ANSWERS.registerTemplate(\"cards/test-name\",\"<img src='static/assets/chizuru.gif'>\\n<img src='../../static/assets/chizuru.gif'>\");</script> ";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/fixtures/source/stringInJs.js
+++ b/tests/static/webpack/html-asset-loader/fixtures/source/stringInJs.js
@@ -1,0 +1,4 @@
+// Module
+var code = "<script> var b=\"static/assets/chizuru.gif\";var c=\"../../../static/assets/chizuru.gif\";</script> ";
+// Exports
+module.exports = code;

--- a/tests/static/webpack/html-asset-loader/html-asset-loader.js
+++ b/tests/static/webpack/html-asset-loader/html-asset-loader.js
@@ -1,0 +1,43 @@
+import HtmlAssetLoader from '../../../../static/webpack/html-asset-loader';
+const fs = require('fs');
+const path = require('path');
+
+it('works inside ANSWERS.registerTemplate() calls using relativePath', () => {
+  const { source, output } = getFixture('registerTemplate');
+  const actualOutput = HtmlAssetLoader.call({}, source);
+  expect(actualOutput).toEqual(output);
+});
+
+it('works for static assets in string in js', () => {
+  const { source, output } = getFixture('stringInJs');
+  const actualOutput = HtmlAssetLoader.call({}, source);
+  expect(actualOutput).toEqual(output);
+});
+
+it('works for static assets in regular html', () => {
+  const { source, output } = getFixture('htmlAttribute');
+  const actualOutput = HtmlAssetLoader.call({}, source);
+  expect(actualOutput).toEqual(output);
+});
+
+it('works for static assets specified using single quotes', () => {
+  const { source, output } = getFixture('singleQuotes');
+  const actualOutput = HtmlAssetLoader.call({}, source);
+  expect(actualOutput).toEqual(output);
+});
+
+/**
+ * Returns the source string (from html-loader), and the output we expect
+ * html-asset-loader to create from it.
+ * 
+ * @param {string} fixtureName
+ * @returns {{{source: string, output: string}}}
+ */
+function getFixture(fixtureName) {
+  const srcPath = path.resolve(__dirname, 'fixtures', 'source', fixtureName + '.js');
+  const outputPath = path.resolve(__dirname, 'fixtures', 'output', fixtureName + '.js');
+  return {
+    source: fs.readFileSync(srcPath, 'utf-8'),
+    output: fs.readFileSync(outputPath, 'utf-8')
+  }
+}


### PR DESCRIPTION
This commit updates the html-asset-loader to not match on trailing escape
characters. The issue was that, a double quote inside
of a card template needs to be escaped two times in a webpack source. The
first time is inside the registerTemplate string, because babel will take
the template string backtik and change it into double quotes. The second
time is within the webpack source itself, where the source is put into a
(see new tests/fixtures). Pre theme 1.17, this extra escape would be removed by
the html-loader's minifyJS option. However, this option was turned off in
1.17 to increase the webpack speed, but the html-asset-loader should be
able to handle this.

the regex was also not suited to match on {{relativePath}} prefixes in
card templates, since the relativePath in cards is computed at runtime
the regex had to also be able to match on the handlebars logic somebody
could use to specify the path.

Also updated the regex to match on single quotes as well as double quotes.
html-loader currently will transform all single quote html attributes,
like src='static/assets/blah.jpg', to double quotes, but it will not do
that within a card's template.hbs (because the template is a js string).

also moved the regex out of the webpack config into the loader itself,
since it's more of an implementation detail. you can still override
it, if you want, but wouldn't recommend this to most hitchhikers.

finally adds a github workflow to run tests

TEST=manual, auto

test that the jinya ramen bar site can specify static assets in its template.hbs-es
again (also tested adding relativePath in)

test that I can still specify a static asset inside component.js like a cta iconUrl

test favicons (tested with pages at root output directory level, and also nested in a directory)

test that both single quotes and double quotes around the static asset work