### PR TITLE
Update the map pins to have the color-brand-primary as their default.

### DIFF
--- a/templates/universal-standard/script/map-pin.hbs
+++ b/templates/universal-standard/script/map-pin.hbs
@@ -3,7 +3,7 @@
     label: marker.label.toString() || '',
     height: {{#if pin.height}}{{pin.height}}{{else}}26{{/if}},
     width: {{#if pin.width}}{{pin.width}}{{else}}22{{/if}},
-    backgroundColor: '{{#if pin.backgroundColor}}{{pin.backgroundColor}}{{else}}#0f70f0{{/if}}',
+    backgroundColor: '{{#if pin.backgroundColor}}{{pin.backgroundColor}}{{else}}#5387d7{{/if}}',
     labelColor: '{{#if pin.labelColor}}{{pin.labelColor}}{{else}}white{{/if}}',
     strokeColor: '{{#if pin.strokeColor}}{{pin.strokeColor}}{{else}}black{{/if}}',
   }

--- a/templates/vertical-map/script/map-pin.hbs
+++ b/templates/vertical-map/script/map-pin.hbs
@@ -3,7 +3,7 @@
     label: marker.label.toString() || '',
     height: {{#if pin.height}}{{pin.height}}{{else}}26{{/if}},
     width: {{#if pin.width}}{{pin.width}}{{else}}22{{/if}},
-    backgroundColor: '{{#if pin.backgroundColor}}{{pin.backgroundColor}}{{else}}#0f70f0{{/if}}',
+    backgroundColor: '{{#if pin.backgroundColor}}{{pin.backgroundColor}}{{else}}#5387d7{{/if}}',
     labelColor: '{{#if pin.labelColor}}{{pin.labelColor}}{{else}}white{{/if}}',
     strokeColor: '{{#if pin.strokeColor}}{{pin.strokeColor}}{{else}}black{{/if}}',
   }


### PR DESCRIPTION
This was initially missed during the UI Refresh when the color-brand-primary was updated. The map's pins should have the updated color-brand-primary as their default.

TEST=manual

Verified that map pins on universal and vertical-map have the new, muted color-brand-primary as their default.