### PR TITLE
vertical-full-page-map: allow specification of clientId in config

### DIFF
--- a/hbshelpers/chainedLookup.js
+++ b/hbshelpers/chainedLookup.js
@@ -9,7 +9,7 @@
 module.exports = function chainedLookup(context, ...lookupChain) {
   let lookupResult = context;
   for (const lookup of lookupChain.slice(0, -1)) {
-    if (!context || typeof context !== 'object') {
+    if (!lookupResult || typeof lookupResult !== 'object') {
       return '';
     }
     lookupResult = lookupResult[lookup];

--- a/hbshelpers/chainedLookup.js
+++ b/hbshelpers/chainedLookup.js
@@ -1,0 +1,18 @@
+/**
+ * A Handlebars helper that performs multiple lookups in a row.
+ *
+ * @param {Object} context The context to perform lookup on
+ * @param {...string} lookupChain The lookups to perform.
+ * @param {import('handlebars').HelperOptions} options
+ * @returns {any} The result of the lookup
+ */
+module.exports = function chainedLookup(context, ...lookupChain) {
+  let lookupResult = context;
+  for (const lookup of lookupChain.slice(0, -1)) {
+    if (!context || typeof context !== 'object') {
+      return '';
+    }
+    lookupResult = lookupResult[lookup];
+  }
+  return lookupResult;
+}

--- a/hbshelpers/chainedLookup.js
+++ b/hbshelpers/chainedLookup.js
@@ -10,7 +10,7 @@ module.exports = function chainedLookup(context, ...lookupChain) {
   let lookupResult = context;
   for (const lookup of lookupChain.slice(0, -1)) {
     if (!lookupResult || typeof lookupResult !== 'object') {
-      return '';
+      return undefined;
     }
     lookupResult = lookupResult[lookup];
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4455,10 +4455,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.67.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4748,12 +4745,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",

--- a/tests/hbshelpers/chainedLookup.js
+++ b/tests/hbshelpers/chainedLookup.js
@@ -7,7 +7,7 @@ it('performs a chained lookup', () => {
         c: 123
       }
     }
-  }
+  };
   expect(chainedLookup(context, 'a', 'b', 'c', {})).toEqual(123);
 });
 
@@ -18,7 +18,7 @@ it('short circuits when key does not exist', () => {
         c: 123
       }
     }
-  }
+  };
   expect(chainedLookup(context, 'a', '123', 'asdf', {})).toEqual(undefined);
 });
 
@@ -28,6 +28,6 @@ it('short circuits when intermediate key points to non-object', () => {
     a: {
       b: 123
     }
-  }
+  };
   expect(chainedLookup(context, 'a', 'b', 'c', 'd', {})).toEqual(undefined);
 });

--- a/tests/hbshelpers/chainedLookup.js
+++ b/tests/hbshelpers/chainedLookup.js
@@ -19,7 +19,7 @@ it('short circuits when key does not exist', () => {
       }
     }
   }
-  expect(chainedLookup(context, 'a', '123', 'asdf', {})).toEqual('');
+  expect(chainedLookup(context, 'a', '123', 'asdf', {})).toEqual(undefined);
 });
 
 
@@ -29,5 +29,5 @@ it('short circuits when intermediate key points to non-object', () => {
       b: 123
     }
   }
-  expect(chainedLookup(context, 'a', 'b', 'c', 'd', {})).toEqual('');
+  expect(chainedLookup(context, 'a', 'b', 'c', 'd', {})).toEqual(undefined);
 });

--- a/tests/hbshelpers/chainedLookup.js
+++ b/tests/hbshelpers/chainedLookup.js
@@ -1,0 +1,33 @@
+import chainedLookup from '../../hbshelpers/chainedLookup';
+
+it('performs a chained lookup', () => {
+  const context = {
+    a: {
+      b: {
+        c: 123
+      }
+    }
+  }
+  expect(chainedLookup(context, 'a', 'b', 'c', {})).toEqual(123);
+});
+
+it('short circuits when key does not exist', () => {
+  const context = {
+    a: {
+      b: {
+        c: 123
+      }
+    }
+  }
+  expect(chainedLookup(context, 'a', '123', 'asdf', {})).toEqual('');
+});
+
+
+it('short circuits when intermediate key points to non-object', () => {
+  const context = {
+    a: {
+      b: 123
+    }
+  }
+  expect(chainedLookup(context, 'a', 'b', 'c', 'd', {})).toEqual('');
+});

--- a/tests/test-utils/hbs.js
+++ b/tests/test-utils/hbs.js
@@ -21,8 +21,8 @@ function registerCustomHbsHelpers(hbs, pathToCustomHelpers) {
       try {
         hbs.registerHelper(helperName, require(filePath));
       } catch (err) {
-        throw new UserError(
-          `Could not register handlebars helper from file ${path}`, err.stack);
+        throw new Error(
+          `Could not register handlebars helper from file ${filePath}`, err.stack);
       }
     });
   return hbs;

--- a/theme-components/vertical-full-page-map/script.js
+++ b/theme-components/vertical-full-page-map/script.js
@@ -3,6 +3,7 @@ ANSWERS.registerComponentType(window.VerticalFullPageMapOrchestrator);
 ANSWERS.addComponent('VerticalFullPageMapOrchestrator', Object.assign({},
 {
   container: '.js-answersVerticalFullPageMap',
+  {{#unless (chainedLookup verticalsToConfig verticalKey 'mapConfig' 'clientId')}}
   apiKey: HitchhikerJS.getDefaultMapApiKey(
     {{#if componentSettings.Map.mapProvider}}
       "{{componentSettings.Map.mapProvider}}"
@@ -14,6 +15,7 @@ ANSWERS.addComponent('VerticalFullPageMapOrchestrator', Object.assign({},
       {{/with}}
     {{/if}}
   ),
+  {{/unless}}
   pageSettings: {{{ json pageSettings }}},
   onPinSelect: () => {
     window.collapsibleFiltersInteractions && window.collapsibleFiltersInteractions.collapseFilters();


### PR DESCRIPTION
clientId is a config option that can be specified for google maps
for authentication, as an alternative to the api key.
If both an api key and client id are passed to the google maps
script, the api key will take higher priority. Even if no apiKey
is explicitly provided in the page config, we automatically provide
a default, so this commit makes it so if a clientId is provided,
we no longer provide a default map api key.

J=SLAP-1114
TEST=manual,auto

test that I can specify a clientId. see that it will be used to load
in google maps (see "gme-yextinc" work and a bogus clientId not work)

see that I can still specify a custom api key
see that an apiKey is still provided by default it no clientId is specified