### PR TITLE
Include a cardOverrides by default in the universal page config.

### DIFF
--- a/templates/universal-standard/page-config.json
+++ b/templates/universal-standard/page-config.json
@@ -11,7 +11,13 @@
     },
     **/
     "DirectAnswer": {
-      "defaultCard": "allfields-standard"
+      "defaultCard": "allfields-standard",
+      "cardOverrides": [
+        {
+          "cardType": "documentsearch-standard",
+          "type": "FEATURED_SNIPPET"
+        }
+      ]
     },
     "SearchBar": {
       "placeholderText": "Search" // The placeholder text in the answers search bar


### PR DESCRIPTION
The default cardOverrides ensures that any `FEATURED_SNIPPET` type answers
use the new `documentsearch-standard` card.

J=SLAP-1063
TEST=manual

Created a universal page using the new config template. Ensured that a
`FEATURED_SNIPPET` type answer was using `documentsearch-standard` and a
`FIELD_VALUE` type answer was using `allfields-standard`.