### PR TITLE
interactive-map: Add canvas click behavior

### DIFF
--- a/static/js/interactive-map/InteractiveMap.js
+++ b/static/js/interactive-map/InteractiveMap.js
@@ -209,7 +209,8 @@ class InteractiveMap extends ANSWERS.Component {
       pinClusterClickListener: pinClusterClickListener,
       dragEndListener: dragEndListener,
       zoomChangedListener: zoomChangedListener,
-      zoomEndListener: zoomEndListener
+      zoomEndListener: zoomEndListener,
+      canvasClickListener: () => this.removeResultFocusedStates()
     }));
   }
 
@@ -269,6 +270,20 @@ class InteractiveMap extends ANSWERS.Component {
     const lng = center.longitude;
 
     return new Coordinate(lat, lng);
+  }
+
+  /**
+   * Remove the result focused state styling from all cards and pins on the page
+   */
+  removeResultFocusedStates () {
+    this._container.classList.remove('InteractiveMap--detailShown');
+    this._pageWrapperEl.classList.remove('YxtPage-wrapper--detailShown');
+
+    document.querySelectorAll('.yxt-Card--pinFocused').forEach((el) => {
+      el.classList.remove('yxt-Card--pinFocused');
+    });
+
+    this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, null);
   }
 
   /**

--- a/static/js/interactive-map/Maps/Map.js
+++ b/static/js/interactive-map/Maps/Map.js
@@ -47,6 +47,7 @@ class MapOptions {
     this.dragEndHandler = () => {};
     this.zoomChangedHandler = () => {};
     this.zoomEndHandler = () => {};
+    this.canvasClickHandler = () => {};
     this.provider = null;
     this.providerOptions = {};
     this.singlePinZoom = 14;
@@ -191,6 +192,22 @@ class MapOptions {
   }
 
   /**
+   * @typedef Map~canvasClickHandler
+   * @function
+   */
+
+  /**
+   * @param {Map~canvasClickHandler} canvasClickHandler
+   * @returns {MapOptions}
+   */
+  withCanvasClickHandler (mapCanvasClickHandler) {
+    assertType(canvasClickHandler, Type.FUNCTION);
+
+    this.canvasClickHandler = canvasClickHandler;
+    return this;
+  }
+
+  /**
    * The MapProvider must be loaded before constructing a Map with it.
    * @param {MapProvider} provider
    * @returns {MapOptions}
@@ -281,6 +298,7 @@ class Map {
     this.setDragEndHandler(options.dragEndHandler);
     this.setZoomChangedHandler(options.zoomChangedHandler);
     this.setZoomEndHandler(options.zoomEndHandler);
+    this.setCanvasClickHandler(options.canvasClickHandler);
 
     // Remove all child elements of wrapper
     while (this._wrapper.firstChild) {
@@ -295,6 +313,7 @@ class Map {
       .withDragEndHandler(() => this._dragEndHandler())
       .withZoomChangedHandler(() => this.zoomChangedHandler())
       .withZoomEndHandler(() => this.zoomEndHandler())
+      .withCanvasClickHandler(() => this._canvasClickHandler())
       .withPanStartHandler(() => this.panStartHandler())
       .withProviderOptions(options.providerOptions)
       .build();
@@ -703,6 +722,15 @@ class Map {
     assertType(zoomEndHandler, Type.FUNCTION);
 
     this._zoomEndHandler = zoomEndHandler;
+  }
+
+  /**
+   * @param {Map~canvasClickHandler} canvasClickHandler
+   */
+  setCanvasClickHandler(canvasClickHandler) {
+    assertType(canvasClickHandler, Type.FUNCTION);
+
+    this._canvasClickHandler = canvasClickHandler;
   }
 
   /**

--- a/static/js/interactive-map/Maps/ProviderMap.js
+++ b/static/js/interactive-map/Maps/ProviderMap.js
@@ -22,6 +22,7 @@ class ProviderMapOptions {
     this.dragEndHandler = () => {};
     this.zoomChangedHandler = () => {};
     this.zoomEndHandler = () => {};
+    this.canvasClickHandler = () => {};
     this.providerOptions = {};
   }
 
@@ -115,6 +116,22 @@ class ProviderMapOptions {
   }
 
   /**
+   * @typedef ProviderMap~canvasClickHandler
+   * @function
+   */
+
+  /**
+   * @param {ProviderMap~canvasClickHandler} canvasClickHandler Function called when the map ends a zoom change
+   * @returns {ProviderMapOptions}
+   */
+  withCanvasClickHandler(canvasClickHandler) {
+    assertType(canvasClickHandler, Type.FUNCTION);
+
+    this.canvasClickHandler = canvasClickHandler;
+    return this;
+  }
+
+  /**
    * @param {Object} providerOptions A free-form object used to set any additional provider-specific options, usually by passing the object to the map's constructor
    * @returns {ProviderMapOptions}
    */
