### PR TITLE
Set a default matchedSubstrings for the highlightField formatter

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -544,7 +544,7 @@ export function price(fieldValue = {}, locale) {
  * @param {Array<Object>} matchedSubstrings The list of matched substrings to
  *                                          highlight.
  */
-export function highlightField(fieldValue, matchedSubstrings) {
+export function highlightField(fieldValue, matchedSubstrings = []) {
   let highlightedString = fieldValue;
 
   // We must first sort the matchedSubstrings by decreasing offset. 


### PR DESCRIPTION
Set a default to the formatter so that it doesn't bork out if the array isn't supplied

J=none
TEST=manual

Confirm that it doesn't throw an error if the array isn't supplied to the formatter