### PR TITLE
Add the new highlightField formatter. (#582)

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -544,3 +544,29 @@ export function price(fieldValue = {}, locale) {
   }
   return price.toLocaleString(localeForFormatting, { style: 'currency', currency: currencyCode });
 }
+
+/**
+ * Highlights snippets of the provided fieldValue according to the matched substrings.
+ * Each match will be wrapped in <mark> tags.
+ * 
+ * @param {string} fieldValue The plain, un-highlighted text.
+ * @param {Array<Object>} matchedSubstrings The list of matched substrings to
+ *                                          highlight.
+ */
+export function highlightField(fieldValue, matchedSubstrings) {
+  let highlightedString = fieldValue;
+
+  // We must first sort the matchedSubstrings by decreasing offset. 
+  const sortedMatches = matchedSubstrings.slice()
+    .sort((match1, match2) => match2.offset - match1.offset);
+  
+  sortedMatches.forEach(match => {
+    const { offset, length } = match;
+    highlightedString = 
+      highlightedString.substr(0, offset) +
+      `<mark>${fieldValue.substr(offset, length)}</mark>`+
+      highlightedString.substr(offset + length);
+  });
+
+  return highlightedString;
+}

--- a/static/js/formatters.js
+++ b/static/js/formatters.js
@@ -27,7 +27,8 @@ import {
   openStatus,
   hoursList,
   generateCTAFieldTypeLink,
-  price
+  price,
+  highlightField
 } from './formatters-internal.js';
 import * as CustomFormatters from './formatters-custom.js';
 
@@ -58,7 +59,8 @@ let Formatters = {
   openStatus,
   hoursList,
   generateCTAFieldTypeLink,
-  price
+  price,
+  highlightField
 };
 Formatters = Object.assign(Formatters, CustomFormatters);
 

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -107,4 +107,50 @@ describe('Formatters', () => {
       expect(consoleWarn).toHaveBeenCalled();
     });
   });
+
+  describe('highlightField', () => {
+    it('Behaves correctly when there are no matchedSubstrings', () => {
+      const plainText = 'No more straws';
+      const actual = Formatters.highlightField(plainText, []);
+
+      expect(actual).toEqual(plainText);
+    });
+
+    it('Highlights single substring correctly', () => {
+      const plainText = 'No more straws';
+      const matchedSubstrings = [
+        {
+           "offset": 8,
+           "length": 6
+        }
+     ];
+      const actual = Formatters.highlightField(plainText, matchedSubstrings);
+
+      const expected = 'No more <mark>straws</mark>'
+      expect(actual).toEqual(expected);
+    });
+
+    it('Highlights multiple substrings correctly', () => {
+      const plainText = 'How does mask wearing prevent COVID-19';
+      const matchedSubstrings = [
+        {
+           "offset": 9,
+           "length": 4
+        },
+        {
+           "offset": 30,
+           "length": 8
+        },
+        {
+           "offset": 14,
+           "length": 7
+        }
+     ];
+      const actual = Formatters.highlightField(plainText, matchedSubstrings);
+
+      const expected = 
+        'How does <mark>mask</mark> <mark>wearing</mark> prevent <mark>COVID-19</mark>';
+      expect(actual).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds the new highlightField formatter to the Theme. This formatter is
the core of the Theme's document search support. It allows different snippets
of a string to be highlighted. Highlighted text is wrapped with '<mark>' tags.
Initially, the spec called for the tags to be configurable. However, it was
later decided that if a user wanted to change the wrapping tag, they could
just override the formatter itself.

J=SLAP-993
TEST=auto

Added unit tests for the new formatter. The back-end is not yet ready, so I
could not verify manually. Once I can test manually, I will.