@@ -155,6 +172,7 @@ class ProviderMap {
     this._dragEndHandler = options.dragEndHandler;
     this._zoomChangedHandler = options.zoomChangedHandler;
     this._zoomEndHandler = options.zoomEndHandler;
+    this._canvasClickHandler = options.canvasClickHandler;
   }
 
   /**

--- a/static/js/interactive-map/Maps/Providers/Google.js
+++ b/static/js/interactive-map/Maps/Providers/Google.js
@@ -66,6 +66,9 @@ class GoogleMap extends ProviderMap {
         this._zoomEndHandler();
       });
     });
+    google.maps.event.addListener(this.map, 'click', () => {
+      this._canvasClickHandler();
+    });
   }
 
   getCenter() {

--- a/static/js/interactive-map/Maps/Providers/Mapbox.js
+++ b/static/js/interactive-map/Maps/Providers/Mapbox.js
@@ -37,6 +37,11 @@ class MapboxMap extends ProviderMap {
     this.map.on('dragend', () => this._dragEndHandler());
     this.map.on('zoomstart', () => this._zoomChangedHandler());
     this.map.on('zoomend', () => this._zoomEndHandler());
+    this.map.on('click', (e) => {
+      if (e.originalEvent.target.nodeName === 'CANVAS') {
+        this._canvasClickHandler();
+      }
+    });
   }
 
   getCenter() {

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -108,6 +108,7 @@ class NewMap extends ANSWERS.Component {
       .withPadding(this.config.mapPadding)
       .build();
     this.map = map;
+    window.mappp = this.map._map.map;
     this.addMapInteractions(map);
   }
 
@@ -139,6 +140,7 @@ class NewMap extends ANSWERS.Component {
         this.updateMapPropertiesInStorage();
         this.config.zoomEndListener(this.map.getZoom(), zoomTrigger);
       });
+      map.setCanvasClickHandler(() => this.config.canvasClickListener());
     });
 
     const mapRenderTargetOptions = new MapRenderTargetOptions()

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -108,7 +108,6 @@ class NewMap extends ANSWERS.Component {
       .withPadding(this.config.mapPadding)
       .build();
     this.map = map;
-    window.mappp = this.map._map.map;
     this.addMapInteractions(map);
   }
 

--- a/static/js/interactive-map/NewMapConfig.js
+++ b/static/js/interactive-map/NewMapConfig.js
@@ -181,6 +181,14 @@ export default class NewMapConfig {
     this.zoomEndListener = jsonConfig.zoomEndListener || function () {};
 
     /**
+     * Callback for when the map canvas is clicked
+     * A click does not include clicks to a pin or a map control
+     * A click is a mouseup and a mousedown with moving the mouse
+     * @type {Function}
+     */
+    this.canvasClickListener = jsonConfig.canvasClickListener || function () {};
+
+    /**
      * The minimum number of pins to be clustered
      * @type {number}
      */


### PR DESCRIPTION
When you click on a pin or a result card, it is meant to show the card
and the pin in a selected state. It is desired behavior that when you
click on the map canvas the current pin and result card should not be
focused anymore.

Because Mapbox and Google handle click events separately, we have to
have provider-specific code for finding when a canvas is clicked.

J=SLAP-1086
TEST=manual

Test that you can click on a pin and then click anywhere on the map
canvas to remove the select styling on both the results list and the
pin.

On mobile, show that clicking on the map canvas when a map pin is
focused will close the detail card and move the map to full height.

Test that you can click on a pin and then directly another pin and these
changes do not cause any unintended behvaior.

Test that you can click on a result card and then click the map canvas
and both the pin and card remove their focused styling.

Test that clicking on the map control or any other pin element on the
map will not trigger a canvas click event.