### PR TITLE
Update dependencies to address vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4455,10 +4455,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.67.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4748,12 +4745,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -5792,9 +5783,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash._reinterpolate": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jest": "^25.5.2",
     "libphonenumber-js": "^1.9.6",
     "loader-utils": "^2.0.0",
+    "lodash": "^4.17.20",
     "lodash.clonedeep": "^4.5.0",
     "postcss": "^8.2.1",
     "serve": "^11.3.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "jest": "^25.5.2",
     "libphonenumber-js": "^1.9.6",
     "loader-utils": "^2.0.0",
-    "lodash": "^4.17.20",
     "lodash.clonedeep": "^4.5.0",
     "postcss": "^8.2.1",
     "serve": "^11.3.2",

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -4325,7 +4325,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -4323,10 +4323,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -6210,8 +6209,7 @@
     "sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -6756,10 +6754,13 @@
       "optional": true
     },
     "underscore.string": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-      "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
-      "dev": true
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "requires": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -6843,8 +6844,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/static/package.json
+++ b/static/package.json
@@ -37,7 +37,6 @@
     "resolve-url-loader": "^3.1.1",
     "sass-loader": "^8.0.2",
     "simple-git": "^2.15.0",
-    "underscore.string": "3.2.3",
     "webpack": "^5.4.0",
     "webpack-cli": "^4.2.0"
   },
@@ -52,9 +51,11 @@
     "iframe-resizer": "^4.1.1",
     "is-mobile": "^2.2.2",
     "libphonenumber-js": "^1.7.51",
+    "lodash": "^4.17.20",
     "lodash.clonedeep": "^4.5.0",
     "merge-options": "^2.0.0",
-    "remove-files-webpack-plugin": "^1.4.3"
+    "remove-files-webpack-plugin": "^1.4.3",
+    "underscore.string": "3.3.5"
   },
   "engines": {
     "node": ">=10"

--- a/static/package.json
+++ b/static/package.json
@@ -51,7 +51,6 @@
     "iframe-resizer": "^4.1.1",
     "is-mobile": "^2.2.2",
     "libphonenumber-js": "^1.7.51",
-    "lodash": "^4.17.20",
     "lodash.clonedeep": "^4.5.0",
     "merge-options": "^2.0.0",
     "remove-files-webpack-plugin": "^1.4.3",


### PR DESCRIPTION
These are dependencies pointed out by dependabot by the hitchhiker
theme solution templates. For example
https://github.com/yext-pages/answers-jambo-template/pull/87
https://github.com/yext-pages/answers-jambo-template/pull/88
https://github.com/yext-pages/answers-jambo-template/pull/89

In the theme's package.json
- lodash 4.17.15 -> 4.17.20
this was done by adding lodash as a direct devDependency
The theme's package.json is technically unused by the solution templates.
But we might as well update our dev dependency to make
the dependabot warning go away.

In the theme's static/package.json, which is the one directly
used by the solution templates
- underscore.string 3.2.3 -> 3.3.5, also moved this from devDependencies to
  a regular dependency because it's used in the browser
- lodash 4.17.15 -> 4.17.20, this updates lodash in multiple @babel/ dependencies

J=SLAP-1196
TEST=manual

test that I can load up a map page (regular vertical-map page not the
vertical-full-page-map) on ie11, and the address will be displayed correctly