### PR TITLE
Add missing null checks to the accordion card variants. (#619)

### DIFF
--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -21,7 +21,7 @@
       </div>
     {{/if}}
     {{> 'details'}}
-    {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
+    {{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
       <div class="HitchhikerFaqAccordion-ctasWrapper">
         {{#if card.CTA1.url}}
         <div class="HitchhikerFaqAccordion-primaryCTA">

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -21,7 +21,7 @@
       </div>
     {{/if}}
     {{> 'details'}}
-    {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
+    {{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
       <div class="HitchhikerFaqAccordion-ctasWrapper">
         {{#if card.CTA1.url}}
         <div class="HitchhikerFaqAccordion-primaryCTA">


### PR DESCRIPTION
This PR adds the missing null checks for label to the Accordion cards variants in the Theme.
After auditing all the cards, these were the only missing null checks that I could find.

J=SLAP-1003
TEST=manual

Verified the new null checks on a simple test site.