### PR TITLE
Allow custom cards to be used with the `vertical` command.

### DIFF
--- a/commands/addvertical.js
+++ b/commands/addvertical.js
@@ -93,7 +93,7 @@ class VerticalAdder {
     const customCardsDir = 'cards';
     if (fs.existsSync(customCardsDir)) {
       fs.readdirSync(customCardsDir, { withFileTypes: true })
-        .filter(dirent => !dirent.isFile())
+        .filter(dirent => !dirent.isFile() && !cards.includes(dirent.name))
         .forEach(dirent => cards.push(dirent.name));
     }
 

--- a/commands/addvertical.js
+++ b/commands/addvertical.js
@@ -84,10 +84,20 @@ class VerticalAdder {
     if (!defaultTheme || !themesDir) {
       return [];
     }
-    const cardsDir = path.join(themesDir, defaultTheme, 'cards');
-    return fs.readdirSync(cardsDir, { withFileTypes: true })
+    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
+
+    const cards = fs.readdirSync(themeCardsDir, { withFileTypes: true })
       .filter(dirent => !dirent.isFile())
       .map(dirent => dirent.name);
+
+    const customCardsDir = 'cards';
+    if (fs.existsSync(customCardsDir)) {
+      fs.readdirSync(customCardsDir, { withFileTypes: true })
+        .filter(dirent => !dirent.isFile())
+        .forEach(dirent => cards.push(dirent.name));
+    }
+
+    return cards;
   }
 
   /**


### PR DESCRIPTION
The `vertical` command had a bug that caused it to only allow built-in cards
to be specified as the `cardName` flag. This was overly restrictive. Users of
the command should be able to configure their vertical to use one of their
custom cards as well.

J=SLAP-1188
TEST=manual

Made a test site with custom cards. Verified that the card names appeared in
the `describe` output for `vertical`. Also verified that I could pass one
of the custom card names to the `cardName` flag and that the vertical would
be configured to use it properly.