### PR TITLE
Update Webpack Performance Warning Thresholds

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -55,6 +55,10 @@ module.exports = function () {
 
   return {
     mode,
+    performance: {
+      maxAssetSize: 1536000,
+      maxEntrypointSize: 1024000
+    },
     target: ['web', 'es5'],
     entry: {
       'bundle': `./${jamboConfig.dirs.output}/static/entry.js`,


### PR DESCRIPTION
Update the asset max size limits for the webpack build so that the warning is more useful

Produce a warning only for assets over 1.5 MiB and for entrypoints over 1 MiB. This is an increase from the webpack default of 244 KiB.

I chose these numbers based on a random sample of live answers sites where the assets are around 900-1050 KiB and the entrypoints are around 550 KiB.

J=937
TEST=manual

Run a build with the test site an observe the warnings go away. Test lowering the size limit and observe the warnings appear again.