### PR TITLE
Scroll to top of iframe

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -84,7 +84,7 @@ export function generateIFrame(domain, queryParam, urlParam) {
     checkOrigin: false,
     onMessage: function(messageData) {
       const message = JSON.parse(messageData.message);
-      if (message.message === "paginate") {
+      if (message.action === "paginate") {
         const iframeOffsetTop = iframe.offsetTop;
         document.documentElement.scrollTop = iframeOffsetTop;
         document.body.scrollTop = iframeOffsetTop; // For Safari

--- a/templates/vertical-grid/script/pagination.hbs
+++ b/templates/vertical-grid/script/pagination.hbs
@@ -2,7 +2,8 @@ ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: ".js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
     if (window.parentIFrame) {
-      window.parentIFrame.sendMessage('{"message": "paginate"}');
+      const paginateMessage = { action: 'paginate' };
+      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
     } else {
       document.documentElement.scrollTop = 0;
       document.body.scrollTop = 0; // Safari

--- a/templates/vertical-map/script/pagination.hbs
+++ b/templates/vertical-map/script/pagination.hbs
@@ -2,7 +2,8 @@ ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
     if (window.parentIFrame) {
-      window.parentIFrame.sendMessage('{"message": "paginate"}');
+      const paginateMessage = { action: 'paginate' };
+      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
     } else {
       document.documentElement.scrollTop = 0;
       document.body.scrollTop = 0; // Safari

--- a/templates/vertical-standard/script/pagination.hbs
+++ b/templates/vertical-standard/script/pagination.hbs
@@ -2,7 +2,8 @@ ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: ".js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
     if (window.parentIFrame) {
-      window.parentIFrame.sendMessage('{"message": "paginate"}');
+      const paginateMessage = { action: 'paginate' };
+      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
     } else {
       document.documentElement.scrollTop = 0;
       document.body.scrollTop = 0; // Safari


### PR DESCRIPTION
Scroll to the top of the iframe during pagination

Use the iframe resizer to send a message to the parent document to scroll up. 

This solution is based on [this HH Community post](https://hitchhikers.yext.com/community/t/answers-iframe-forward-pagination-does-not-jump-you-to-top-of-page/2077/5 ), however I needed to make two changes. First, vertical-map has a results column which also needs to be scrolled to the top. Secondly, that solution scrolls to the top of the page, but not necessarily to the top of the iframe. To address this, I set the `scrollTop` to the iframe `offsetTop` rather than to 0.

J=SLAP-940
TEST=manual

Build a site with an iframe and observe scrolling to top when paginating in vertical-standard, vertical-grid, and vertical-map. Add a div with padding above the iframe and confirm that the page scrolls to the top of the iframe and not to the top of the page. Test in Chrome and Safari.