### PR TITLE
interactive-map: Fix map height on all browsers

### DIFF
--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -159,6 +159,7 @@
       display: block;
       width: 100%;
       height: 100%;
+      min-height: 0;
 
       @include bplte($mobile-break-point-max)
       {


### PR DESCRIPTION
Previously, the map would much longer than the viewport height. This
is because of leftover styling from the old maps page type, where it
specified a min-height of 950px.

Now, we override that property, reset it to its default (min-height: 0)
and let the map take the height of its container, which should be 100%
of the page.

J=SLAP-1110
TEST=manual

Tested on Firefox, Chrome, Safari on MBP that the map is the correct
height and basic interactions like seeing pins within the visible map
area works, and clicking on a pin scrolls the results.

Tested on Browserstack iOS Safari the same things. Make sure if you
scroll past the map on mobile, you do not see the LocationBias/Search
this area toggle before the bottom of the map.