### PR TITLE
templates: add overlays partial to all vertical pages

### DIFF
--- a/templates/vertical-grid/page.html.hbs
+++ b/templates/vertical-grid/page.html.hbs
@@ -23,7 +23,7 @@
       </div>
     </div>
     <!-- Uncomment the following if you want to include an overlay on the page -->
-    <!-- You should only use one overlay partial per site, e.g. if you use uncomment the
+    <!-- The overlay should be used on at most one page of your site, e.g. if you use uncomment the
     partial for a location page, you should not use it on any other page.  -->
     {{!-- {{> layouts/overlay-suggestions }} --}}
     <div class="Answers-container Answers-resultsWrapper Hitchhiker-3-columns">

--- a/templates/vertical-map/page.html.hbs
+++ b/templates/vertical-map/page.html.hbs
@@ -24,7 +24,7 @@
       </div>
     </div>
     <!-- Uncomment the following if you want to include an overlay on the page -->
-    <!-- You should only use one overlay partial per site, e.g. if you use uncomment the
+    <!-- The overlay should be used on at most one page of your site, e.g. if you use uncomment the
     partial for a location page, you should not use it on any other page.  -->
     {{!-- {{> layouts/overlay-suggestions }} --}}
     <div class="Answers-resultsWrapper js-answersResultsWrapper">

--- a/templates/vertical-standard/page.html.hbs
+++ b/templates/vertical-standard/page.html.hbs
@@ -23,7 +23,7 @@
       </div>
     </div>
     <!-- Uncomment the following if you want to include an overlay on the page -->
-    <!-- You should only use one overlay partial per site, e.g. if you use uncomment the
+    <!-- The overlay should be used on at most one page of your site, e.g. if you use uncomment the
     partial for a location page, you should not use it on any other page.  -->
     {{!-- {{> layouts/overlay-suggestions }} --}}
     <div class="Answers-container Answers-resultsWrapper">


### PR DESCRIPTION
Adds the overlays partial to the vertical-grid, vertical-map,
and vertical-standard page templates.

The partial is left commented out on these page templates.

A comment about only enabling one partial is also added.

J=SLAP-938
TEST=none