### PR TITLE
vertical-full-page-map: Handle out of bounds longitude

### DIFF
--- a/static/js/theme-map/Geo/GeoBounds.js
+++ b/static/js/theme-map/Geo/GeoBounds.js
@@ -1,5 +1,6 @@
 import { Unit, Projection } from './constants.js';
 import { Coordinate } from './Coordinate.js';
+import { getNormalizedLongitude } from '../Util/helpers.js';
 
 /**
  * This class represents a bounded coordinate region of a sphere.
@@ -121,25 +122,9 @@ class GeoBounds {
     const newLon = (nw.longitude + this._ne.longitude) / 2 + (this._ne.longitude < nw.longitude ? 180 : 0);
 
     nw.add(-latDist / 2, 0, Unit.DEGREE, projection);
-    nw.longitude = this._getNormalizedLongitude(newLon);
+    nw.longitude = getNormalizedLongitude(newLon);
 
     return nw;
-  }
-
-  /**
-   * Normalize lng to the range [-180, 180]. If you give -181, for
-   * example, we wrap back to 180.
-   *
-   * @param {Number} lng The longitude
-   * @returns {Number} The normalized longitude
-   */
-  _getNormalizedLongitude(lng) {
-    const positiveModLng = ((lng % 361) + 361) % 361;
-    const normalizedLng = positiveModLng > 180
-      ? positiveModLng - 361
-      : positiveModLng;
-
-    return normalizedLng;
   }
 }
 

--- a/static/js/theme-map/Geo/GeoBounds.js
+++ b/static/js/theme-map/Geo/GeoBounds.js
@@ -121,9 +121,25 @@ class GeoBounds {
     const newLon = (nw.longitude + this._ne.longitude) / 2 + (this._ne.longitude < nw.longitude ? 180 : 0);
 
     nw.add(-latDist / 2, 0, Unit.DEGREE, projection);
-    nw.longitude = newLon;
+    nw.longitude = this._getNormalizedLongitude(newLon);
 
     return nw;
+  }
+
+  /**
+   * Normalize lng to the range [-180, 180]. If you give -181, for
+   * example, we wrap back to 180.
+   *
+   * @param {Number} lng The longitude
+   * @returns {Number} The normalized longitude
+   */
+  _getNormalizedLongitude(lng) {
+    const positiveModLng = ((lng % 361) + 361) % 361;
+    const normalizedLng = positiveModLng > 180
+      ? positiveModLng - 361
+      : positiveModLng;
+
+    return normalizedLng;
   }
 }
 

