### PR TITLE
Update the Jambo version prescribed by the Theme.

### DIFF
--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -3988,9 +3988,9 @@
       "dev": true
     },
     "jambo": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.10.0.tgz",
-      "integrity": "sha512-eZXjzvVYVhSVIdgS5WPCeZLiaGbOXCmvAJgfuvwzDV+W2HpWdTfBLvFVPZuGaedcatpY2CKku1pUv38aRTYR6Q==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.10.2.tgz",
+      "integrity": "sha512-0pFBbClKQU9n9WIY7Bt0HNrLxS1zis/9B6arTh/Sic11jHyD8T8iybLe/DsF70br4VAwi0XLW9vq3tuFzuVD8A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.6",

--- a/static/package.json
+++ b/static/package.json
@@ -29,7 +29,7 @@
     "grunt-webpack": "^4.0.0",
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
-    "jambo": "^1.10.0",
+    "jambo": "^1.10.2",
     "jsdom": "^16.4.0",
     "mini-css-extract-plugin": "^0.11.0",
     "node-sass": "^4.13.1",


### PR DESCRIPTION
This PR updates the Jambo version specified in the static/package.json to the latest: v1.10.2.

TEST=none