### PR TITLE
Update font defaults

### DIFF
--- a/static/scss/answers/common/fonts-default.scss
+++ b/static/scss/answers/common/fonts-default.scss
@@ -14,13 +14,13 @@ $font-weight-light: 300;
   --yxt-font-weight-normal: #{$font-weight-normal};
   --yxt-font-weight-light: #{$font-weight-light};
 
-  --yxt-font-size-xs: 10px;
-  --yxt-font-size-sm: 12px;
-  --yxt-font-size-md: 14px;
-  --yxt-font-size-md-lg: 16px;
-  --yxt-font-size-lg: 18px;
-  --yxt-font-size-xlg: 20px;
-  --yxt-font-size-xxlg: 40px;
+  --yxt-font-size-xs: 12px;
+  --yxt-font-size-sm: 14px;
+  --yxt-font-size-md: 16px;
+  --yxt-font-size-md-lg: 18px;
+  --yxt-font-size-lg: 20px;
+  --yxt-font-size-xlg: 22px;
+  --yxt-font-size-xxlg: 42px;
 
   --yxt-line-height-xs: 1;
   --yxt-line-height-sm: 1.2;
@@ -30,7 +30,9 @@ $font-weight-light: 300;
   --yxt-line-height-xlg: 5/3;
   --yxt-line-height-xxlg: 1.7;
 
-  --yxt-font-family: "Source Sans Pro",system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  --yxt-autocomplete-text-font-size: var(--yxt-font-size-md-lg);
+
+  --yxt-font-family: "Source Sans Pro","Open Sans",system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 }
 
 @font-face


### PR DESCRIPTION
Update font-defaults.scss to match the fonts.scss

When updating fonts.scss for the ui refresh, we didn't make all of the the corresponding changes to fonts-default.scss. This PR includes them.

J=none
TEST=none

I built a site and smoke tested it