### PR TITLE
Add a 'development' mode toggle to the Webpack configuration. (#544)

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -6,6 +6,10 @@ const HtmlPlugin = require('html-webpack-plugin');
 const RemovePlugin = require('remove-files-webpack-plugin');
 
 module.exports = function () {
+  const isDevelopment = 'IS_DEVELOPMENT_PREVIEW' in process.env ?
+    process.env.IS_DEVELOPMENT_PREVIEW === 'true':
+    false;
+
   const jamboConfig = require('./jambo.json');
   const InlineAssetHtmlPlugin = require(
     `./${jamboConfig.dirs.output}/static/webpack/InlineAssetHtmlPlugin`
@@ -28,8 +32,29 @@ module.exports = function () {
     });
   }
 
+  const plugins = [
+    new MiniCssExtractPlugin({ filename: '[name].css' }),
+    ...htmlPlugins,
+    new webpack.EnvironmentPlugin({
+      JAMBO_INJECTED_DATA: null
+    }),
+    new RemovePlugin({
+      after: {
+        root: `${jamboConfig.dirs.output}`,
+        include: ['static'],
+        log: true
+      }
+    })
+  ];
+
+  let mode = 'development';
+  if (!isDevelopment) {
+    plugins.push(new InlineAssetHtmlPlugin());
+    mode = 'production';
+  }
+
   return {
-    mode: 'production',
+    mode,
     target: ['web', 'es5'],
     entry: {
       'bundle': `./${jamboConfig.dirs.output}/static/entry.js`,
@@ -52,21 +77,7 @@ module.exports = function () {
       libraryTarget: 'window',
       publicPath: ''
     },
-    plugins: [
-      new MiniCssExtractPlugin({ filename: '[name].css' }),
-      ...htmlPlugins,
-      new InlineAssetHtmlPlugin(),
-      new webpack.EnvironmentPlugin({
-        JAMBO_INJECTED_DATA: null
-      }),
-      new RemovePlugin({
-        after: {
-          root: `${jamboConfig.dirs.output}`,
-          include: ['static'],
-          log: true
-        }
-      })
-    ],
+    plugins,
     module: {
       rules: [
         {


### PR DESCRIPTION
This PR allows our Webpack toolchain to be easily toggled between two modes:
'production' and 'development'. These are built-in Webpack modes. In
'development', minimization of JS assets process by Webpack does not occur. We
add the additional behavior that bundle.js and bundle.css are not inlined
in 'development'. This inlining behavior is not too important during local
development. Mainly, it offers a performance boost for published pages. But, it
considerably slows down the Webpack compilation.

By running Webpack in 'development' and getting rid of inlining, preview
generation should happen much faster and use considerably less memory. I tried
the new 'development' mode for YAnswers. I found that memory usage reduced by
60% and the compilation time reduced by about 70%.

The toggle behavior is driven off an 'IS_DEVELOPMENT_PREVIEW' environment
variable. This variable will be set to true/false in the relevant CI scripts.

J=SLAP-962
TEST=manual

Tested the following on a sample Jambo repo:
- The 'development' version of the toolchain was run when the environment
  variable was set to true.
- The 'production' version was run when the variable was set to false.
- The 'production' version was run when the variable was unset.