### PR TITLE
interactive-map: Add selected cluster pin styling on card click

### DIFF
--- a/static/js/interactive-map/Maps/MapPin.js
+++ b/static/js/interactive-map/Maps/MapPin.js
@@ -50,6 +50,15 @@ class MapPinOptions {
   }
 
   /**
+   * @param {string} id The unique id for the pin
+   * @returns {MapPinOptions}
+   */
+  withId(id) {
+    this.id = id
+    return this;
+  }
+
+  /**
    * @typedef MapPin~propertiesForStatus
    * @function
    * @param {Object} status A generic object whose properties define the state of the pin, from {@link MapPin#setStatus}
@@ -135,6 +144,8 @@ class MapPin {
       .withHoverHandler(hovered => this._hoverHandler(hovered))
       .build();
 
+    this._id = options.id;
+
     this._pin.setCoordinate(options.coordinate);
 
     this._status = {};
@@ -156,6 +167,14 @@ class MapPin {
    */
   getIcon(key) {
     return this._icons[key];
+  }
+
+  /**
+   * Get the unique identifier for the map pin
+   * @returns {string}
+   */
+  getId() {
+    return this._id;
   }
 
   /**

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -229,7 +229,8 @@ class NewMap extends ANSWERS.Component {
   }
 
   /**
-   * Update the pin and map state with select result information.
+   * Update the pin and map state with information about the selected result. This result
+   * may be selected by either a pin click or a card click.
    *
    * @param {string} id
    * @param {MapPin[]} pins
@@ -244,7 +245,8 @@ class NewMap extends ANSWERS.Component {
   }
 
   /**
-   * Update the pin and map state with selected result information.
+   * Update the pin and map state with information about the selected result. This result
+   * may be selected by either a pin click or a card click.
    * This will check if the selected result, identified by id, is in a cluster in clusters
    * and enact changes according to the selected cluster.
    * If not, fallback to the normal selected result behavior.

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -63,6 +63,12 @@ class NewMap extends ANSWERS.Component {
      * @type {string}
      */
     this.selectedPinId = null;
