### PR TITLE
add templatedataformatter hook

### DIFF
--- a/hooks/templatedataformatter.js
+++ b/hooks/templatedataformatter.js
@@ -10,6 +10,7 @@
  * @param {Object} siteLevelAttributes.env all environment variables, like JAMBO_INJECTED_DATA
  * 
  * @param {Object} pageNameToConfig object of pageName to pageConfig
+ * @returns {Object}
  */
 module.exports = function (pageMetadata, siteLevelAttributes, pageNameToConfig) {
   const { relativePath, pageName } = pageMetadata;
@@ -30,11 +31,12 @@ module.exports = function (pageMetadata, siteLevelAttributes, pageNameToConfig) 
 
 /**
  * Gets the global config, with experienceKey and locale added
- * to it from the currentLocaleConfig.
+ * to it.
  * 
  * @param {Object} globalConfig 
- * @param {string} currentLocaleConfig chunk of locale config for the current locale
+ * @param {Object} currentLocaleConfig chunk of locale config for the current locale
  * @param {string} locale the current locale
+ * @returns {Object}
  */
 function getLocalizedGlobalConfig(globalConfig, currentLocaleConfig, locale) {
   const localizedGlobalConfig = {


### PR DESCRIPTION
This commit adds the templatedata hook. It currently
mirrors what jambo will do by default. This commit
has no functional differences with regards to the
data passed to templates.

The jambo version will need to be bumped once
the newest jambo (containing support for this hook)
is released, for this to do anything.

J=SLAP-857
TEST=manual

added a custom helper that would fs.writeFile the current template data
into a json file
jambo build-ed a site with and without the templatedata hook,
checked that the 2 json files were identical (eye test + jest)
then checkout current develop version of jambo and test that
the template data without any of these changes was the same as the
other 2

also did the above for yanswers index, index.ja, index.en_GB
also did the above for weight watchers repo when it was still single lang
(no locale_config.json)

test building a site with a local JAMBO_INJECTED_DATA and also with it unset