### PR TITLE
Collapsible Filters changes for Interactive Map

### DIFF
--- a/static/js/collapsible-filters/interactions.js
+++ b/static/js/collapsible-filters/interactions.js
@@ -4,16 +4,20 @@
 export default class Interactions {
   constructor(domElements) {
     const { filterEls, resultEls } = domElements;
+    this.collapsibleFiltersParentEl = document.querySelector('.CollapsibleFilters');
     this.filterEls = filterEls || [];
     this.resultEls = resultEls || [];
     this.viewResultsButton = document.getElementById('js-answersViewResultsButton');
     this.searchBarContainer = document.getElementById('js-answersSearchBar');
     this.resultsColumn = document.querySelector('.js-answersResultsColumn');
     this.inactiveCssClass = 'CollapsibleFilters-inactive';
+    this.collapsedcCssClass = 'CollapsibleFilters--collapsed';
     this.resultsWrapper = document.querySelector('.js-answersResultsWrapper')
       || document.querySelector('.Answers-resultsWrapper');
     this._updateStickyButton = this._updateStickyButton.bind(this);
     this._debouncedStickyUpdate = this._debouncedStickyUpdate.bind(this);
+    this._disableScrollToTopOnToggle = 
+      document.querySelector('.js-CollapsibleFilters--disableScrollToTop') !== null;
   }
 
   /**
@@ -170,6 +174,20 @@ export default class Interactions {
   }
 
   /**
+   * If isCollapsed is true, then set the css class
+   * for CollapsibleFilters indicating that the filters are collapsedc
+   *
+   * @param {boolean} isCollapsed
+   */
+  toggleCollapsedStatusClass(isCollapsed) {
+    if (isCollapsed) {
+      this.collapsibleFiltersParentEl.classList.remove(this.collapsedcCssClass);
+    } else {
+      this.collapsibleFiltersParentEl.classList.add(this.collapsedcCssClass)
+    }
+  }
+
+  /**
    * Either collapses or expands the collapsible filters panel.
    * @param {boolean} shouldCollapseFilters 
    */
@@ -186,7 +204,10 @@ export default class Interactions {
       this.toggleInactiveClass(el, !shouldCollapseFilters);
     }
     this.toggleInactiveClass(this.viewResultsButton, shouldCollapseFilters);
-    this.scrollToTop();
+    this.toggleCollapsedStatusClass(shouldCollapseFilters);
+    if (!this._disableScrollToTopOnToggle) {
+      this.scrollToTop();
+    }
     ANSWERS.components.getActiveComponent('FilterLink').setState({
       panelIsDisplayed: !shouldCollapseFilters
     });

--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -53,12 +53,6 @@
 @import "directanswercards/allfields-standard";
 @import "directanswercards/documentsearch-standard";
 
-// Vertical map component styling
-@import 'interactive-map/InteractiveMap.scss';
-
-// HH files
-@import "../answers";
-
 // Styling for CollapsibleFilters
 @import "collapsible-filters/collapsible-filters";
 @import "collapsible-filters/collapsible-filters-templates";
@@ -66,6 +60,12 @@
 // Styling for CollapsibleFilters components
 @import "collapsible-filters/filter-link";
 @import "collapsible-filters/view-results-button";
+
+// Vertical map component styling
+@import 'interactive-map/InteractiveMap.scss';
+
+// HH files
+@import "../answers";
 
 // Custom styling outside of the Answers experience
 @import "../page.scss";

--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -454,7 +454,7 @@
   }
 
   // TODO move to js
-  &.InteractiveMap--showCollapsibleFilters {
+  &.CollapsibleFilters--collapsed {
     .Answers-mobileToggles {
       display: none;
     }
@@ -557,21 +557,21 @@
   }
   
   &.CollapsibleFilters .Answers-resultsHeader {
-    background-color: var(--hh-color-gray-2) !important;
+    background-color: var(--hh-color-gray-2);
   }
 
   &.CollapsibleFilters .Answers-viewResultsButton {
     padding: 8px;
     
     @include bpgte($desktop-break-point-min) {
-      width: 100% !important;
+      width: 100%;
       position: absolute;
     }
   }
 
   &.CollapsibleFilters .Answers-filtersWrapper {
     @include bplte($mobile-break-point-max) {
-      margin: 0 !important;
+      margin: 0;
       padding: 16px;
     }
   }

--- a/templates/vertical-interactive-map/page.html.hbs
+++ b/templates/vertical-interactive-map/page.html.hbs
@@ -17,7 +17,7 @@
     {{> templates/vertical-interactive-map/script/locationbias modifier="main" }}
     {{> templates/vertical-interactive-map/script/locationbias modifier="mobileMap" }}
   {{/script/core }}
-    <div class="Answers AnswersVerticalMap CollapsibleFilters InteractiveMap InteractiveMap--listShown js-answersInteractiveMap">
+    <div class="Answers AnswersVerticalMap CollapsibleFilters InteractiveMap InteractiveMap--listShown js-answersInteractiveMap js-CollapsibleFilters--disableScrollToTop">
       <div class="Answers-content">
         <div class="Answers-contentWrap js-locator-contentWrap">
           <div class="Answers-resultsHeader">


### PR DESCRIPTION
We change collapsible filters in 3 ways for certain interactive map
interactions:

1. Add a check for when to scrollToTop when toggling collapsible filters
   in interactions. This manifests in the HTML as
   .js-CollapsibleFilters--disableScrollToTop. This is necessary because
   the results wrapper would scroll to top upon clicking a map pin
   attempting to scroll the results wrapper to the corresponding card.

2. Add a top-level CollapsibleFilters--collapsed class that can be used
   to guide classes underneath. This was important to have collapsed
   filter styling in the interactive map (hide the LocationBias for
   example, only when the filters are collapsed). Note: we do not use
   CollapsibleFilters-inactive because that has corresponding styling
   that would hide the entire locator.

3. Move the order of the collapsible filters imports so that styles can
   be overridden in files that come after it in _default.scss (namely,
   InteractiveMap styling and answers.scss as a fun +1).

J=SLAP-1093
TEST=manual

1. Test that you can pin on a result card and be scrolled direectly to
   the card, NOT to the top and then to the result card.

2. Test that LocationBias and Search This Area disappear once the
   collapsible filters are expanded.

3. See previous styling (100% width button, gray background results
   header) without !important in the css styles.