### PR TITLE
interactive-map: Fix cluster click moves to wrong center

### DIFF
--- a/static/js/interactive-map/Maps/ProviderMap.js
+++ b/static/js/interactive-map/Maps/ProviderMap.js
@@ -189,21 +189,19 @@ class ProviderMap {
     throw new Error('not implemented');
   }
 
-/**
+  /**
    * @param {number} zoom
    * @param {Object} center Must be convertible to {@link Coordinate}
-   * @param {boolean} [animated=false] Whether to transition smoothly to the new bounds
+   * @param {boolean} animated Whether to transition smoothly to the new bounds
    * @see {@link ProviderMap#setZoom}
    * @see {@link ProviderMap#setCenter}
    */
-  setZoomCenter(zoom, center, animated = false) {
-    // Some maps change center when zooming and others snap to integer zoom when setting center.
-    // Set zoom a second time after setting center to fix for all providers.
+  setZoomCenter(zoom, center, animated) {
+    // This method doesn't need to be implemented for each provider,
+    // but it can be overridden if this default function doesn't work.
     this.setZoom(zoom, animated);
     this.setCenter(center, animated);
-    this.setZoom(zoom, animated);
   }
-
 }
 
 export {

--- a/static/js/interactive-map/Maps/Providers/Mapbox.js
+++ b/static/js/interactive-map/Maps/Providers/Mapbox.js
@@ -68,6 +68,14 @@ class MapboxMap extends ProviderMap {
       this.map.setZoom(zoom - 1);
     }
   }
+
+  setZoomCenter(zoom, coordinate, animated) {
+    const center = new mapboxgl.LngLat(coordinate.longitude, coordinate.latitude);
+
+    // Our standard zoom: at level 0, the world is 256 pixels wide and doubles each level
+    // Mapbox zoom: at level 0, the world is 512 pixels wide and doubles each level
+    this.map[animated ? 'easeTo' : 'jumpTo']({ center, zoom: zoom - 1 });
+  }
 }
 
 // Pin Class


### PR DESCRIPTION
Previously, if you clicked on a pin cluster on a mapbxo map, it would
take you to the current center of map, except zoomed in. This behavior
was a result of conflicting setZoom/setCenter calls on the map.

Instead, we want Mapbox to set the zoom center in one call. It turns
out Consulting fixed this in a recent commit. We add these changes to our
Consulting map code to allow Mapbox to setZoomCenter in its own way that
does not give undesired behavior.

J=SLAP-1134
TEST=manual

Test that clicking on a mapbox pin cluster will zoom you and take you to
the center of the pins within that cluster. The behavior before was
obviously taking you to the wrong location on a pin cluster click.