### PR TITLE
interactive-map: Fix View Results button styling on tablet

### DIFF
--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -578,6 +578,20 @@
       padding: 16px;
     }
   }
+
+  &.CollapsibleFilters {
+    .Answers-viewResultsButton {
+      @include bplte(sm) {
+        width: 100%;
+      }
+    }
+
+    .CollapsibleFilters-unstuck {
+      @include bplte(sm) {
+        position: fixed;
+      }
+    }
+  }
 }
 
 .YxtPage-wrapper--detailShown {


### PR DESCRIPTION
Previously, the View Results button for Collapsible Filters was not
hanging at the bottom of the screen on tablet breakpoint. We fix this
specifically for the Interactive Map page type, where tablet breakpoint
should match the View Results button behavior of mobile.

J=SLAP-1058
TEST=manual

Check that the view results button on mobile, tablet, and desktop have
the correct behavior (desktop, position absolute to the content
wrapper).