### PR TITLE
scripts: Use canary/latest css and templates

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -137,7 +137,9 @@
     {{/babel}}
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.css">
+    <!-- TODO: change back to versioned answers script when new storage is available widely -->
+    <!-- <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.css"> --->
+    <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/canary/latest/answers.css">
     <link rel="stylesheet" type="text/css" href="{{relativePath}}/bundle.css" data-webpack-inline>
   </head>
   <body>

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -4,7 +4,9 @@
     console.error('ERROR: no sdkVersion specified, please specify an sdkVersion in the global_config.');
   }
 </script>
-<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answerstemplates.compiled.min.js" defer></script>
+<!-- TODO: change back to versioned answers script when new storage is available widely -->
+<!-- <script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answerstemplates.compiled.min.js" defer></script> -->
+<script src="https://assets.sitescdn.net/answers/canary/latest/answerstemplates.compiled.min.js" defer></script>
 <script>
 {{#babel}}
   function initAnswers() {


### PR DESCRIPTION
While we are in EA, we want to use the canary/latest branch of the SDK
to see how our changes work with the new library changes. This means we
use canary/latest for all SDK assets.

This item is necessary because we noticed that the star icon was still
showing for verticals on univeral pages. Specifically, the star icon
would show when this vertical was not an entry in any verticalsToConfig
of any config.json file.

J=SLAP-1173
TEST=manual

Run on a local jambo site, show that stars aren't showing for verticals
that have no corresponding entry in any verticalsToConfig.