### PR TITLE
interactive-map: Address race condition for components

### DIFF
--- a/templates/vertical-interactive-map/page-setup.js
+++ b/templates/vertical-interactive-map/page-setup.js
@@ -7,5 +7,5 @@ if (window.locatorBundleLoaded) {
   locatorBundleScript.onload = function() {
     {{> theme-components/new-map/script}}
     {{> theme-components/interactive-map/script}}
-  }();
+  };
 }

--- a/templates/vertical-interactive-map/page-setup.js
+++ b/templates/vertical-interactive-map/page-setup.js
@@ -1,2 +1,11 @@
-{{> theme-components/new-map/script}}
-{{> theme-components/interactive-map/script}}
+if (window.locatorBundleLoaded) {
+  {{> theme-components/new-map/script}}
+  {{> theme-components/interactive-map/script}}
+} else {
+  const locatorBundleScript = document.querySelector('script#js-answersLocatorBundleScript');
+
+  locatorBundleScript.onload = function() {
+    {{> theme-components/new-map/script}}
+    {{> theme-components/interactive-map/script}}
+  }();
+}

--- a/templates/vertical-interactive-map/page.html.hbs
+++ b/templates/vertical-interactive-map/page.html.hbs
@@ -17,7 +17,8 @@
     {{> templates/vertical-interactive-map/script/locationbias modifier="main" }}
     {{> templates/vertical-interactive-map/script/locationbias modifier="mobileMap" }}
   {{/script/core }}
-  <script src="{{relativePath}}/locator-bundle.js" defer></script>
+  <script id="js-answersLocatorBundleScript" src="{{relativePath}}/locator-bundle.js"
+    onload="window.locatorBundleLoaded = true;" defer></script>
     <div class="Answers AnswersVerticalMap CollapsibleFilters InteractiveMap InteractiveMap--listShown js-answersInteractiveMap">
       <div class="Answers-content">
         <div class="Answers-contentWrap js-locator-contentWrap" role="region" aria-label="{{ translate phrase="Main location search" }}">


### PR DESCRIPTION
We were seeing that intermittently the NewMap component was not defined
when trying to add it as a component in the ANSWERS.onReady.

The locator-bundle.js loads the map components to the page. This means
that adding the InteractiveMap component requires two scripts to be
ready: the Answers SDK and the bundle. By putting it in the core
partial, we know it's running when the SDK is ready, but we get no
guarantees about the bundle.

Here we add a window flag to let code know that the script has been
loaded. If the flag is set, we add the components like normal. If the
flag is not set, we assign an onload to the script.

This was not happening locally as the file loads fairly quickly through
localhost.

There were other options considered:
* Remove the defer from the locator-bundle. This would have meant that
  the script would block the rest of the page from loading until the components
  were loaded. This felt like it would be a page speed hit we could go
  without.
* Inline the components to avoid the defer / load problem altogether.
  This was not possible with our current `data-webpack-inline` because
  it is part of a separate bundle. It would take more dev work to fix
  our webpack to allow inlining across different bundles.

J=SLAP-1171
TEST=manual

Tested locally, general smoke test to see that the NewMap component
shows up and you can see an experience (you would not be able to see an
experience if anything failed in the bundle loading).

Tested on live preview on a Jambo site with these changes. Previously, every
2-3 refreshes would show the error. Tested this error doesn't show up with
the changes after many refreshes. Also added a `console.log` to show the
status of `window.locatorBundleLoaded` and it works when it is both
`undefined` and `true` at the start of the addComponent calls.