### PR TITLE
tests for navigation, universalresults, verticalresults relativePath usage

### DIFF
--- a/tests/templates/script/navigation.js
+++ b/tests/templates/script/navigation.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const path = require('path');
+const hbs = require('../../test-utils/hbs');
+
+const pageTemplates = [
+  'universal-standard',
+  'vertical-grid',
+  'vertical-standard',
+  'vertical-map'
+];
+
+for (const pageTemplate of pageTemplates) {
+  const templatePath = path.resolve(__dirname, `../../../templates/${pageTemplate}/script/navigation.hbs`);
+  const navigationConfigTemplate = fs.readFileSync(templatePath, 'utf-8');
+  const compiledTemplate = hbs.compile(navigationConfigTemplate);
+
+  describe(`uses relativePath correctly (${pageTemplate})`, () => {
+    describe('with url set in a vertical page\'s verticalsToConfig', () => {
+      const templateData = {
+        relativePath: '../..',
+        verticalConfigs: {
+          people: {
+            verticalKey: 'people',
+            verticalsToConfig: {
+              people: {
+                url: 'vtc.html',
+              }
+            }
+          }
+        }
+      };
+      const output = compiledTemplate(templateData);
+      const ANSWERS = {
+        addComponent: jest.fn()
+      };
+      eval(output);
+      const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+      const verticalPage = componentConfig.verticalPages[0];
+      expect(verticalPage.url).toEqual('../../vtc.html');
+    });
+
+    it('with url set in a vertical page\'s top level config', () => {
+      const templateData = {
+        relativePath: '../..',
+        verticalConfigs: {
+          people: {
+            url: 'top-level.html',
+            verticalKey: 'people',
+            verticalsToConfig: {
+              people: {}
+            }
+          }
+        }
+      };
+      const output = compiledTemplate(templateData);
+      const ANSWERS = {
+        addComponent: jest.fn()
+      };
+      eval(output);
+      const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+      const verticalPage = componentConfig.verticalPages[0];
+      expect(verticalPage.url).toEqual('../../top-level.html');
+    });
+
+    it('will default url to {{pageName}}.html without relativePath', () => {
+      const templateData = {
+        relativePath: '../..',
+        verticalConfigs: {
+          people: {
+            verticalKey: 'people',
+            verticalsToConfig: {
+              people: {}
+            }
+          }
+        }
+      };
+      const output = compiledTemplate(templateData);
+      const ANSWERS = {
+        addComponent: jest.fn()
+      };
+      eval(output);
+      const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+      const verticalPage = componentConfig.verticalPages[0];
+      expect(verticalPage.url).toEqual('people.html');
+    });
+  });
+}

--- a/tests/templates/script/universalresults.js
+++ b/tests/templates/script/universalresults.js
@@ -1,0 +1,110 @@
+const fs = require('fs');
+const path = require('path');
+const hbs = require('../../test-utils/hbs');
+
+const universalResultsPath =
+  path.resolve(__dirname, '../../../templates/universal-standard/script/universalresults.hbs');
+const universalResultsTemplate = fs.readFileSync(universalResultsPath, 'utf-8');
+const compiledTemplate = hbs.compile(universalResultsTemplate);
+
+hbs.registerHelper('read', () => {
+  return 'mock universal section template'
+});
+
+describe('uses relativePath correctly', () => {
+  describe('with url set in a vertical page\'s verticalsToConfig', () => {
+    const templateData = {
+      relativePath: '../..',
+      verticalConfigs: {
+        people: {
+          verticalKey: 'people',
+          verticalsToConfig: {
+            people: {
+              url: 'vtc-url.html',
+              iconUrl: 'static/assets/icon.gif',
+              viewAllText: 'test view all'
+            }
+          }
+        }
+      }
+    };
+    const output = compiledTemplate(templateData);
+    const ANSWERS = {
+      addComponent: jest.fn()
+    };
+    eval(output);
+    const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+    const peopleConfig = componentConfig.config.people;
+  
+    it('verticalPages and url', () => {
+      expect(peopleConfig.verticalPages).toEqual([{
+        verticalKey: 'people',
+        url: '../../vtc-url.html',
+      }]);
+      expect(peopleConfig.url).toEqual('../../vtc-url.html');
+    });
+
+    it('sectionTitleIconUrl', () => {
+      expect(peopleConfig.sectionTitleIconUrl).toEqual('../../static/assets/icon.gif');
+    });
+  });
+
+  it('with url set in a vertical page\'s top level config', () => {
+    const templateData = {
+      relativePath: '../..',
+      verticalConfigs: {
+        people: {
+          url: 'page-path.html',
+          verticalKey: 'people',
+          verticalsToConfig: {
+            people: {
+              viewAllText: 'test view all'
+            }
+          }
+        }
+      }
+    };
+    const output = compiledTemplate(templateData);
+    const ANSWERS = {
+      addComponent: jest.fn()
+    };
+    eval(output);
+    const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+    const peopleConfig = componentConfig.config.people;
+  
+    expect(peopleConfig.verticalPages).toEqual([{
+      verticalKey: 'people',
+      pageUrl: '../../page-path.html',
+    }]);
+    expect(peopleConfig.url).toEqual('../../page-path.html');
+  });
+
+  it('will default url to {{pageName}}.html without relativePath', () => {
+    const templateData = {
+      relativePath: '../..',
+      verticalConfigs: {
+        people: {
+          verticalKey: 'people',
+          verticalsToConfig: {
+            people: {
+              viewAllText: 'test view all'
+            }
+          }
+        }
+      }
+    };
+    const output = compiledTemplate(templateData);
+    const ANSWERS = {
+      addComponent: jest.fn()
+    };
+    eval(output);
+    const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+    const peopleConfig = componentConfig.config.people;
+  
+    expect(peopleConfig.verticalPages).toEqual([{
+      verticalKey: 'people',
+      url: 'people.html',
+    }]);
+    expect(peopleConfig.url).toEqual('people.html');
+  });
+});

