### PR TITLE
Fix locator WCAG contrast issues

### DIFF
--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -12,6 +12,8 @@
 
   $border-default: 1px solid #666 !default;
 
+  $locator-text-gray: #737373;
+
   position: relative;
   display: flex;
   flex-direction: column;
@@ -238,7 +240,7 @@
       display: flex;
       align-items: center;
       border-top: var(--yxt-border-default);
-      color: #737373;
+      color: $locator-text-gray;
 
       &--desktop {
         display: none;
@@ -346,7 +348,7 @@
         border-top: var(--yxt-border-default);
         padding-left: 16px;
         padding-right: 16px;
-        color: #737373;
+        color: $locator-text-gray;
 
         @include bplte($mobile-break-point-max) {
           height: 60px;
@@ -565,7 +567,7 @@
   }
 
   &.CollapsibleFilters .yxt-VerticalResultsCount {
-    color: #737373;
+    color: $locator-text-gray;
   }
 
   &.CollapsibleFilters .Answers-viewResultsButton {

--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -238,7 +238,7 @@
       display: flex;
       align-items: center;
       border-top: var(--yxt-border-default);
-      color: var(--yxt-locationBias-text-color);
+      color: #737373;
 
       &--desktop {
         display: none;
@@ -346,6 +346,7 @@
         border-top: var(--yxt-border-default);
         padding-left: 16px;
         padding-right: 16px;
+        color: #737373;
 
         @include bplte($mobile-break-point-max) {
           height: 60px;
@@ -561,6 +562,10 @@
   
   &.CollapsibleFilters .Answers-resultsHeader {
     background-color: var(--hh-color-gray-2);
+  }
+
+  &.CollapsibleFilters .yxt-VerticalResultsCount {
+    color: #737373;
   }
 
   &.CollapsibleFilters .Answers-viewResultsButton {

--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -561,13 +561,13 @@
       }
     }
   }
+
+  .yxt-VerticalResultsCount {
+    color: $locator-text-gray;
+  }
   
   &.CollapsibleFilters .Answers-resultsHeader {
     background-color: var(--hh-color-gray-2);
-  }
-
-  &.CollapsibleFilters .yxt-VerticalResultsCount {
-    color: $locator-text-gray;
   }
 
   &.CollapsibleFilters .Answers-viewResultsButton {


### PR DESCRIPTION
The locator WCAG contrast issues by darkening the shade of grey

The default grey colors are fine against a white background, but since Product requested a grey background, the text doesn't meet the WCAG contrast ratio standard. Darken these values so that they pass the WCAG contrast test.

Note: Some of the other colors on the page don't pass the contrast test, but those aren't locator-specific so they are not addressed here

J=1059
TEST=manual

Run the WAVE evaluation tool and see that the locator colors pass the contrast tests