### PR TITLE
Update the LocationBias script partials for the vertical templates.

### DIFF
--- a/templates/vertical-grid/script/locationbias.hbs
+++ b/templates/vertical-grid/script/locationbias.hbs
@@ -1,3 +1,6 @@
 ANSWERS.addComponent("LocationBias", Object.assign({}, {
-  container: ".js-answersLocationBias"
+  container: ".js-answersLocationBias",
+  {{#if verticalKey}}
+    verticalKey: "{{{verticalKey}}}"
+  {{/if}}
 }, {{{ json componentSettings.LocationBias }}}));

--- a/templates/vertical-map/script/locationbias.hbs
+++ b/templates/vertical-map/script/locationbias.hbs
@@ -1,3 +1,6 @@
 ANSWERS.addComponent("LocationBias", Object.assign({}, {
-  container: "#js-answersLocationBias",
+  container: ".js-answersLocationBias",
+  {{#if verticalKey}}
+    verticalKey: "{{{verticalKey}}}"
+  {{/if}}
 }, {{{ json componentSettings.LocationBias }}}));

--- a/templates/vertical-standard/script/locationbias.hbs
+++ b/templates/vertical-standard/script/locationbias.hbs
@@ -1,3 +1,6 @@
 ANSWERS.addComponent("LocationBias", Object.assign({}, {
-  container: ".js-answersLocationBias"
+  container: ".js-answersLocationBias",
+  {{#if verticalKey}}
+    verticalKey: "{{{verticalKey}}}"
+  {{/if}}
 }, {{{ json componentSettings.LocationBias }}}));


### PR DESCRIPTION
The LocationBias expects verticalKey to be provided either as part of the
component configuration or the global search configuration. No verticalKey means
the LocationBias component conducts a universal search. The three vertical
templates were never providing one as part of the component configuration. So,
any page built with one of these templates was improperly issuing universal
searches unless there was a global search configuration.

This PR ensures that the three templates now send verticalKey along with the
computed LocationBias configuration.

J=SLAP-1010
TEST=manual

Created a page using each of the three vertical templates. Verified that the
correct vertical search was issued when clicing 'Update my location'. Also
ensured that a verticalKey in the componentSettings could override the one
automatically provided by Jambo.