### PR TITLE
interactive-map: Fix interactions when no filters

### DIFF
--- a/static/js/collapsible-filters/interactions.js
+++ b/static/js/collapsible-filters/interactions.js
@@ -13,6 +13,7 @@ export default class Interactions {
     this.resultsColumn = document.querySelector('.js-answersResultsColumn');
     this.inactiveCssClass = 'CollapsibleFilters-inactive';
     this.collapsedcCssClass = 'CollapsibleFilters--collapsed';
+    this.expandedCssClass = 'CollapsibleFilters--expanded';
     this.resultsWrapper = document.querySelector('.js-answersResultsWrapper')
       || document.querySelector('.Answers-resultsWrapper');
     this._updateStickyButton = this._updateStickyButton.bind(this);
@@ -189,8 +190,10 @@ export default class Interactions {
    */
   toggleCollapsedStatusClass(isCollapsed) {
     if (isCollapsed) {
+      this.collapsibleFiltersParentEl.classList.remove(this.expandedCssClass);
       this.collapsibleFiltersParentEl.classList.add(this.collapsedcCssClass)
     } else {
+      this.collapsibleFiltersParentEl.classList.add(this.expandedCssClass);
       this.collapsibleFiltersParentEl.classList.remove(this.collapsedcCssClass);
     }
   }

--- a/static/scss/answers/interactive-map/InteractiveMap.scss
+++ b/static/scss/answers/interactive-map/InteractiveMap.scss
@@ -469,16 +469,6 @@
     }
   }
 
-  &:not(.CollapsibleFilters--collapsed) {
-    .Answers-mobileToggles {
-      display: none;
-    }
-
-    .Answers-stickyBottom {
-      display: none;
-    }
-  }
-
   // TODO move to js
   &.InteractiveMap--noResults {
     .Answers-searchThisAreaWrapper {
@@ -600,6 +590,16 @@
   }
 
   &.CollapsibleFilters {
+    &.CollapsibleFilters--expanded {
+      .Answers-mobileToggles {
+        display: none;
+      }
+
+      .Answers-stickyBottom {
+        display: none;
+      }
+    }
+
     .Answers-viewResultsButton {
       @include bplte(sm) {
         width: 100%;

--- a/templates/vertical-interactive-map/collapsible-filters/page-setup.js
+++ b/templates/vertical-interactive-map/collapsible-filters/page-setup.js
@@ -8,6 +8,7 @@ const collapsibleFiltersInteractions = new CollapsibleFilters.Interactions({
   resultEls: document.querySelectorAll('.js-answersResults,.js-answersFooter'),
   disableScrollToTopOnToggle: true
 });
+window.collapsibleFiltersInteractions = collapsibleFiltersInteractions;
 
 // When a search is made with the searchbar, collapse the filters.
 collapsibleFiltersInteractions.registerCollapseFiltersOnSearchbarSearch();

--- a/theme-components/interactive-map/script.js
+++ b/theme-components/interactive-map/script.js
@@ -16,7 +16,7 @@ ANSWERS.addComponent('InteractiveMap', Object.assign({},
   ),
   pageSettings: {{{ json pageSettings }}},
   onPinSelect: () => {
-    collapsibleFiltersInteractions.collapseFilters();
+    window.collapsibleFiltersInteractions && window.collapsibleFiltersInteractions.collapseFilters();
   },
   locale: "{{global_config.locale}}",
   verticalKey: "{{{verticalKey}}}",


### PR DESCRIPTION
There were two problems we needed to consider:

1. The collapsibleFiltersInteractions variable might not exist. This is
   because the filters are not uncommented in the page html.hbs by default.
   It seems brittle to rely on this variable being created in another
   file. Thus, we add it to the window and check it on the window
   instead of relying on collapsibleFiltersInteractions as a local
   variable.

2. To hide the Location Bias component and Search This Area toggle, we
   were relying on a class :not(.CollapsibleFilters--collapsed). This is
   the default state when collapsible filters are commented out. That
   is, the --collapsed class is not added to the page when there are no
   Collapsible Filters. To account for this, we add a class signaling
   that the collapsible filters are actually expanded to know that we
   should hide something on an expanded UI.

J=SLAP-1167
TEST=manual

With collapsible filters commented out:
* Test that you can click on a map pin on the interactive map vertical
  page and it will scroll you to the correct card.
* Test that the Location Bias and Search This Area toggle interfaces
  still show up on the bottom of the results on desktop.

With collapsible filters uncommented:
* Test that you can click on a map pin on the interactive map vertical
  page and it will scroll you to the correct card.
* Test that you can click on a map pin on the interactive map vertical
  page while cfilters are expanded and it will scroll you to the correct
  card.
* Test that the Location Bias and Search This Area toggle interfaces
  still show up on the bottom of the results on desktop.
* Test that the Location Bias and Search This Area toggle interfaces
  don't show up on the bottom of the results when cfilters are expanded.