### PR TITLE
removing display:none on QA submission icon

### DIFF
--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -143,10 +143,6 @@ $container-width-at-collapsed-filters-breakpoint: $breakpoint-collapsed-filters 
       font-weight: var(--yxt-font-weight-light);
     }
 
-    .yxt-QuestionSubmission-titleIconWrapper {
-      display: none;
-    }
-
     .yxt-QuestionSubmission-title {
       text-transform: none;
       font-weight: var(--yxt-font-weight-normal);


### PR DESCRIPTION
extension of https://github.com/yext/answers-hitchhiker-theme/pull/578, putting icon back on qa submission component too! 

TEST: Ran the test site and verified the qa submission icon was back