+
+    /**
+     * HTML element id for the selected cluster
+     * @type {string}
+     */
+    this.selectedClusterPin = null;
   }
 
   onCreate () {
@@ -147,8 +153,10 @@ class NewMap extends ANSWERS.Component {
       .withOnPostRender((data, map) => this.config.onPostMapRender(data, map, mapRenderTarget.getPins()))
       .withPinBuilder((pinOptions, entity, index) => this.buildPin(pinOptions, entity, index))
 
+    let pinClusterer;
     if (this.config.enablePinClustering) {
-      mapRenderTargetOptions.withPinClusterer(this.getClusterer());
+      pinClusterer = this.getClusterer();
+      mapRenderTargetOptions.withPinClusterer(pinClusterer);
     }
 
     const mapRenderTarget = mapRenderTargetOptions.build();
@@ -183,29 +191,86 @@ class NewMap extends ANSWERS.Component {
       eventType: 'update',
       storageKey: StorageKeys.LOCATOR_SELECTED_RESULT,
       callback: id => {
-        if (id != this.selectedPinId) {
-          const pins = mapRenderTarget.getPins();
+        if (id === this.selectedPinId) {
+          return;
+        }
 
-          if (this.selectedPinId && pins[this.selectedPinId]) {
-            pins[this.selectedPinId].setStatus({ selected: false });
-            this.selectedPinId = null;
-          }
+        const pins = mapRenderTarget.getPins();
 
-          if (id && pins[id]) {
-            pins[id].setStatus({ selected: true });
-            this.selectedPinId = id;
+        if (this.selectedPinId && pins[this.selectedPinId]) {
+          pins[this.selectedPinId].setStatus({ selected: false });
+          this.selectedPinId = null;
+        }
 
-            if (this.config.onPinSelect) {
-              this.config.onPinSelect();
-            }
+        if (this.selectedClusterPin) {
+          this.selectedClusterPin.setStatus({ selected: false });
+          this.selectedClusterPin = null;
+        }
 
-            if (!map.coordinateIsInVisibleBounds(pins[id].getCoordinate())) {
-              map.setCenterWithPadding(pins[id].getCoordinate(), true);
-            }
-          }
+        if (!id) {
+          return;
+        }
+
+        if (!pins[id]) {
+          throw new Error(`A pin with the id ${id} could not be found on the map.`);
+        }
+
+        if (this.config.enablePinClustering && pinClusterer) {
+          this.updateSelectedResultStateWithClusters(id, pins, pinClusterer.getClusters());
+        } else {
+          this.updateSelectedResultStateWithoutClusters(id, pins);
+        }
+
+        if (this.config.onPinSelect) {
+          this.config.onPinSelect();
         }
       }
     });
+  }
+
+  /**
+   * Update the pin and map state with select result information.
+   *
+   * @param {string} id
+   * @param {MapPin[]} pins
+   */
+  updateSelectedResultStateWithoutClusters(id, pins) {
+    pins[id].setStatus({ selected: true });
+    this.selectedPinId = id;
+
+    if (!this.map.coordinateIsInVisibleBounds(pins[id].getCoordinate())) {
+      this.map.setCenterWithPadding(pins[id].getCoordinate(), true);
+    }
+  }
+
+  /**
+   * Update the pin and map state with selected result information.
+   * This will check if the selected result, identified by id, is in a cluster in clusters
+   * and enact changes according to the selected cluster.
+   * If not, fallback to the normal selected result behavior.
+   *
+   * @param {string} id
+   * @param {MapPin[]} pins
+   * @param {PinCluster[]} clusters
+   */
+  updateSelectedResultStateWithClusters(id, pins, clusters) {
+    const filteredClusters = clusters.filter((cluster) => cluster.containsPin(id));
+
+    if (filteredClusters.length === 0) {
+      this.updateSelectedResultStateWithoutClusters(id, pins);
+      return;
+    }
+
+    const selectedCluster = filteredClusters[0];
+    const selectedClusterPin = selectedCluster.clusterPin;
+
+    selectedClusterPin.setStatus({ selected: true });
+    this.selectedPinId = id;
+    this.selectedClusterPin = selectedClusterPin;
+
+    if (!this.map.coordinateIsInVisibleBounds(selectedCluster.clusterPin.getCoordinate())) {
+      this.map.setCenterWithPadding(selectedCluster.clusterPin.getCoordinate(), true);
+    }
   }
 
   /**
@@ -228,7 +293,7 @@ class NewMap extends ANSWERS.Component {
       })
       .withPropertiesForStatus(status => {
         const properties = new PinProperties()
-          .setIcon(status.hovered || status.focused ? 'hovered' : 'default')
+          .setIcon(status.hovered || status.focused || status.selected ? 'hovered' : 'default')
           .setWidth(28)
           .setHeight(28);
 
@@ -248,7 +313,9 @@ class NewMap extends ANSWERS.Component {
    * @param {Number} index The index of the entity in the result list ordering
    */
   buildPin(pinOptions, entity, index) {
+    const id = 'js-yl-' + entity.profile.meta.id;
     const pin = pinOptions
+      .withId(id)
       .withIcon(
         'default',
         getEncodedSvg(this.config.pinImages.getDefaultPin(index, entity.profile)))
@@ -277,8 +344,6 @@ class NewMap extends ANSWERS.Component {
         return properties;
       })
       .build();
-
-    const id = 'js-yl-' + entity.profile.meta.id;
 
     this.core.storage.registerListener({
       eventType: 'update',

--- a/static/js/interactive-map/NewMap.js
+++ b/static/js/interactive-map/NewMap.js
@@ -213,7 +213,7 @@ class NewMap extends ANSWERS.Component {
    */
   getClusterer () {
     const clustererOptions = new PinClustererOptions()
-      .withClickListener(() => {
+      .withClickHandler(() => {
         this.updateMapPropertiesInStorage();
         this.config.pinClusterClickListener();
       })

--- a/static/js/interactive-map/PinClusterer/PinClusterer.js
+++ b/static/js/interactive-map/PinClusterer/PinClusterer.js
@@ -27,7 +27,7 @@ class PinCluster {
    * @returns {boolean}
    */
   containsPin(id) {
-    return this.pins.filter((pin) => pin.getId() === id).length;
+    return this.pins.filter(pin => pin.getId() === id).length;
   }
 }
 

--- a/static/js/interactive-map/PinClusterer/PinClusterer.js
+++ b/static/js/interactive-map/PinClusterer/PinClusterer.js
@@ -19,6 +19,16 @@ class PinCluster {
     this.clusterPin = clusterPin;
     this.pins = [...pins];
   }
+
+  /**
+   * Returns true if the cluster contains the pin with the given id, false otherwise
+   *
+   * @param {string} id The unique identifier for the pin
+   * @returns {boolean}
+   */
+  containsPin(id) {
+    return this.pins.filter((pin) => pin.getId() === id).length;
+  }
 }
 
 /**


### PR DESCRIPTION
This PR is split into two commits: One is adding changes to the
Consulting map code from their latest commits. The second is
building on top of that for our personal use case.

Previously, if you were using pin clustering, if you clicked on a result
card associated with a pin in a pin cluster, the map pin cluster would
not have selected styling. By default, this styling changes the color of
the cluster pin to separate it from other pins.

This change is important because we removed ordinals from cards. It is
important for users to be able to see that the card is associated with a
pin that is not on the map but rather in a cluster.

We build on top of Consulting locator code to store the id of the pins
and find the cluster if it exists.

J=SLAP-1085
TEST=manual

Test that you can click on a card in the results list and have it
highlight a cluster pin to indicate that the card exists in the cluster.

Test that you can click out of the selected cluster pin by clicking on
another card in the results list or on the canvas.

Test on both Google and Mapbox.