### PR TITLE
Default `cardName` to `standard` in the `vertical` command. (#594)

### DIFF
--- a/commands/addvertical.js
+++ b/commands/addvertical.js
@@ -37,7 +37,7 @@ class VerticalAdder {
       name: new ArgumentMetadata(ArgumentType.STRING, 'name of the vertical\'s page', true),
       verticalKey: new ArgumentMetadata(ArgumentType.STRING, 'the vertical\'s key', true),
       cardName: new ArgumentMetadata(
-        ArgumentType.STRING, 'card to use with vertical', true),
+        ArgumentType.STRING, 'card to use with vertical', false, 'standard'),
       template: new ArgumentMetadata(
         ArgumentType.STRING, 'page template to use within theme', true)
     };
@@ -62,7 +62,6 @@ class VerticalAdder {
         },
         cardName: {
           displayName: 'Card Name',
-          required: true,
           type: 'singleoption',
           options: this._getAvailableCards(jamboConfig)
         },


### PR DESCRIPTION
This PR updates the `vertical` command so that `cardName` is not required.
If no value is supplied, the default of `standard` will be applied.

TEST=manual

Used the `vertical` command without a `cardName` and saw `standard` was used.
Used the command with a `cardName` and saw that used.