### PR TITLE
Pre-load the SourceSans fonts now used by default in the Theme.

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -22,6 +22,18 @@
     <link rel="dns-prefetch" href="//dynm.mktgcdn.com">
     <link rel="dns-prefetch" href="//www.google-analytics.com">
     <link rel="dns-prefetch" href="//assets.sitescdn.net">
+
+    <!-- Uncomment this block if you use the legacy OpenSans fonts -->
+    {{!-- <link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/opensans-bold-webfont.woff" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/opensans-regular-webfont.woff" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/opensans-semibold-webfont.woff" type="font/woff" crossorigin="anonymous"> --}}
+    
+    <!-- Preload the SourceSans fonts used by default in the Theme -->
+    <link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-300.woff" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-600.woff" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-700.woff" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-regular.woff" type="font/woff" crossorigin="anonymous">
+
     <script>
       document.documentElement.lang = {{#if global_config.locale}}"{{global_config.locale}}"{{else}}'en'{{/if}};
     </script>


### PR DESCRIPTION
This PR adds pre-load links to fetch the new fonts used in the Theme. These
fetches are initiated before any component is actually rendered on the page.
This makes it much more likely that we will not see any "font flashing"
behavior. If a component happens to be rendered before a font request is
complete, we still have the `font-display: swap` directives. With this, the
text would be visible, albeit in a different font, until the requested font
loads. In my testing, the requests all resolved before components were
rendered.

J=SLAP-1008
TEST=manual

Tested the following:

- Saw no more "font flashing" with this change.
- On a single language site, all the fonts were loaded properly.
- On a multi-language site, the fonts were loaded properly for all localized
  pages. This includes pages that had a `relativePath` other than `.`.