### PR TITLE
Remove default star icon behavior from Universal Section Templates.

### DIFF
--- a/universalsectiontemplates/grid-four-columns.hbs
+++ b/universalsectiontemplates/grid-four-columns.hbs
@@ -20,10 +20,12 @@
 
 {{#*inline "header"}}
   <div class="HitchhikerResultsGridFourColumns-title">
-    {{#if iconIsBuiltIn}}
-      <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
-    {{else}}
-      <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+    {{#if _config.icon}}
+      {{#if iconIsBuiltIn}}
+        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+      {{else}}
+        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+      {{/if}}
     {{/if}}
     <div class="HitchhikerResultsGridFourColumns-titleLabel">{{_config.title}}</div>
   </div>

--- a/universalsectiontemplates/grid-three-columns.hbs
+++ b/universalsectiontemplates/grid-three-columns.hbs
@@ -21,10 +21,12 @@
 
 {{#*inline "header"}}
   <div class="HitchhikerResultsGridThreeColumns-title">
-    {{#if iconIsBuiltIn}}
-      <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
-    {{else}}
-      <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+    {{#if _config.icon}}
+      {{#if iconIsBuiltIn}}
+        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+      {{else}}
+        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+      {{/if}}
     {{/if}}
     <div class="HitchhikerResultsGridThreeColumns-titleLabel">{{_config.title}}</div>
   </div>

--- a/universalsectiontemplates/grid-two-columns.hbs
+++ b/universalsectiontemplates/grid-two-columns.hbs
@@ -21,10 +21,12 @@
 
 {{#*inline "header"}}
   <div class="HitchhikerResultsGridTwoColumns-title">
-    {{#if iconIsBuiltIn}}
-      <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
-    {{else}}
-      <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+    {{#if _config.icon}}
+      {{#if iconIsBuiltIn}}
+        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+      {{else}}
+        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+      {{/if}}
     {{/if}}
     <div class="HitchhikerResultsGridTwoColumns-titleLabel">{{_config.title}}</div>
   </div>

--- a/universalsectiontemplates/standard.hbs
+++ b/universalsectiontemplates/standard.hbs
@@ -21,10 +21,12 @@
 
 {{#*inline "header"}}
   <div class="HitchhikerResultsStandard-title">
-    {{#if iconIsBuiltIn}}
-      <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
-    {{else}}
-      <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+    {{#if _config.icon}}
+      {{#if iconIsBuiltIn}}
+        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+      {{else}}
+        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+      {{/if}}
     {{/if}}
     <div class="HitchhikerResultsStandard-titleLabel">{{_config.title}}</div>
   </div>


### PR DESCRIPTION
This PR adds a check to each of the section templates such that no Icon
component is rendered unless there is actually a `_config.icon`. What was
happening was that even if there was no icon config, a star icon component
would still get rendered.

J=SLAP-1170
TEST=manual

Verified that the default star icon no longer appeared in each of the section
templates. If an icon was specified in the config, though, it did appear
properly.