### PR TITLE
interactive-map: Fix uncommenting navigation component

### DIFF
--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -141,8 +141,8 @@
     {
       display: flex;
       flex-direction: column;
-      flex-grow: 1;
       position: relative;
+      width: 100%;
     }
 
     &-mapWrapper {

--- a/templates/vertical-interactive-map/page.html.hbs
+++ b/templates/vertical-interactive-map/page.html.hbs
@@ -25,7 +25,7 @@
             <div class="Answers-searchWrapper js-sticky">
               <div class="Answers-form">
                 {{> templates/vertical-interactive-map/markup/searchbar }}
-                {{!-- {{> templates/vertical-grid/markup/navigation }} --}} 
+                {{!-- {{> templates/vertical-interactive-map/markup/navigation }} --}}
               </div>
             </div>
             <div class="Answers-resultsHeaderTop">


### PR DESCRIPTION
We should be able to uncomment the navigation partials in the page hbs
for vertical-interactive-map. This should show the navigation component
with the correct styling. Fix a bug where we were referencing the wrong
partial. Then fix the styling so it stays within its container.

J=SLAP-1166
TEST=manual

Test that you can see the Navigation component when you uncomment the
script partial and the html partial. Also ensure that the Navigation
does not leak its container horizontally, on the latest theme.