### PR TITLE
default.scss: Move answers.scss after collapsible filters

### DIFF
--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -50,9 +50,6 @@
 @import "cards/product-prominentimage-clickable";
 @import "directanswercards/allfields-standard";
 
-// HH files
-@import "../answers";
-
 // Styling for CollapsibleFilters
 @import "collapsible-filters/collapsible-filters";
 @import "collapsible-filters/collapsible-filters-templates";
@@ -60,6 +57,9 @@
 // Styling for CollapsibleFilters components
 @import "collapsible-filters/filter-link";
 @import "collapsible-filters/view-results-button";
+
+// HH files
+@import "../answers";
 
 // Custom styling outside of the Answers experience
 @import "../page.scss";


### PR DESCRIPTION
We move the HH-configurable answers.scss after collapsible filters so
that any changes in answers.scss to collapsible filters classes take
precedence (without the need for !important).

J=None
TEST=manual

Make sure that a style change to (example below) works.

```
  .CollapsibleFilters .Answers-resultsHeader {
    background-color: red;
  }
```