### PR TITLE
vertical-full-page-map: z-index fixes for android

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -54,7 +54,7 @@
       max-height: 100%;
       width: 100%;
       position: absolute;
-      z-index: 2;
+      z-index: 3;
       display: flex;
       flex-direction: column;
 
@@ -187,7 +187,7 @@
       position: fixed;
       bottom: 72px;
       right: 16px;
-      z-index: 2;
+      z-index: 4;
       background-color: #eaeaea;
       color: black;
       cursor: pointer;


### PR DESCRIPTION
Explicitly set the z-index for the results list as higher than the z-index
for the map controls. There was a bug where the map controls (Mapbox
logo, the zoom controls) would show on the results list. By explicitly
setting the results list as higher (and subsequently the map/list toggle
higher than that), we don't see that behavior anymore on mobile.

J=SLAP-1150
TEST=manual

Test on Browserstack that when you look at a vertical full page map
results list on mobile, you do not see the zoom controls anywhere on the
landing page

Tested on a Samsung S21 on Google Chrome specifically. Also tested on
Chrome on MacOS.