### PR TITLE
Add card name validation to the `vertical` command.

### DIFF
--- a/commands/addvertical.js
+++ b/commands/addvertical.js
@@ -110,7 +110,7 @@ class VerticalAdder {
    * @param {Object<string, string>} args The arguments, keyed by name 
    */
   execute(args) {
-    if (!this._getAvailableCards(this.config).includes(args.cardName)) {
+    if (!VerticalAdder._getAvailableCards(this.config).includes(args.cardName)) {
       throw new UserError(`${args.cardName} is not a valid card`);
     }
 


### PR DESCRIPTION
Logic was added to the command to validate the provided `cardName`. If the provided card does not
exist, a `UserError` will be thrown with a helpful error message.

TEST=manual

On a test site, provided an invalid `cardName` and saw the error. The command worked as expected when I provided a valid card name. 