### PR TITLE
Add translations for the "Close Card" string.

### DIFF
--- a/translations/de.po
+++ b/translations/de.po
@@ -114,3 +114,10 @@ msgid "View 1 Result"
 msgid_plural "View [[count]] Results"
 msgstr[0] "1 Ergebnis anzeigen"
 msgstr[1] "[[count]] Ergebnisse anzeigen"
+
+#: cards/multilang-financial-professional-location/template.hbs:195
+#: cards/multilang-location-standard/template.hbs:206
+#: cards/multilang-professional-location/template.hbs:192
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Karte schließen"

--- a/translations/es.po
+++ b/translations/es.po
@@ -114,3 +114,10 @@ msgid "View 1 Result"
 msgid_plural "View [[count]] Results"
 msgstr[0] "Ver 1 resultado"
 msgstr[1] "Ver [[count]] resultados"
+
+#: cards/multilang-financial-professional-location/template.hbs:195
+#: cards/multilang-location-standard/template.hbs:206
+#: cards/multilang-professional-location/template.hbs:192
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Cerrar tarjeta"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -114,3 +114,10 @@ msgid "View 1 Result"
 msgid_plural "View [[count]] Results"
 msgstr[0] "Afficher 1 résultat"
 msgstr[1] "Afficher [[count]] résultats"
+
+#: cards/multilang-financial-professional-location/template.hbs:195
+#: cards/multilang-location-standard/template.hbs:206
+#: cards/multilang-professional-location/template.hbs:192
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Fermer la carte"

--- a/translations/it.po
+++ b/translations/it.po
@@ -114,3 +114,10 @@ msgid "View 1 Result"
 msgid_plural "View [[count]] Results"
 msgstr[0] "Visualizza 1 risultato"
 msgstr[1] "Visualizza [[count]] risultati"
+
+#: cards/multilang-financial-professional-location/template.hbs:195
+#: cards/multilang-location-standard/template.hbs:206
+#: cards/multilang-professional-location/template.hbs:192
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Chiudi scheda"

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -113,3 +113,10 @@ msgstr "並べ替えとフィルタ"
 msgid "View 1 Result"
 msgid_plural "View [[count]] Results"
 msgstr[0] "[[count]]件の結果を表示"
+
+#: cards/multilang-financial-professional-location/template.hbs:195
+#: cards/multilang-location-standard/template.hbs:206
+#: cards/multilang-professional-location/template.hbs:192
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "カードを閉じる"


### PR DESCRIPTION
This PR adds translations for the "Close Card" string that appears in some of
our result cards. French, German, Spanish, Italian, and Japanese translations
were all added.

TEST=none