### PR TITLE
interactive-map: NewMapConfig class to hold config logic

### DIFF
--- a/static/js/interactive-map/InteractiveMap.js
+++ b/static/js/interactive-map/InteractiveMap.js
@@ -2,6 +2,7 @@ import { Coordinate } from './Geo/Coordinate.js';
 import { smoothScroll } from './Util/SmoothScroll.js';
 import { getLanguageForProvider } from './Util/helpers.js';
 import { SearchDebouncer } from './SearchDebouncer';
+import { defaultCenterCoordinate } from './constants.js';
 
 import ZoomTriggers from './Maps/ZoomTriggers.js';
 import StorageKeys from '../storage-keys.js';
@@ -63,7 +64,7 @@ class InteractiveMap extends ANSWERS.Component {
      */
     this.defaultCenter = this.providerOptions.center
       ? new Coordinate(this.providerOptions.center)
-      : new Coordinate(37.0902, -95.7129);
+      : defaultCenterCoordinate;
 
     /**
      * The default zoom level for the map

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -233,10 +233,10 @@ class NewMap extends ANSWERS.Component {
 
         return properties;
       })
-      .withMinClusterSize(2)
-      .withClusterRadius(50)
-      .withClusterZoomAnimated(true)
-      .withClusterZoomMax(20);
+      .withMinClusterSize(this.config.minClusterSize)
+      .withClusterRadius(this.config.minClusterRadius)
+      .withClusterZoomAnimated(this.config.clusterZoomAnimated)
+      .withClusterZoomMax(this.config.clusterZoomMax);
     return clustererOptions.build();
   }
 

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -10,6 +10,7 @@ import { getEncodedSvg } from './Util/helpers.js';
 import { GoogleMaps } from './Maps/Providers/Google.js';
 import { MapboxMaps } from './Maps/Providers/Mapbox.js';
 
+import NewMapConfig from './NewMapConfig.js'
 import StorageKeys from '../storage-keys.js';
 
 /**
@@ -18,28 +19,14 @@ import StorageKeys from '../storage-keys.js';
  * listeners, and rendering the map on the page with results changes
  */
 class NewMap extends ANSWERS.Component {
-  constructor(config, systemConfig) {
-    super(config, systemConfig);
+  constructor(rawConfig, systemConfig) {
+    super(rawConfig, systemConfig);
 
-    this.mapProvider = config.mapProvider;
-    this.apiKey = config.apiKey;
-    this.clientId = config.cliendId;
-    this.language = config.language;
-    this.defaultCenter = config.defaultCenter;
-    this.defaultZoom = config.defaultZoom;
-    this.providerOptions = config.providerOptions;
-    this.mapPadding = config.mapPadding;
-    this.pinImages = config.pinImages;
-    this.pinClusterImages = config.pinClusterImages;
-    this.enablePinClustering = config.enablePinClustering;
-    this.onPinSelect = config.onPinSelect;
-    this.onPostMapRender = config.onPostMapRender;
-    this.pinClickListener = config.pinClickListener;
-    this.pinClusterClickListener = config.pinClusterClickListener;
-    this.dragEndListener = config.dragEndListener;
-    this.zoomChangedListener = config.zoomChangedListener;
-    this.zoomEndListener = config.zoomEndListener;
-    this.displayAllResultsOnNoResults  = config.displayAllResultsOnNoResults;
+    /**
+     * Configuration with default logic
+     * @type {NewMapConfig}
+     */
+    this.config = new NewMapConfig(rawConfig);
 
     /**
      * The map object
@@ -107,18 +94,18 @@ class NewMap extends ANSWERS.Component {
    * Load the map provider scripts and initialize the map with the configuration options
    */
   async loadAndInitializeMap () {
-    const mapProviderImpl = (this.mapProvider === 'google') ? GoogleMaps : MapboxMaps;
-    await mapProviderImpl.load(this.apiKey, {
-      client: this.clientId,
-      language: this.language,
+    const mapProviderImpl = (this.config.mapProvider === 'google') ? GoogleMaps : MapboxMaps;
+    await mapProviderImpl.load(this.config.apiKey, {
+      client: this.config.clientId,
+      language: this.config.language,
     });
     const map = new MapOptions()
-      .withDefaultCenter(this.defaultCenter)
-      .withDefaultZoom(this.defaultZoom)
+      .withDefaultCenter(this.config.defaultCenter)
+      .withDefaultZoom(this.config.defaultZoom)
       .withWrapper(this._container)
       .withProvider(mapProviderImpl)
-      .withProviderOptions(this.providerOptions || {})
-      .withPadding(this.mapPadding)
+      .withProviderOptions(this.config.providerOptions || {})
+      .withPadding(this.config.mapPadding)
       .build();
     this.map = map;
     this.addMapInteractions(map);
@@ -143,23 +130,23 @@ class NewMap extends ANSWERS.Component {
       map.setPanHandler(() => this.updateMapPropertiesInStorage());
       map.setDragEndHandler(() => {
         this.updateMapPropertiesInStorage();
-        this.dragEndListener()
+        this.config.dragEndListener()
       });
       map.setZoomChangedHandler((zoomTrigger) => {
-        this.zoomChangedListener(this.map.getZoom(), zoomTrigger);
+        this.config.zoomChangedListener(this.map.getZoom(), zoomTrigger);
       });
       map.setZoomEndHandler((zoomTrigger) => {
         this.updateMapPropertiesInStorage();
-        this.zoomEndListener(this.map.getZoom(), zoomTrigger);
+        this.config.zoomEndListener(this.map.getZoom(), zoomTrigger);
       });
     });
 
     const mapRenderTargetOptions = new MapRenderTargetOptions()
       .withMap(map)
-      .withOnPostRender((data, map) => this.onPostMapRender(data, map, mapRenderTarget.getPins()))
+      .withOnPostRender((data, map) => this.config.onPostMapRender(data, map, mapRenderTarget.getPins()))
       .withPinBuilder((pinOptions, entity, index) => this.buildPin(pinOptions, entity, index))
 
-    if (this.enablePinClustering) {
+    if (this.config.enablePinClustering) {
       mapRenderTargetOptions.withPinClusterer(this.getClusterer());
     }
 
@@ -207,8 +194,8 @@ class NewMap extends ANSWERS.Component {
             pins[id].setStatus({ selected: true });
             this.selectedPinId = id;
 
-            if (this.onPinSelect) {
-              this.onPinSelect();
+            if (this.config.onPinSelect) {
+              this.config.onPinSelect();
             }
 
             if (!map.coordinateIsInVisibleBounds(pins[id].getCoordinate())) {
@@ -227,16 +214,16 @@ class NewMap extends ANSWERS.Component {
     const clustererOptions = new PinClustererOptions()
       .withClickListener(() => {
         this.updateMapPropertiesInStorage();
-        this.pinClusterClickListener();
+        this.config.pinClusterClickListener();
       })
       .withIconTemplate('default', (pinDetails) => {
-        return getEncodedSvg(this.pinClusterImages.getDefaultPin(pinDetails.pinCount));
+        return getEncodedSvg(this.config.pinClusterImages.getDefaultPin(pinDetails.pinCount));
       })
       .withIconTemplate('hovered', (pinDetails) => {
-        return getEncodedSvg(this.pinClusterImages.getHoveredPin(pinDetails.pinCount));
+        return getEncodedSvg(this.config.pinClusterImages.getHoveredPin(pinDetails.pinCount));
       })
       .withIconTemplate('selected', (pinDetails) => {
-        return getEncodedSvg(this.pinClusterImages.getSelectedPin(pinDetails.pinCount));
+        return getEncodedSvg(this.config.pinClusterImages.getSelectedPin(pinDetails.pinCount));
       })
       .withPropertiesForStatus(status => {
         const properties = new PinProperties()
@@ -261,9 +248,15 @@ class NewMap extends ANSWERS.Component {
    */
   buildPin(pinOptions, entity, index) {
     const pin = pinOptions
-      .withIcon('default', getEncodedSvg(this.pinImages.getDefaultPin(index, entity.profile)))
-      .withIcon('hovered', getEncodedSvg(this.pinImages.getHoveredPin(index, entity.profile)))
-      .withIcon('selected', getEncodedSvg(this.pinImages.getSelectedPin(index, entity.profile)))
+      .withIcon(
+        'default',
+        getEncodedSvg(this.config.pinImages.getDefaultPin(index, entity.profile)))
+      .withIcon(
+        'hovered',
+        getEncodedSvg(this.config.pinImages.getHoveredPin(index, entity.profile)))
+      .withIcon(
+        'selected',
+        getEncodedSvg(this.config.pinImages.getSelectedPin(index, entity.profile)))
       .withHideOffscreen(false)
       .withCoordinate(new Coordinate(entity.profile.yextDisplayCoordinate))
       .withPropertiesForStatus(status => {
@@ -296,7 +289,7 @@ class NewMap extends ANSWERS.Component {
         }
       }
     });
-    pin.setClickHandler(() => this.pinClickListener(index, id));
+    pin.setClickHandler(() => this.config.pinClickListener(index, id));
     pin.setHoverHandler(hovered => this.core.storage.set(
       StorageKeys.LOCATOR_HOVERED_RESULT,
       hovered ? id : null
@@ -319,7 +312,7 @@ class NewMap extends ANSWERS.Component {
     let updateZoom = !fromSearchThisArea;
 
     const isNoResults = data.resultsContext === 'no-results';
-    if (isNoResults && !this.displayAllResultsOnNoResults) {
+    if (isNoResults && !this.config.displayAllResultsOnNoResults) {
       entityData = [];
       updateZoom = false;
     }

--- a/static/js/interactive-map/NewMapConfig.js
+++ b/static/js/interactive-map/NewMapConfig.js
@@ -1,0 +1,187 @@
+import { Coordinate } from './Geo/Coordinate.js';
+import { PinImages } from './PinImages.js';
+import { ClusterPinImages } from './ClusterPinImages.js';
+import { getLanguageForProvider } from './Util/helpers.js';
+
+/**
+ * The configuration for the NewMap component.
+ */
+export default class NewMapConfig {
+  /**
+   * @param {Object} rawConfig Configuration to parse
+   */
+  constructor (rawConfig) {
+    /**
+     * The provider for the map, normalized to lowercase
+     * @type {string}
+     */
+    this.mapProvider = rawConfig.mapProvider && rawConfig.mapProvider.toLowerCase();
+
+    /**
+     * The API key for the map provider (if applicable)
+     * @type {string}
+     */
+    this.apiKey = rawConfig.apiKey;
+
+    /**
+     * The client id for the map provider (if applicable)
+     * @type {string}
+     */
+    this.clientId = rawConfig.clientId;
+
+    /**
+     * The language locale for the map. This is different from
+     * the specified locale because some map providers do not support
+     * certain locales and we want to fallback in a specific pattern
+     * when we come across a locale we do not support
+     * @type {string}
+     */
+    this.language = getLanguageForProvider(rawConfig.locale, this.mapProvider);
+
+    /**
+     * The content wrapper for the floating content above the map
+     * @type {HTMLElement}
+     */
+    this.contentWrapperEl = rawConfig.contentWrapperEl;
+
+    /**
+     * Map options to be passed directly to the Map Provider
+     * @type {Object}
+     */
+    this.providerOptions = rawConfig.providerOptions || {};
+
+    const defaultCenter = rawConfig.defaultCenter 
+      || this.providerOptions.center 
+      || { lat: 37.0902, lng: -95.7129 };
+
+    /**
+     * The default center coordinate for the map, an object with {lat, lng}
+     * @type {Coordinate}
+     */
+    this.defaultCenter = new Coordinate(defaultCenter);
+
+    /**
+     * The default zoom level for the map
+     * @type {number}
+     */
+    this.defaultZoom = rawConfig.defaultZoom 
+      || this.providerOptions.zoom 
+      || 14;
+
+    /**
+     * The mobile breakpoint (inclusive max) in px
+     * @type {Number}
+     */
+    this.mobileBreakpointMax = rawConfig.mobileBreakpointMax || 991;
+
+    /**
+     * The padding for the map within the viewable area
+     * @type {Object}
+     */
+    this.mapPadding = {
+      top: () => window.innerWidth <= this.mobileBreakpointMax ? 150 : 50,
+      bottom: () => 50,
+      right: () => 50,
+      left: () => this.getLeftVisibleBoundary(),
+    };
+
+    /**
+     * The pin options for the map, with information for each pin state (e.g. default, hovered)
+     * @type {Object}
+     */
+    this.pinOptions = rawConfig.pinOptions || {};
+
+    /**
+     * The pin images for the default Map Pin
+     * @type {PinImages}
+     */
+    this.pinImages = new PinImages(
+      this.pinOptions.default,
+      this.pinOptions.hovered,
+      this.pinOptions.selected,
+    );
+
+    /**
+     * The cluster pin options for the map, with information for each pin state
+     * @type {Object}
+     */
+    this.pinClusterOptions = rawConfig.pinClusterOptions || rawConfig.pinOptions;
+
+    /**
+     * The pin images for the default Map Pin
+     * @type {ClusterPinImages}
+     */
+    this.pinClusterImages = new ClusterPinImages(
+      this.pinClusterOptions.default || this.pinOptions.default,
+      this.pinClusterOptions.hovered || this.pinOptions.hovered,
+      this.pinClusterOptions.selected || this.pinOptions.selected,
+    );
+
+    /**
+     * Whether the map should cluster pins that are close to each other
+     * @type {boolean}
+     */
+    this.enablePinClustering = rawConfig.enablePinClustering;
+
+    const noResultsConfig = rawConfig.noResults || {};
+
+    /**
+     * Whether the map should display all results on no results
+     * @type {boolean}
+     */
+    this.displayAllResultsOnNoResults = noResultsConfig.displayAllResultsOnNoResults;
+
+    /**
+     * Callback for when a non-cluster pin is selected
+     * @type {Function}
+     */
+    this.onPinSelect = rawConfig.onPinSelect || function () {};
+
+    /**
+     * Callback for when the map is rendered
+     * @type {Function}
+     */
+    this.onPostMapRender = rawConfig.onPostMapRender || function () {};
+
+    /**
+     * Callback for when a non-cluster pin is clicked
+     * @type {Function}
+     */
+    this.pinClickListener = rawConfig.pinClickListener || function () {};
+
+    /**
+     * Callback for when a cluster pin is clicked
+     * @type {Function}
+     */
+    this.pinClusterClickListener = rawConfig.pinClusterClickListener || function () {};
+
+    /**
+     * Callback for when a map drag event has finished
+     */
+    this.dragEndListener = rawConfig.dragEndListener || function () {};
+
+    /**
+     * Callback for when a map zoom event has fired
+     */
+    this.zoomChangedListener = rawConfig.zoomChangedListener || function () {};
+
+    /**
+     * Callback for when a map zoom event has finished
+     */
+    this.zoomEndListener = rawConfig.zoomEndListener || function () {};
+  }
+
+  /**
+   * Get the leftmost point on the map, such that pins will still be visible
+   * @return {Number} The boundary (in pixels) for the visible area of the map, from the left
+   *                  hand side of the viewport
+   */
+  getLeftVisibleBoundary () {
+    if (window.innerWidth <= this.mobileBreakpointMax) {
+      return 50;
+    }
+
+    const contentWrapperElWidth = this.contentWrapperEl ? this.contentWrapperEl.offsetWidth : 0;
+    return 50 + contentWrapperElWidth;
+  };
+}

--- a/static/js/interactive-map/NewMapConfig.js
+++ b/static/js/interactive-map/NewMapConfig.js
@@ -9,26 +9,26 @@ import { defaultCenterCoordinate } from './constants.js';
  */
 export default class NewMapConfig {
   /**
-   * @param {Object} rawConfig Configuration to parse
+   * @param {Object} jsonConfig Configuration to parse
    */
-  constructor (rawConfig) {
+  constructor (jsonConfig) {
     /**
      * The provider for the map, normalized to lowercase
      * @type {string}
      */
-    this.mapProvider = rawConfig.mapProvider && rawConfig.mapProvider.toLowerCase();
+    this.mapProvider = jsonConfig.mapProvider && jsonConfig.mapProvider.toLowerCase();
 
     /**
      * The API key for the map provider (if applicable)
      * @type {string}
      */
-    this.apiKey = rawConfig.apiKey;
+    this.apiKey = jsonConfig.apiKey;
 
     /**
      * The client id for the map provider (if applicable)
      * @type {string}
      */
-    this.clientId = rawConfig.clientId;
+    this.clientId = jsonConfig.clientId;
 
     /**
      * The language locale for the map. This is different from
@@ -37,21 +37,21 @@ export default class NewMapConfig {
      * when we come across a locale we do not support
      * @type {string}
      */
-    this.language = getLanguageForProvider(rawConfig.locale, this.mapProvider);
+    this.language = getLanguageForProvider(jsonConfig.locale, this.mapProvider);
 
     /**
      * The content wrapper for the floating content above the map
      * @type {HTMLElement}
      */
-    this.contentWrapperEl = rawConfig.contentWrapperEl;
+    this.contentWrapperEl = jsonConfig.contentWrapperEl;
 
     /**
      * Map options to be passed directly to the Map Provider
      * @type {Object}
      */
-    this.providerOptions = rawConfig.providerOptions || {};
+    this.providerOptions = jsonConfig.providerOptions || {};
 
-    const defaultCenterFromConfig = rawConfig.defaultCenter || this.providerOptions.center;
+    const defaultCenterFromConfig = jsonConfig.defaultCenter || this.providerOptions.center;
 
     /**
      * The default center coordinate for the map, an object with {lat, lng}
@@ -65,7 +65,7 @@ export default class NewMapConfig {
      * The default zoom level for the map
      * @type {number}
      */
-    this.defaultZoom = rawConfig.defaultZoom 
+    this.defaultZoom = jsonConfig.defaultZoom
       || this.providerOptions.zoom 
       || 14;
 
@@ -73,7 +73,7 @@ export default class NewMapConfig {
      * The mobile breakpoint (inclusive max) in px
      * @type {Number}
      */
-    this.mobileBreakpointMax = rawConfig.mobileBreakpointMax || 991;
+    this.mobileBreakpointMax = jsonConfig.mobileBreakpointMax || 991;
 
     /**
      * The padding for the map within the viewable area
@@ -90,7 +90,7 @@ export default class NewMapConfig {
      * The pin options for the map, with information for each pin state (e.g. default, hovered)
      * @type {Object}
      */
-    this.pinOptions = rawConfig.pinOptions || {};
+    this.pinOptions = jsonConfig.pinOptions || {};
 
     /**
      * The pin images for the default Map Pin
@@ -106,7 +106,7 @@ export default class NewMapConfig {
      * The cluster pin options for the map, with information for each pin state
      * @type {Object}
      */
-    this.pinClusterOptions = rawConfig.pinClusterOptions || rawConfig.pinOptions;
+    this.pinClusterOptions = jsonConfig.pinClusterOptions || jsonConfig.pinOptions;
 
     /**
      * The pin images for the default Map Pin
@@ -122,9 +122,9 @@ export default class NewMapConfig {
      * Whether the map should cluster pins that are close to each other
      * @type {boolean}
      */
-    this.enablePinClustering = rawConfig.enablePinClustering;
+    this.enablePinClustering = jsonConfig.enablePinClustering;
 
-    const noResultsConfig = rawConfig.noResults || {};
+    const noResultsConfig = jsonConfig.noResults || {};
 
     /**
      * Whether the map should display all results on no results
@@ -136,43 +136,43 @@ export default class NewMapConfig {
      * Callback for when a non-cluster pin is selected
      * @type {Function}
      */
-    this.onPinSelect = rawConfig.onPinSelect || function () {};
+    this.onPinSelect = jsonConfig.onPinSelect || function () {};
 
     /**
      * Callback for when the map is rendered
      * @type {Function}
      */
-    this.onPostMapRender = rawConfig.onPostMapRender || function () {};
+    this.onPostMapRender = jsonConfig.onPostMapRender || function () {};
 
     /**
      * Callback for when a non-cluster pin is clicked
      * @type {Function}
      */
-    this.pinClickListener = rawConfig.pinClickListener || function () {};
+    this.pinClickListener = jsonConfig.pinClickListener || function () {};
 
     /**
      * Callback for when a cluster pin is clicked
      * @type {Function}
      */
-    this.pinClusterClickListener = rawConfig.pinClusterClickListener || function () {};
+    this.pinClusterClickListener = jsonConfig.pinClusterClickListener || function () {};
 
     /**
      * Callback for when a map drag event has finished
      * @type {Function}
      */
-    this.dragEndListener = rawConfig.dragEndListener || function () {};
+    this.dragEndListener = jsonConfig.dragEndListener || function () {};
 
     /**
      * Callback for when a map zoom event has fired
      * @type {Function}
      */
-    this.zoomChangedListener = rawConfig.zoomChangedListener || function () {};
+    this.zoomChangedListener = jsonConfig.zoomChangedListener || function () {};
 
     /**
      * Callback for when a map zoom event has finished
      * @type {Function}
      */
-    this.zoomEndListener = rawConfig.zoomEndListener || function () {};
+    this.zoomEndListener = jsonConfig.zoomEndListener || function () {};
 
     /**
      * The minimum number of pins to be clustered

--- a/static/js/interactive-map/NewMapConfig.js
+++ b/static/js/interactive-map/NewMapConfig.js
@@ -169,6 +169,30 @@ export default class NewMapConfig {
      * Callback for when a map zoom event has finished
      */
     this.zoomEndListener = rawConfig.zoomEndListener || function () {};
+
+    /**
+     * The minimum number of pins to be clustered
+     * @type {number}
+     */
+    this.minClusterSize = 2;
+
+    /**
+     * The max pixel distance from the center of a cluster to any pin in the cluster
+     * @type {number}
+     */
+    this.minClusterRadius = 50;
+
+    /**
+     * Whether to animate map zoom on cluster click
+     * @type {boolean}
+     */
+    this.clusterZoomAnimated = true;
+
+    /**
+     * Max zoom level for the map after clicking a cluster
+     * @type {number}
+     */
+    this.clusterZoomMax = 20;
   }
 
   /**

--- a/static/js/interactive-map/NewMapConfig.js
+++ b/static/js/interactive-map/NewMapConfig.js
@@ -2,6 +2,7 @@ import { Coordinate } from './Geo/Coordinate.js';
 import { PinImages } from './PinImages.js';
 import { ClusterPinImages } from './ClusterPinImages.js';
 import { getLanguageForProvider } from './Util/helpers.js';
+import { defaultCenterCoordinate } from './constants.js';
 
 /**
  * The configuration for the NewMap component.
@@ -50,15 +51,15 @@ export default class NewMapConfig {
      */
     this.providerOptions = rawConfig.providerOptions || {};
 
-    const defaultCenter = rawConfig.defaultCenter 
-      || this.providerOptions.center 
-      || { lat: 37.0902, lng: -95.7129 };
+    const defaultCenterFromConfig = rawConfig.defaultCenter || this.providerOptions.center;
 
     /**
      * The default center coordinate for the map, an object with {lat, lng}
      * @type {Coordinate}
      */
-    this.defaultCenter = new Coordinate(defaultCenter);
+    this.defaultCenter = defaultCenterFromConfig
+      ? new Coordinate(defaultCenterFromConfig)
+      : defaultCenterCoordinate;
 
     /**
      * The default zoom level for the map
@@ -157,16 +158,19 @@ export default class NewMapConfig {
 
     /**
      * Callback for when a map drag event has finished
+     * @type {Function}
      */
     this.dragEndListener = rawConfig.dragEndListener || function () {};
 
     /**
      * Callback for when a map zoom event has fired
+     * @type {Function}
      */
     this.zoomChangedListener = rawConfig.zoomChangedListener || function () {};
 
     /**
      * Callback for when a map zoom event has finished
+     * @type {Function}
      */
     this.zoomEndListener = rawConfig.zoomEndListener || function () {};
 

--- a/static/js/interactive-map/constants.js
+++ b/static/js/interactive-map/constants.js
@@ -1,0 +1,8 @@
+import { Coordinate } from './Geo/Coordinate.js';
+
+/**
+ * The default center coordinate, currently in Dearing, KS, in the middle
+ * of the United States
+ * @type {Coordinate}
+ */
+export const defaultCenterCoordinate = new Coordinate(37.0902, -95.7129);


### PR DESCRIPTION
We add a NewMapConfig class to handle the logic of configuration for the
NewMap component. This helps us move the responsibility of configuration
parsing to its own class and cut down the bulk in InteractiveMap. This
is also a good way for Hitchhikers to shadow only this configuration and
not the entire component, for common use cases.

Additionally, we move some (previously) hardcoded values for clustering
to the new config to further let HHs change only this new file for configuration
changes.

Note that some configuration is used by both the InteractiveMap and the
NewMap and thus they exist in both component configuration. Also note
that the InteractveMap must (currently) accept specific passthrough
configuration for the NewMap, as it exists as the parent component for
it. (If you recall, we must pass in specific functions to NewMap, thus
must be the parent).

See the current component documentation (below).

```
InteractiveMap
{
    // required, The container that all functionality should exist inside, not re-rendered
    container: no default,

    // required, The current Answers API vertical key
    verticalKey: no default,

    // required, The vertical configuration
    verticalPages: no default,

    // optional, Map options to be passed directly to the Map Provider
    providerOptions: {}

    // optional, The default center coordinate for the map, an object with {lat, lng}
    providerOptions.center: { lat: 37.0902, lng: -95.7129 }

    // optional, The default zoom level for the map
    providerOptions.zoom: 14

    // optional, Whether the map should search on a map movement action like map drag
    disableSearchOnMapMove: false

    // optional, Contains no results configuration
    noResults: {},

    // optional, Whether the map should display all results on no results
    noResults.displayAllResults: false,

    // The following are accepted as a means of passthrough to NewMap
    mapProvider,
    apiKey,
    clientId,
    locale,
    pin,
    pinCluster,
    enablePinClustering,
    onPinSelect
}
```

```
NewMap
{
    // required
    container: no default,

    // required, The provider for the map, normalized to lowercase
    mapProvider: no default,

    // either apiKey or clientId required, The API key for the map provider (if applicable)
    apiKey: no default,

    // either apiKey or clientId required, The client id for the map provider (if applicable)
    clientId: no default,

    // required, has involved logic for defaulting based on validity of given locale
    locale: no default

    // required, The content wrapper for the floating content above the map
    contentWrapperEl: no default

    // optional, Map options to be passed directly to the Map Provider
    providerOptions: {}

    // optional, The default center coordinate for the map, an object with {lat, lng}
    defaultCenter: { lat: 37.0902, lng: -95.7129 }

    // optional, The default zoom level for the map
    defaultZoom: 14

    // optional, The mobile breakpoint (inclusive max) in px
    mobileBreakpointMax: 991

    // optional, The pin options for the map, with information for each pin state (e.g. default, hovered)
    pinOptions:  the default pin options

    // optional, The cluster pin options for the map, with information for each pin state
    pinClusterOptions:  the default pin cluster options

    // optional, Whether the map should cluster pins that are close to each other
    enablePinClustering: false

    // optional, Contains no results configuration
    noResults: {},

    // optional, Whether the map should display all results on no results
    noResults.displayAllResults: false,

    // optional, Callback for when a non-cluster pin is selected
    onPinSelect: function () {},

    // optional, Callback for when the map is rendered
    onPostMapRender: function () {},

    // optional, Callback for when a non-cluster pin is clicked
    pinClickListener: function () {},

    // optional, Callback for when a cluster pin is clicked
    pinClusterClickListener: function () {},

    // optional, Callback for when a map drag event has finished
    dragEndListener: function () {},

    // optional, Callback for when a map zoom event has fired
    zoomChangedListener: function () {},

    // optional, Callback for when a map zoom event has finished
    zoomEndListener: function () {},
}
```

J=SLAP-1117
TEST=manual

Smoke test all configuration to see that changes made to the JSON
reflect on the map experience. For example:

* Changing the map pin colors changes the pins in the map
* Enabling/disabling clustering works
* Default (landing state) map center can be changed
* Provider options are passed through
* Zooming still calls search this area
* Padding on the map is correct (pins on search are not under the
content wrapper)
* No results hides the pins

Also test that changing the new configuration options for clustering
affect the clustering. e.g. minClusterSize = 3 for the query `all` should
not show the cluster of size 2.