### PR TITLE
cardcreator: Add partials path if cards/ dir already exists

### DIFF
--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra');
-const { addToPartials } = require('./helpers/utils/jamboconfigutils');
+const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
 const path = require('path');
 const UserError = require('./helpers/errors/usererror');
 const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
@@ -114,7 +114,8 @@ class CardCreator {
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
     if (fs.existsSync(templateCardFolder)) {
-      !fs.existsSync(this._customCardsDir) && this._createCustomCardsDir();
+      !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
+      !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
       fs.copySync(templateCardFolder, cardFolder);
       this._renameCardComponent(cardFolderName, cardFolder);
     } else {
@@ -154,15 +155,6 @@ class CardCreator {
       .replace(registerComponentTypeRegex, `(${customComponentClassName})`)
       .replace(new RegExp(originalComponentName, 'g'), customCardName)
       .replace(/cards[/_](.*)[/_]template/g, `cards/${customCardName}/template`);
-  }
-
-  /**
-   * Creates the 'cards' directory in the Jambo repository and adds the newly 
-   * created directory to the list of partials in the Jambo config.
-   */
-  _createCustomCardsDir() {
-    fs.mkdirSync(this._customCardsDir);
-    addToPartials(this._customCardsDir);
   }
 }
 module.exports = CardCreator;

--- a/commands/directanswercardcreator.js
+++ b/commands/directanswercardcreator.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra');
-const { addToPartials } = require('./helpers/utils/jamboconfigutils');
+const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
 const path = require('path');
 const UserError = require('./helpers/errors/usererror');
 const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
@@ -114,7 +114,8 @@ class DirectAnswerCardCreator {
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
     if (fs.existsSync(templateCardFolder)) {
-      !fs.existsSync(this._customCardsDir) && this._createCustomCardsDir();
+      !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
+      !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
       fs.copySync(templateCardFolder, cardFolder);
       this._renameCardComponent(cardFolderName, cardFolder);
     } else {
@@ -158,15 +159,6 @@ class DirectAnswerCardCreator {
       .replace(
         /directanswercards[/_](.*)[/_]template/g,
         `directanswercards/${customCardName}/template`);
-  }
-
-  /**
-   * Creates the 'directanswercards' directory in the Jambo repository and adds the newly 
-   * created directory to the list of partials in the Jambo config.
-   */
-  _createCustomCardsDir() {
-    fs.mkdirSync(this._customCardsDir);
-    addToPartials(this._customCardsDir);
   }
 }
 

--- a/commands/helpers/utils/jamboconfigutils.js
+++ b/commands/helpers/utils/jamboconfigutils.js
@@ -53,3 +53,17 @@ exports.addToPartials = function (partialsPath) {
     fs.writeFileSync('jambo.json', stringify(jamboConfig, null, 2));
   }
 }
+
+/**
+ * Returns whether or not the partialsPath exists in the partials object in the
+ * Jambo config
+ *
+ * @param {Object} jamboConfig The parsed jambo config
+ * @param {string} partialsPath The local path to the set of partials. 
+ * @returns {boolean}
+ */
+exports.containsPartial = function (jamboConfig, partialsPath) {
+  return jamboConfig.dirs
+    && jamboConfig.dirs.partials
+    && jamboConfig.dirs.partials.includes(partialsPath);
+}


### PR DESCRIPTION
We were seeing behavior where if the `cards/` directory already existed
in a repository (the new card directory at the top-level of a
repository), then the cardcreator would not automatically add "cards" as
a partial in the jambo.json. This is necessary to have jambo register
the new card partial.

We add a check to make sure it exists as a partial when a card is
created, instead of adding it only when the cards directory doesn't
exist.

We also do this for direct answer cards.

J=None
TEST=manual

Test on a local jambo repository

npx jambo card --name president-fork --templateCardFolder themes/answers-hitchhiker-theme/cards/standard

When creating a card and the cards directory already exists,
and the jambo.json partials doesn't contain the cards directory
and changing a cardType to use the new card (president-fork),
(1) the card is used
(2) the cards directory is not re-created
(3) the jambo.json is updated to include the partial cards

When creating a card and the cards directory does not already exist
and the jambo.json partials doesn't contain the cards directory
and changing a cardType to use the new card (president-fork),
(1) the card is used
(2) the cards directory is created
(3) the jambo.json is updated to include the partial cards

When creating a card and the cards directory already exists
and the jambo.json partials contains the cards directory
and changing a cardType to use the new card (president-fork),
(1) the card is used
(2) the cards directory is not re-created
(3) the jambo.json is not updated

All above test cases with direct answer cards as well.