### PR TITLE
interactive-map: Automatically encode custom pin SVGs

### DIFF
--- a/static/js/interactive-map/ClusterPinImages.js
+++ b/static/js/interactive-map/ClusterPinImages.js
@@ -33,7 +33,7 @@ class ClusterPinImages {
     height= '24px',
     labelText = ''
   } = {}) {
-    return `data:image/svg+xml;utf8,${encodeURIComponent(`
+    return `
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
         <g fill="none" fill-rule="evenodd">
           <circle fill="${backgroundColor}" fill-rule="nonzero" stroke="${strokeColor}" cx="12" cy="12" r="11"/>
@@ -41,7 +41,8 @@ class ClusterPinImages {
             <tspan x="50%" y="16" text-anchor="middle">${labelText}</tspan>
           </text>
         </g>
-      </svg>`)}`;
+      </svg>
+    `;
   };
 
   /**

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -5,6 +5,7 @@ import { RendererOptions } from './Renderer/Renderer.js';
 import { PinProperties } from './Maps/PinProperties.js';
 import { PinClustererOptions } from './PinClusterer/PinClusterer.js';
 import { transformDataToUniversalData, transformDataToVerticalData } from './Util/transformers.js';
+import { getEncodedSvg } from './Util/helpers.js';
 
 import { GoogleMaps } from './Maps/Providers/Google.js';
 import { MapboxMaps } from './Maps/Providers/Mapbox.js';
@@ -232,13 +233,13 @@ class NewMap extends ANSWERS.Component {
         this.pinClusterClickListener();
       })
       .withIconTemplate('default', (pinDetails) => {
-        return this.pinClusterImages.getDefaultPin(pinDetails.pinCount);
+        return getEncodedSvg(this.pinClusterImages.getDefaultPin(pinDetails.pinCount));
       })
       .withIconTemplate('hovered', (pinDetails) => {
-        return this.pinClusterImages.getHoveredPin(pinDetails.pinCount);
+        return getEncodedSvg(this.pinClusterImages.getHoveredPin(pinDetails.pinCount));
       })
       .withIconTemplate('selected', (pinDetails) => {
-        return this.pinClusterImages.getSelectedPin(pinDetails.pinCount);
+        return getEncodedSvg(this.pinClusterImages.getSelectedPin(pinDetails.pinCount));
       })
       .withPropertiesForStatus(status => {
         const properties = new PinProperties()
@@ -263,9 +264,9 @@ class NewMap extends ANSWERS.Component {
    */
   buildPin(pinOptions, entity, index) {
     const pin = pinOptions
-      .withIcon('default', this.pinImages.getDefaultPin(index, entity.profile))
-      .withIcon('hovered', this.pinImages.getHoveredPin(index, entity.profile))
-      .withIcon('selected', this.pinImages.getSelectedPin(index, entity.profile))
+      .withIcon('default', getEncodedSvg(this.pinImages.getDefaultPin(index, entity.profile)))
+      .withIcon('hovered', getEncodedSvg(this.pinImages.getHoveredPin(index, entity.profile)))
+      .withIcon('selected', getEncodedSvg(this.pinImages.getSelectedPin(index, entity.profile)))
       .withHideOffscreen(false)
       .withCoordinate(new Coordinate(entity.profile.yextDisplayCoordinate))
       .withPropertiesForStatus(status => {

--- a/static/js/interactive-map/PinImages.js
+++ b/static/js/interactive-map/PinImages.js
@@ -34,7 +34,7 @@ class PinImages {
     index = '',
     profile = ''
   } = {}) {
-    return `data:image/svg+xml;utf8,${encodeURIComponent(`
+    return `
     <svg width="${width}" height="${height}" viewBox="0 0 20 27" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <title>Path</title>
         <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -46,7 +46,8 @@ class PinImages {
           <tspan x="50%" y="15" text-anchor="middle">${index}</tspan>
         </text>
         </g>
-    </svg>`)}`;
+    </svg>
+    `;
   };
 
   /**

--- a/static/js/interactive-map/Util/helpers.js
+++ b/static/js/interactive-map/Util/helpers.js
@@ -23,6 +23,17 @@ const getLanguageForProvider = (localeStr, supportedLocales) => {
   return 'en';
 };
 
+/**
+ * Returns a utf-8 encoding of an SVG
+ *
+ * @param {string} svg The SVG to encode
+ * @return {string}
+ */
+const getEncodedSvg = (svg) => {
+  return `data:image/svg+xml;charset=utf-8, ${encodeURIComponent(svg)}`;
+}
+
 export {
-  getLanguageForProvider
+  getLanguageForProvider,
+  getEncodedSvg
 }


### PR DESCRIPTION
This is mostly adding back previous behavior. Previously, we would add
this utf-8 encoding to the pins passed into the Mapbox/Google
implementations. Add this back in such a way that a HH can still paste
an SVG straight into the PinImages/ClusterPinImages functions without
having to remember to use this.

J=SLAP-1112
TEST=manual

Test on both Google, Mapbox
* You can see default pins
* You can see default cluster pins
* You can see their hovered, selected variants