### PR TITLE
De-dupe the computed card types inside `getCardPartials`.

### DIFF
--- a/hbshelpers/getCardPartials.js
+++ b/hbshelpers/getCardPartials.js
@@ -28,15 +28,18 @@ module.exports = function getCardPartials(pageUrl, pageNamesToConfig, opt) {
 }
 
 /**
- * Returns all the cardTypes specified in the provided vertical configs.
+ * Returns all the cardTypes specified in the provided vertical configs. Note that the
+ * types will be de-duped.
  * 
  * @param {Array<Object>} verticalConfigs An array of vertical configs.
- * @returns {Array<string>} The referenced cardTypes.
+ * @returns {Set<string>} The referenced cardTypes.
  */
 function getCardTypes(verticalConfigs) {
-  return verticalConfigs
+  const rawCardTypes = verticalConfigs
     .filter(verticalConfig => verticalConfig.cardType)
     .map(verticalConfig => verticalConfig.cardType);
+
+  return new Set(rawCardTypes);
 }
 
 /**
@@ -44,7 +47,7 @@ function getCardTypes(verticalConfigs) {
  * partial is passed to the provided block. The block's output is then concatenated
  * to a string.
  * 
- * @param {Array<string>} cardTypes The cardTypes. 
+ * @param {Set<string>} cardTypes The cardTypes. 
  * @param {Object} opt The block.
  * @returns {string} The concatenated string of block results.
  */


### PR DESCRIPTION
The `getCardPartials` helper first iterates through the various page configs
and determines which card types are used. This list needs to be de-duped,
however, to ensure we don't include the same card partial twice.

TEST=manual

Created a sample site with a universal page and two vertical pages. Both
vertical pages used the same card. Ensured that the universal page included
that card's partial only once.