### PR TITLE
Add card name validation to the `vertical` command. (#592)

### DIFF
--- a/commands/addvertical.js
+++ b/commands/addvertical.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
+const UserError = require('./helpers/errors/usererror');
 const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
 
 /**
@@ -109,6 +110,10 @@ class VerticalAdder {
    * @param {Object<string, string>} args The arguments, keyed by name 
    */
   execute(args) {
+    if (!VerticalAdder._getAvailableCards(this.config).includes(args.cardName)) {
+      throw new UserError(`${args.cardName} is not a valid card`);
+    }
+
     this._createVerticalPage(args.name, args.template);
     this._configureVerticalPage(args.name, args.verticalKey, args.cardName);
   }


### PR DESCRIPTION
Logic was added to the command to validate the provided `cardName`. If the provided card does not
exist, a `UserError` will be thrown with a helpful error message.

TEST=manual

On a test site, provided an invalid `cardName` and saw the error. The command worked as expected when I provided a valid card name.