### PR TITLE
vertical-full-page-map: Fix map not loading on Chrome mobile

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -164,6 +164,10 @@
       height: 100%;
       right: 0;
       top: 0;
+
+      @include bplte($mobile-break-point-max) {
+        max-height: 100vh;
+      }
     }
 
     &-map


### PR DESCRIPTION
Previously, on Chrome on the mobile breakpoint, if you entered the map
view after a search, the map would be mostly gray (and partially loaded
at the top). This would happen on

1. An iPhone 8 Plus
2. A Macbook Pro when you refreshed the page in the mobile breakpoint
3. A Windows 10 machine when you refreshed the page in the mobile
   breakpoint.

The only way to re-paint the map is by zooming out/in the map. You
cannot move the map center and re-paint the map.

Previously, you would solve this by triggering a resize of the Google
maps instance. Calling a re-size would trigger a re-paint of the maps.
However, this has been deprecated since Google Maps v3.32, docs confirm
no resize event for the Map object. The docs suggest this is unnecessary
as the new renderer knows when a block is unloaded.

The reason this was happening on this new renderer is because the map
was taking up the height of the results container (very long on mobile)
and then re-sizing when someone clicked on the Map toggle button.
Because it was so tall when it loaded, the map only partially loaded and
you saw the gray blob behavior. This change makes it so the map is at a
max height of 100vh all the time on mobile.

J=SLAP-1082
TEST=manual

Test on Chrome mobile breakpoint on (below) that you can conduct a
search ('all') on the vertical-full-page-map template, click on the Map
toggle to see the map, and see the Google maps. If the map is not gray,
then it is working.

1. An iPhone 8 Plus
2. A Macbook Pro when you refreshed the page in the mobile breakpoint
3. A Windows 10 machine when you refreshed the page in the mobile
   breakpoint.