### PR TITLE
vertical-full-page-map: Show navigation by default

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -61,7 +61,7 @@ $container-width: 1000px;
   --yxt-maps-search-this-area-text-color: var(--yxt-color-text-primary);
   --yxt-maps-mobile-detail-card-height: 225px;
   --yxt-maps-desktop-results-container-width: 410px;
-  --yxt-maps-mobile-results-header-height: 121px;
+  --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
 }
 

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -60,7 +60,7 @@ $container-width: 1000px;
   --yxt-maps-search-this-area-text-color: var(--yxt-color-text-primary);
   --yxt-maps-mobile-detail-card-height: 225px;
   --yxt-maps-desktop-results-container-width: 410px;
-  --yxt-maps-mobile-results-header-height: 121px;
+  --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
 }
 

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -157,6 +157,15 @@
       width: 100%;
     }
 
+    &-nav
+    {
+      @include bplte($mobile-break-point-max)
+      {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    }
+
     &-mapWrapper {
       display: block;
       position: absolute;

--- a/templates/vertical-full-page-map/page.html.hbs
+++ b/templates/vertical-full-page-map/page.html.hbs
@@ -5,7 +5,7 @@
     {{> templates/vertical-full-page-map/page-setup }}
     {{> templates/vertical-full-page-map/script/searchbar }}
     {{> templates/vertical-full-page-map/script/spellcheck }}
-    {{!-- {{> templates/vertical-full-page-map/script/navigation }} --}}
+    {{> templates/vertical-full-page-map/script/navigation }}
     {{> templates/vertical-full-page-map/script/verticalresultscount }}
     {{> templates/vertical-full-page-map/script/appliedfilters }}
     {{!-- {{> templates/vertical-full-page-map/script/sortoptions }} --}}
@@ -26,7 +26,7 @@
             <div class="Answers-searchWrapper js-sticky">
               <div class="Answers-form">
                 {{> templates/vertical-full-page-map/markup/searchbar }}
-                {{!-- {{> templates/vertical-full-page-map/markup/navigation }} --}}
+                {{> templates/vertical-full-page-map/markup/navigation }}
               </div>
             </div>
             <div class="Answers-resultsHeaderTop">


### PR DESCRIPTION
Before, the navigation component was commented out by default. Change
this so it is uncommented by default. This is from requests from the
HHs.

Also change the default height of the mobile map to handle the change
in search header height on mobile. And remove padding on the sides on
mobile at suggestion of Product.

J=SLAP-1189
TEST=manual

On new a site, creating a page (below) should show the navigation
component below the searchbar by default on both mobile and desktop

Make sure the zoom controls on the map in mobile are still visible (as
the height of the search header is now taller).

e.g. npx jambo page --template vertical-full-page-map --name locations2