### PR TITLE
Support the 4 column layout at all breakpoints

### DIFF
--- a/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
+++ b/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
@@ -8,6 +8,7 @@
       width: $container-width-at-collapsed-filters-breakpoint / $breakpoint-collapsed-filters * 100%;
     }
   }
+
   .yxt-FilterOptions {
     &-fieldSet {
       margin: 0;

--- a/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
+++ b/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
@@ -1,4 +1,13 @@
+ // This variable does not change the filters width. It is simply used for calculation
+ $filters-width: 242px;
+ $container-width-at-collapsed-filters-breakpoint: $breakpoint-collapsed-filters - (2 * $filters-width);
+
 @mixin CollapsibleFiltersOverrides {
+  .Answers-container {
+    @media (min-width: #{$breakpoint-expanded-filters}) {
+      width: $container-width-at-collapsed-filters-breakpoint / $breakpoint-collapsed-filters * 100%;
+    }
+  }
   .yxt-FilterOptions {
     &-fieldSet {
       margin: 0;

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -1,8 +1,5 @@
 // answers theme goes here
 
- // This variable does not change the filters width. It is simply used for calculation
-$filters-width: 242px;
-$container-width-at-collapsed-filters-breakpoint: $breakpoint-collapsed-filters - (2 * $filters-width);
 
 .Answers
 {
@@ -19,10 +16,6 @@ $container-width-at-collapsed-filters-breakpoint: $breakpoint-collapsed-filters 
     margin-right: auto;
     max-width: var(--hh-answers-container-width);
     width: 100%;
-
-    @media (min-width: #{$breakpoint-expanded-filters}) {
-      width: $container-width-at-collapsed-filters-breakpoint / $breakpoint-collapsed-filters * 100%;
-    }
   }
 
   &-search,

--- a/static/scss/answers/universalsectiontemplates/common.scss
+++ b/static/scss/answers/universalsectiontemplates/common.scss
@@ -207,18 +207,6 @@
     flex-basis: 100%;
     flex-grow: 1;
 
-    &,
-    &-placeholder {
-      border: var(--yxt-border-default);
-      margin-right: var(--yxt-cards-margin);
-    }
-
-    &-placeholder {
-      visibility: hidden;
-      border-top: none;
-      border-bottom: none;
-    }
-
     &-child {
       flex-grow: 1;
       min-height: 1px;

--- a/static/scss/answers/universalsectiontemplates/common.scss
+++ b/static/scss/answers/universalsectiontemplates/common.scss
@@ -209,7 +209,6 @@
 
     &,
     &-placeholder {
-      min-width: var(--yxt-cards-min-width);
       border: var(--yxt-border-default);
       margin-right: var(--yxt-cards-margin);
     }

--- a/universalsectiontemplates/grid-four-columns.hbs
+++ b/universalsectiontemplates/grid-four-columns.hbs
@@ -40,9 +40,6 @@
         data-opts='{ "_index": {{@index}} }'>
       </div>
     {{/each}}
-    {{#each placeholders}}
-      <div class="HitchhikerResultsGridFourColumns-Card-placeholder" aria-hidden="true"></div>
-    {{/each}}
   </div>
 {{/inline}}
 

--- a/universalsectiontemplates/grid-three-columns.hbs
+++ b/universalsectiontemplates/grid-three-columns.hbs
@@ -41,9 +41,6 @@
         data-opts='{ "_index": {{@index}} }'>
       </div>
     {{/each}}
-    {{#each placeholders}}
-      <div class="HitchhikerResultsGridThreeColumns-Card-placeholder" aria-hidden="true"></div>
-    {{/each}}
   </div>
 {{/inline}}
 

--- a/universalsectiontemplates/grid-two-columns.hbs
+++ b/universalsectiontemplates/grid-two-columns.hbs
@@ -41,9 +41,6 @@
         data-opts='{ "_index": {{@index}} }'>
       </div>
     {{/each}}
-    {{#each placeholders}}
-      <div class="HitchhikerResultsGridTwoColumns-Card-placeholder" aria-hidden="true"></div>
-    {{/each}}
   </div>
 {{/inline}}
 

--- a/universalsectiontemplates/standard.hbs
+++ b/universalsectiontemplates/standard.hbs
@@ -41,9 +41,6 @@
         data-opts='{ "_index": {{@index}} }'>
       </div>
     {{/each}}
-    {{#each placeholders}}
-      <div class="HitchhikerResultsStandard-Card-placeholder" aria-hidden="true"></div>
-    {{/each}}
   </div>
 {{/inline}}
 


### PR DESCRIPTION
Support the 4 column layout at all breakpoints

The layout wasn't working at breakpoints because there was a min-width on the placeholder cards which interfered with the 4 column width.  Removing that fixes it. In fact, we don't need the placeholders anymore since we are setting the widths  directly, so I removed those entirely.

The page width shrinks to take into account filters on the left side of the page. Since this styling is specific to CFilters, I moved the CSS to the CFilters styling. This means that the universal page no longer shrinks to accommodate filters since filters aren't supported on the universal page.

J=SLAP-1169
TEST=manual

Confirm that the 4 column layout works at all breakpoints. Test deleting some of the cards and observe them maintain the proper size. Also test this on the 3 other unviersalsectiontemplates. Observe that the container on the universal page maintains its larger size for longer since it is no longer shrinking to try to accommodate filters. 