### PR TITLE
Add npm install step to upgrades

### DIFF
--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -66,4 +66,3 @@ async function isGitSubmodule(submodulePath) {
     .find(p => p === submodulePath)
 }
 exports.isGitSubmodule = isGitSubmodule;
-


### PR DESCRIPTION
J=SLAP-965
TEST=manual

test that I can do an upgrade or legacy upgrade and npm install
will run for both
test that I can setup a new jambo site, import the theme,
delete node_modules, upgrade to this branch, see npm install run,
and see that no errors are thrown (which means that fs-extra is being installed
correctly since that is used in the upgrade script)