### PR TITLE
product-prominentimage card: align CTAs to bottom

### DIFF
--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -10,7 +10,7 @@
 
   &-body
   {
-    height: 100%;
+    flex-grow: 1;
     display: flex;
     flex-direction: column;
     width: 100%;


### PR DESCRIPTION
This change introduces additional CSS to the
product-prominentimage card so that CTAs will align
to the bottom of each card instead of appearing
immediately after the preceding content.

J=SLAP-672
TEST=manual
On a local site, used the rosetest account's products
vertical in a vertical-grid page and saw that the
cards had their CTAs aligned to the bottom.
Also tested on IE11 using browserstack to verify
UI changes looked good there.