### PR TITLE
interactive-map: Remove results-specific storage listeners

### DIFF
--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -359,7 +359,6 @@ class NewMap extends ANSWERS.Component {
       callback: (data) => {
         const cardIndex = data.index;
         if (cardIndex + 1 === index) {
-          console.log('setting in card focus handler');
           this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, id);
         }
       }

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -69,6 +69,12 @@ class NewMap extends ANSWERS.Component {
      * @type {string}
      */
     this.selectedClusterPin = null;
+
+    /*
+     * A list of listeners to remove when results are updated
+     * @type {StorageListener[]}
+     */
+    this.resultsSpecificStorageListeners = [];
   }
 
   onCreate () {
@@ -347,16 +353,19 @@ class NewMap extends ANSWERS.Component {
       })
       .build();
 
-    this.core.storage.registerListener({
+    const cardFocusUpdateListener = {
       eventType: 'update',
       storageKey: StorageKeys.LOCATOR_CARD_FOCUS,
       callback: (data) => {
         const cardIndex = data.index;
         if (cardIndex + 1 === index) {
+          console.log('setting in card focus handler');
           this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, id);
         }
       }
-    });
+    };
+    this.resultsSpecificStorageListeners.push(cardFocusUpdateListener);
+    this.core.storage.registerListener(cardFocusUpdateListener);
     pin.setClickHandler(() => this.config.pinFocusListener(index, id));
     pin.setFocusHandler(() => this.config.pinFocusListener(index, id));
     pin.setHoverHandler(hovered => this.core.storage.set(
@@ -372,6 +381,11 @@ class NewMap extends ANSWERS.Component {
    * @param data The vertical results data
    */
   _updateMap (data) {
+    this.resultsSpecificStorageListeners.forEach((listener) => {
+      this.core.storage.removeListener(listener);
+    });
+    this.resultsSpecificStorageListeners = [];
+
     const verticalData = transformDataToVerticalData(data);
     const universalData = transformDataToUniversalData(data);
     let entityData = verticalData.length ? verticalData : universalData;


### PR DESCRIPTION
Previously, we would keep listeners for card clicks in storage all
searches. This is a problem because part of the listener is relying on
the index of the pinned card remaining static. However, we cannot rely
on this because the index of cards can change with every search.

We remove any results-specific listeners when the map is updated with
new pins. That way, we do not keep our old listeners from pins in a
different search state.

J=None
TEST=manual

Test that you can click on a cluster pin and it then click on a card in
the new results list. This should highlight the corresponding pin on the
map.