### PR TITLE
Add the 4 Column universal search layout. (#622)

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -26,6 +26,7 @@ $container-width: 1000px;
   --hh-product-tag-text-color: var(--yxt-color-brand-white);
   --hh-product-tag-background-color: var(--hh-color-gray-3);
   --hh-universal-grid-margin: 8px;
+  --hh-universal-grid-four-columns-width: calc(calc(100% - var(--hh-universal-grid-margin) * 8)/4);
   --hh-universal-grid-three-columns-width: calc(calc(100% - var(--hh-universal-grid-margin) * 6) / 3);
   --hh-universal-grid-two-columns-width: calc(calc(100% - var(--hh-universal-grid-margin) * 4) / 2);
   --hh-universal-section-title-text-color: var(--yxt-color-text-primary);

--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -30,6 +30,7 @@
 
 // Universal Section Template styling
 @import "universalsectiontemplates/standard";
+@import "universalsectiontemplates/grid-four-columns";
 @import "universalsectiontemplates/grid-three-columns";
 @import "universalsectiontemplates/grid-two-columns";
 

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -25,6 +25,7 @@ $container-width: 1000px;
   --hh-product-tag-text-color: var(--yxt-color-brand-white);
   --hh-product-tag-background-color: var(--hh-color-gray-3);
   --hh-universal-grid-margin: 8px;
+  --hh-universal-grid-four-columns-width: calc(calc(100% - var(--hh-universal-grid-margin) * 8)/4);
   --hh-universal-grid-three-columns-width: calc(calc(100% - var(--hh-universal-grid-margin) * 6) / 3);
   --hh-universal-grid-two-columns-width: calc(calc(100% - var(--hh-universal-grid-margin) * 4) / 2);
   --hh-universal-section-title-text-color: var(--yxt-color-text-primary);

--- a/static/scss/answers/universalsectiontemplates/grid-four-columns.scss
+++ b/static/scss/answers/universalsectiontemplates/grid-four-columns.scss
@@ -1,0 +1,26 @@
+/** @define HitchhikerResultsGridFourColumns */
+
+@import 'common';
+
+.HitchhikerResultsGridFourColumns
+{
+  @include universal-standard;
+
+  &-items
+  {
+    @include column-grid-items;
+  }
+
+  &-Card
+  {
+    &--universal
+    {
+      @media (min-width: $breakpoint-mobile-min) {
+        margin: var(--hh-universal-grid-margin);
+        flex-basis: var(--hh-universal-grid-four-columns-width);
+        max-width: var(--hh-universal-grid-four-columns-width);
+        border: var(--yxt-border-default);
+      }
+    }
+  }
+}

--- a/universalsectiontemplates/grid-four-columns.hbs
+++ b/universalsectiontemplates/grid-four-columns.hbs
@@ -1,0 +1,69 @@
+{{#if isSearchComplete}}
+  {{#if showNoResults}}
+    {{> noResults}}
+  {{/if}}
+  {{#if resultsPresent}}
+    <section class="HitchhikerResultsGridFourColumns HitchhikerResultsGridFourColumns--{{_config.modifier}} HitchhikerResultsGridFourColumns--universal">
+      {{> header}}
+      {{> map}}
+      {{> results}}
+      {{> viewMore}}
+    </section>
+  {{/if}}
+{{/if}}
+
+{{#*inline "noResults"}}
+  {{#if useLegacyNoResults}}
+    {{> results/noresults}}
+  {{/if}}
+{{/inline}}
+
+{{#*inline "header"}}
+  <div class="HitchhikerResultsGridFourColumns-title">
+    {{#if iconIsBuiltIn}}
+      <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+    {{else}}
+      <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+    {{/if}}
+    <div class="HitchhikerResultsGridFourColumns-titleLabel">{{_config.title}}</div>
+  </div>
+  <div data-component="ResultsHeader"></div>
+{{/inline}}
+
+{{#*inline "results"}}
+  <div class="HitchhikerResultsGridFourColumns-items js-HitchhikerResultsGridFourColumns-items">
+    {{#each results}}
+      <div class="HitchhikerResultsGridFourColumns-Card HitchhikerResultsGridFourColumns-Card--universal"
+        data-component="Card"
+        data-opts='{ "_index": {{@index}} }'>
+      </div>
+    {{/each}}
+    {{#each placeholders}}
+      <div class="HitchhikerResultsGridFourColumns-Card-placeholder" aria-hidden="true"></div>
+    {{/each}}
+  </div>
+{{/inline}}
+
+{{#*inline "map"}}
+  {{#if _config.includeMap}}
+    <div class="HitchhikerResultsGridFourColumns-map"
+          data-component="Map"
+          data-prop="map">
+    </div>
+  {{/if}}
+{{/inline}}
+
+{{#*inline "viewMore"}}
+  {{#if _config.isUniversal}}
+    <div class="HitchhikerResultsGridFourColumns-viewMore">
+      <a class="HitchhikerResultsGridFourColumns-viewMoreLink" 
+         href="{{ verticalURL }}"
+         data-eventtype="VERTICAL_VIEW_ALL"
+         data-eventoptions='{{eventOptions}}'
+      >
+        <div class="HitchhikerResultsGridFourColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
+        <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+      </a>
+    </div>
+  {{/if}}
+{{/inline}}


### PR DESCRIPTION
This PR adds a new universal section template: grid-four-columns. This
template lays out the results in a four column grid (as the name suggests).
The layout works best with the product type cards and, as such, has only
been tested with them. We already had an existing Hitchhiker-4-columns CSS
class that can be used in a vertical-grid template.

J=SLAP-989
TEST=manual

Built a sample site and used the new section template for the products
vertical. Also made sure that the product vertical page was using the
Hitchhikers-4-columns class. Verified things looked correct on universal and
vertical. Screenshots will be attached.