### PR TITLE
Add default styling for `<mark/>` tags in inline snippets. (#644)

### DIFF
--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -180,4 +180,11 @@ $container-width-at-collapsed-filters-breakpoint: $breakpoint-collapsed-filters 
   .yxt-SortOptions-optionLabel {
     font-size: var(--yxt-filters-and-sorts-font-size);
   }
+
+  .yxt-Card-child {
+    mark {
+      background-color: unset;
+      font-weight: var(--yxt-font-weight-medium);
+    }
+  }
 }


### PR DESCRIPTION
The new Document Search work allows the back-end to return inline,
highlightable snippets for individual results. The snippets will
be highlighted using `<mark/>` tags, but we do not want the user
agent styling for those elements. Instead, we want the wrapped text
to have no background and be bolded.

J=SLAP-1165
TEST=manual

Used the highlightField formatter on a couple of different results cards.
Verified that the `<mark/>` tags had the proper styling.