--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -61,6 +61,16 @@ const isViewableWithinContainer = (targetEl, containerEl) => {
  * example, we wrap back to 179. If lng is 180, we return 180. Otherwise, we
  * prefer to return -180 over 180 when wrapping, as they are the same coordinate.
  *
+ * The idea is that we must mod by the range of the longitude values (360) to
+ * be span our entire range of values. In order to have our negative to
+ * positive wrapping work with modulus, the values we mod by need to be positive.
+ *
+ * 1. Add 180 to shift values to make sure -180 to 0 map to 0 to 180 
+ *    and 0 to 180 map to 180 to 360 for example
+ * 2. Mod by 360 to make the range (-360, 360)
+ * 3. Add 360 and mod by 360 again to make the range positive [0, 360)
+ * 4. Subtract by 180 to make the range into the desired range [-180, 180)
+ *
  * @param {Number} lng The longitude
  * @returns {Number} The normalized longitude
  */
@@ -68,7 +78,8 @@ const getNormalizedLongitude = (lng) => {
   if (lng === 180) {
     return lng;
   }
-  return ((lng + 180) % 360 + 360) % 360 - 180;
+  const range = 360; // 180 - (-180)
+  return ((lng + 180) % range + range) % range - 180;
 }
 
 export {

--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -55,8 +55,25 @@ const isViewableWithinContainer = (targetEl, containerEl) => {
   return isScrolledIntoView;
 };
 
+
+/**
+ * Normalize lng to the range [-180, 180]. If you give -181, for
+ * example, we wrap back to 179. If lng is 180, we return 180. Otherwise, we
+ * prefer to return -180 over 180 when wrapping, as they are the same coordinate.
+ *
+ * @param {Number} lng The longitude
+ * @returns {Number} The normalized longitude
+ */
+const getNormalizedLongitude = (lng) => {
+  if (lng === 180) {
+    return lng;
+  }
+  return ((lng + 180) % 360 + 360) % 360 - 180;
+}
+
 export {
   getLanguageForProvider,
   getEncodedSvg,
+  getNormalizedLongitude,
   isViewableWithinContainer
 }

--- a/tests/static/js/theme-map/Util/helpers.js
+++ b/tests/static/js/theme-map/Util/helpers.js
@@ -1,0 +1,54 @@
+import { getNormalizedLongitude } from 'static/js/theme-map/Util/helpers.js';
+
+describe('getNormalizedLongitude', () => {
+  describe('it works within normal longitude bounds', () => {
+    it('works with 0', () => {
+      expect(getNormalizedLongitude(0)).toEqual(0);
+    });
+
+    it('works with the boundaries', () => {
+      expect(getNormalizedLongitude(179)).toEqual(179);
+      expect(getNormalizedLongitude(180)).toEqual(180);
+      expect(getNormalizedLongitude(-179)).toEqual(-179);
+      expect(getNormalizedLongitude(-180)).toEqual(-180);
+    });
+
+    it('works with numbers between boundaries', () => {
+      expect(getNormalizedLongitude(1)).toEqual(1);
+      expect(getNormalizedLongitude(-1)).toEqual(-1);
+      expect(getNormalizedLongitude(60)).toEqual(60);
+      expect(getNormalizedLongitude(-60)).toEqual(-60);
+    });
+  });
+
+  describe('it works outside of normal longitude bounds', () => {
+    it('works with the boundaries', () => {
+      expect(getNormalizedLongitude(180.5)).toEqual(-179.5);
+      expect(getNormalizedLongitude(181)).toEqual(-179);
+
+      expect(getNormalizedLongitude(-180.5)).toEqual(179.5);
+      expect(getNormalizedLongitude(-181)).toEqual(179);
+    });
+
+    it('works with large numbers', () => {
+      expect(getNormalizedLongitude(780.5)).toEqual(60.5);
+      expect(getNormalizedLongitude(-780.5)).toEqual(-60.5);
+      expect(getNormalizedLongitude(190)).toEqual(-170);
+      expect(getNormalizedLongitude(-190)).toEqual(170);
+    });
+
+    it('works with multiples of the boundaries', () => {
+      expect(getNormalizedLongitude(270)).toEqual(-90);
+      expect(getNormalizedLongitude(360)).toEqual(0);
+      expect(getNormalizedLongitude(450)).toEqual(90);
+      expect(getNormalizedLongitude(540)).toEqual(-180);
+      expect(getNormalizedLongitude(720)).toEqual(0);
+
+      expect(getNormalizedLongitude(-270)).toEqual(90);
+      expect(getNormalizedLongitude(-360)).toEqual(0);
+      expect(getNormalizedLongitude(-450)).toEqual(-90);
+      expect(getNormalizedLongitude(-540)).toEqual(-180);
+      expect(getNormalizedLongitude(-720)).toEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
Before, if you moved the map outside of the boundaries of longitude
[-180, 180], it was possible to get outside of the range. This would
cause liveapi to error because the longitude was incorrect. Here we mod
our longitudes so it wraps from -180 to 180 and stays within range.

Note: we do not need to do this for latitude because our current map
implementation does not let you wrap along the latitude lines.

J=SLAP-1107
TEST=manual

On a vertical full page map, zoom out to the maximum value and drag the
map to the left. Make sure when you're at the -180 longitude mark, if
you drag more to the left, you will be in the positive range and
correctly a liveapi request without an error.

Test this the positive longitude direction as well.