--- a/tests/templates/script/verticalresults.js
+++ b/tests/templates/script/verticalresults.js
@@ -1,0 +1,163 @@
+const fs = require('fs');
+const path = require('path');
+const hbs = require('../../test-utils/hbs');
+
+const pageTemplates = [
+  'vertical-grid',
+  'vertical-standard',
+  'vertical-map'
+];
+
+for (const pageTemplate of pageTemplates) {
+  const templatePath = path.resolve(__dirname, `../../../templates/${pageTemplate}/script/verticalresults.hbs`);
+  const verticalResultsConfigTemplate = fs.readFileSync(templatePath, 'utf-8');
+  const compiledTemplate = hbs.compile(verticalResultsConfigTemplate);
+
+  describe(`uses relativePath correctly (${pageTemplate})`, () => {
+    describe('for vertical pages with url at the top level page config', () => {
+      const templateData = {
+        relativePath: '../..',
+        verticalConfigs: {
+          people: {
+            url: 'top-level.html',
+            verticalKey: 'people',
+            verticalsToConfig: {
+              people: {
+                iconUrl: 'static/assets/icon.gif'
+              }
+            }
+          }
+        }
+      };
+      const output = compiledTemplate(templateData);
+      const ANSWERS = {
+        addComponent: jest.fn()
+      };
+      eval(output);
+      const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+      const verticalPage = componentConfig.verticalPages[0];
+  
+      it('iconUrl correctly uses relativePath', () => {
+        expect(verticalPage.iconUrl).toEqual('../../static/assets/icon.gif');
+      });
+  
+      it('url correctly uses relativePath', () => {
+        expect(verticalPage.url).toEqual('../../top-level.html');
+      });
+    });
+  
+    it('for vertical pages with url inside verticalsToConfig', () => {
+      const templateData = {
+        relativePath: '../..',
+        verticalConfigs: {
+          people: {
+            verticalKey: 'people',
+            verticalsToConfig: {
+              people: {
+                url: 'vtc.html'
+              }
+            }
+          }
+        }
+      };
+      const output = compiledTemplate(templateData);
+      const ANSWERS = {
+        addComponent: jest.fn()
+      };
+      eval(output);
+      const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+      const verticalPage = componentConfig.verticalPages[0];
+      expect(verticalPage.url).toEqual('../../vtc.html');
+    });
+  
+    it('defaults to {{pageName}}.html without relativePath', () => {
+      const templateData = {
+        relativePath: '../..',
+        verticalConfigs: {
+          people: {
+            verticalKey: 'people',
+            verticalsToConfig: {
+              people: {}
+            }
+          }
+        }
+      };
+      const output = compiledTemplate(templateData);
+      const ANSWERS = {
+        addComponent: jest.fn()
+      };
+      eval(output);
+      const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+      const verticalPage = componentConfig.verticalPages[0];
+      expect(verticalPage.url).toEqual('people.html');
+    });
+  
+    describe('for universal pages', () => {
+      it('works when url is at the top level page config', () => {
+        const templateData = {
+          relativePath: '../..',
+          verticalConfigs: {
+            index: {
+              url: 'index-page.html',
+              verticalsToConfig: {
+                Universal: {}
+              }
+            }
+          }
+        };
+        const output = compiledTemplate(templateData);
+        const ANSWERS = {
+          addComponent: jest.fn()
+        };
+        eval(output);
+        const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+        const verticalPage = componentConfig.verticalPages[0];
+        expect(verticalPage.url).toEqual('../../index-page.html');
+      });
+  
+      it('works when url is in verticalsToConfig', () => {
+        const templateData = {
+          relativePath: '../..',
+          verticalConfigs: {
+            index: {
+              verticalsToConfig: {
+                Universal: {
+                  url: 'index-page-vtc.html'
+                }
+              }
+            }
+          }
+        };
+        const output = compiledTemplate(templateData);
+        const ANSWERS = {
+          addComponent: jest.fn()
+        };
+        eval(output);
+        const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+        const verticalPage = componentConfig.verticalPages[0];
+        expect(verticalPage.url).toEqual('../../index-page-vtc.html');
+      });
+  
+      it('defaults to {{pageName}}.html without relativePath', () => {
+        const templateData = {
+          relativePath: '../..',
+          verticalConfigs: {
+            index: {
+              verticalsToConfig: {
+                Universal: {}
+              }
+            }
+          }
+        };
+        const output = compiledTemplate(templateData);
+        const ANSWERS = {
+          addComponent: jest.fn()
+        };
+        eval(output);
+        const componentConfig = ANSWERS.addComponent.mock.calls[0][1];
+        const verticalPage = componentConfig.verticalPages[0];
+        expect(verticalPage.url).toEqual('index.html');
+      });
+    });
+  });
+}


### PR DESCRIPTION
This commit adds unit tests for relativePath usages in the
navigation, universal results, and vertical results addComponent calls.

J=SLAP-967
TEST=auto

It works by mocking the global ANSWERS instance, and eval'ing the
output of the template