### PR TITLE
Only load the locator bundle on interactive map pages

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -84,4 +84,3 @@
 <!-- TODO: change back to versioned answers script when new storage is available widely -->
 <!-- <script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answers.min.js" onload="initAnswers()" defer></script> -->
 <script src="https://assets.sitescdn.net/answers/canary/latest/answers.min.js" onload="initAnswers()" defer></script>
-<script src="{{relativePath}}/locator-components.js" defer></script>

--- a/templates/vertical-interactive-map/page.html.hbs
+++ b/templates/vertical-interactive-map/page.html.hbs
@@ -17,6 +17,7 @@
     {{> templates/vertical-interactive-map/script/locationbias modifier="main" }}
     {{> templates/vertical-interactive-map/script/locationbias modifier="mobileMap" }}
   {{/script/core }}
+  <script src="{{relativePath}}/locator-components.js" defer></script>
     <div class="Answers AnswersVerticalMap CollapsibleFilters InteractiveMap InteractiveMap--listShown js-answersInteractiveMap">
       <div class="Answers-content">
         <div class="Answers-contentWrap js-locator-contentWrap">


### PR DESCRIPTION
Only load the locator bundle on interactive map pages

Previously the locator-components.js bundle was being loaded on every page template. Update it so that it is only being loaded on the vertical-interactive-map page

J=SLAP-1096
TEST=manual

Build a site and confirm that the interactive map still works. Build a location-standard page and confirm that the locator-components.js bundle is no longer being loaded