### PR TITLE
Fix a bug with the price formatter.

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -527,7 +527,7 @@ export { generateCTAFieldTypeLink };
  */
 export function price(fieldValue = {}, locale) {
   const localeForFormatting = locale || _getDocumentLocale() || 'en';
-  const price = fieldValue.value && parseInt(fieldValue.value);
+  const price = fieldValue.value && parseFloat(fieldValue.value);
   const currencyCode = fieldValue.currencyCode && fieldValue.currencyCode.split('-')[0];
   if (!price || isNaN(price) || !currencyCode) {
     console.warn(`No price or currency code in the price fieldValue object: ${fieldValue}`);

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -54,31 +54,31 @@ describe('Formatters', () => {
 
   describe('price', () => {
     const priceField = {
-      value: '100',
+      value: '100.99',
       currencyCode: 'USD-US Dollar'
     };
     it('Formats a price in USD', () => {
       const price = Formatters.price(priceField, 'en');
-      expect(price).toEqual('$100.00');
+      expect(price).toEqual('$100.99');
     });
     it('Formats a price in USD with no provided locale', () => {
       const price = Formatters.price(priceField);
-      expect(price).toEqual('$100.00');
+      expect(price).toEqual('$100.99');
     });
     it('Formats a price in USD with a non-en locale', () => {
       const price = Formatters.price(priceField, 'fr');
-      expect(price).toEqual('100,00 $US');
+      expect(price).toEqual('100,99 $US');
     });
 
     it('Formats a price in EUR', () => {
       priceField.currencyCode = 'EUR-Euro';
       const price = Formatters.price(priceField);
-      expect(price).toEqual('€100.00');
+      expect(price).toEqual('€100.99');
     });
     it('Formats a price in EUR with a non-en locale', () => {
       priceField.currencyCode = 'EUR-Euro';
       const price = Formatters.price(priceField, 'fr');
-      expect(price).toEqual('100,00 €');
+      expect(price).toEqual('100,99 €');
     });
 
     it('Returns value when no price or currency code', () => {


### PR DESCRIPTION
The price formatter was using parseInt for the string-ified price value. This
led to a loss of precision. Specifically, if a price was stored in the KG as
$10.99, our formatter would report it as $10.00. This is corrected by using
parseFloat.

TEST=auto

Updated the unit tests for the formatter to ensure the precision is not lost.