### PR TITLE
ie11: fix results height

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -58,6 +58,12 @@
       display: flex;
       flex-direction: column;
 
+      // IE11 only styling to fix content height problem
+      @media (-ms-high-contrast:none)
+      {
+        height: 100%;
+      }
+
       @include bpgte($desktop-break-point-min)
       {
         width: $results-width-desktop;
@@ -69,6 +75,12 @@
         border-radius: 4px;
         box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.25);
         background-color: var(--hh-color-gray-2);
+
+        // IE11 only styling to fix content height problem
+        @media (-ms-high-contrast:none)
+        {
+          height: calc(100% - #{$results-padding-top} - #{$results-padding-bottom});
+        }
       }
 
       @include bplte($mobile-break-point-max)


### PR DESCRIPTION
Previously, the height of the results wrapper on desktop, only in
Internet Explorer 11, would not respect the height of its parent. This
is apparently a larger issue with flexbox in IE11 (GH issue below).
The solutions on the thread did not appear to solve our issue because we
absolute our container.

GH issue: philipwalton/ flexbugs/ issues/216

So, instead we make the height explicit and static for IE11 only. This
has the caveat where if you have a small results list, there will be
white space between the last result and the footer of the results
container. Have talked to product and they are fine with this decision
as it affects IE11 only.

J=SLAP-1148
TEST=manual

Test on IE11, Edge, Google Chrome

Test that the styling only affects IE11. If you go to a query on the
vertical full page map page type, where only 1-2 results show up, the
height should be dynamic on all browsers except for IE11. That is, the
height should be smaller for smaller results on Chrome, on IE11, there
should be whitespace between the end of the results and the bottom of
the results box.