### PR TITLE
 interactive-map: Fix scroll to result off by a few px

### DIFF
--- a/static/js/interactive-map/InteractiveMap.js
+++ b/static/js/interactive-map/InteractiveMap.js
@@ -29,12 +29,6 @@ class InteractiveMap extends ANSWERS.Component {
     this._pageWrapperEl = document.querySelector('.YxtPage-wrapper');
 
     /**
-     * The header DOM element
-     * @type {HTMLElement}
-     */
-    this._headerEl = this._pageWrapperEl.querySelector('.js-answersHeader');
-
-    /**
      * The results wrapper DOM element
      * @type {HTMLElement}
      */
@@ -401,7 +395,6 @@ class InteractiveMap extends ANSWERS.Component {
    * @param {HTMLElement} targetEl The result card to scroll to
    */
   scrollToResult(targetEl) {
-    const headerHeight = this._headerEl ? this._headerEl.offsetHeight : 0;
     const scrollContainer = this._resultsWrapperEl;
     const scrollDistance  = targetEl.offsetTop - scrollContainer.scrollTop;
 

--- a/static/js/interactive-map/InteractiveMap.js
+++ b/static/js/interactive-map/InteractiveMap.js
@@ -1,6 +1,6 @@
 import { Coordinate } from './Geo/Coordinate.js';
 import { smoothScroll } from './Util/SmoothScroll.js';
-import { getLanguageForProvider } from './Util/helpers.js';
+import { getLanguageForProvider, isViewableWithinContainer } from './Util/helpers.js';
 import { SearchDebouncer } from './SearchDebouncer';
 import { defaultCenterCoordinate } from './constants.js';
 
@@ -401,19 +401,12 @@ class InteractiveMap extends ANSWERS.Component {
    * @param {HTMLElement} targetEl The result card to scroll to
    */
   scrollToResult(targetEl) {
-    const stickyHeight = 0;
+    const headerHeight = this._headerEl ? this._headerEl.offsetHeight : 0;
+    const scrollContainer = this._resultsWrapperEl;
+    const scrollDistance  = targetEl.offsetTop - scrollContainer.scrollTop;
 
-    const header = this._headerEl;
-    const headerHeight = header ? header.offsetHeight : 0;
-
-    const container = this._resultsWrapperEl;
-    const elTop = targetEl.offsetTop - (container.scrollTop + container.offsetTop);
-    const elBottom = elTop + targetEl.offsetHeight;
-    const isScrolledIntoView = elTop >= stickyHeight && elBottom <= container.offsetHeight - headerHeight;
-
-    window.scroll = (x) => smoothScroll(container, x, 400);
-    if (!isScrolledIntoView) {
-      smoothScroll(container, elTop - stickyHeight, 400);
+    if (!isViewableWithinContainer(targetEl, scrollContainer)) {
+      smoothScroll(scrollContainer, scrollDistance, 400);
     }
   }
 

--- a/static/js/interactive-map/Util/helpers.js
+++ b/static/js/interactive-map/Util/helpers.js
@@ -33,7 +33,30 @@ const getEncodedSvg = (svg) => {
   return `data:image/svg+xml;charset=utf-8, ${encodeURIComponent(svg)}`;
 }
 
+/**
+ * Returns whether or not targetEl is viewable within containerEl, considering
+ * its container's scroll position and the target's offset from the top
+ *
+ * @param {HTMLElement} targetEl The element that is meant to be viewable
+ * @param {HTMLElement} containerEl The wrapper element, should be some ancestor for targetEl
+ * @return {boolean}
+ */
+const isViewableWithinContainer = (targetEl, containerEl) => {
+  const containerElViewableTop = containerEl.scrollTop;
+  const containerElViewableBottom = containerEl.scrollTop + containerEl.offsetHeight;
+  const targetElTop = targetEl.offsetTop;
+  const targetElBottom = targetEl.offsetTop + targetEl.offsetHeight;
+
+  const isScrolledIntoView =
+    targetElTop >= containerElViewableTop &&
+    targetElTop <= containerElViewableBottom &&
+    targetElBottom >= containerElViewableTop &&
+    targetElBottom <= containerElViewableBottom;
+  return isScrolledIntoView;
+};
+
 export {
   getLanguageForProvider,
-  getEncodedSvg
+  getEncodedSvg,
+  isViewableWithinContainer
 }


### PR DESCRIPTION
Previously, when clicking on a pin, the results list would move to the
card, except with a few px of padding between the top of the results
container and the selected card. This was not the case before the theme
migration (see the test site on staging).

To fix this, we change (and clean up) the way we find the scroll
distance and whether or not the card we are looking at is within view.

Note: Tested with a big header and header offset is not a variable in
calcualting the offset.

We also
(1) remove a useless `window.scroll` placement and
(2) move out non-class-specific code to a helper function

J=SLAP-1095
TEST=manual

Test that clicking on a pin correctly moves the card to the top of the
results container.

Try to find two cards that are right next to each other. Make sure being
at the lower card and then clicking the higher card takes you to the
higher card. Make sure being at the higher card and clicking on the
lower card in view will not scroll the results list.