### PR TITLE
remove themes/answers-hitchhiker-theme prefix from custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Creates a new, custom card based on an existing card.
 
 Example usage:
 ```bash
-npx jambo card --name custom-location --templateCardFolder themes/answers-hitchhiker-theme/cards/location-standard
+npx jambo card --name custom-location --templateCardFolder cards/location-standard
 ```
 
 See `jambo card --help` for more info.
@@ -68,7 +68,7 @@ Creates a new, custom direct answer card.
 
 Example usage:
 ```bash
-npx jambo directanswercard --name custom-directanswer --templateCardFolder themes/answers-hitchhiker-theme/directanswercards/allfields-standard
+npx jambo directanswercard --name custom-directanswer --templateCardFolder directanswercards/allfields-standard
 ```
 
 See `jambo directanswercard --help` for more info.

--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -73,7 +73,7 @@ class CardCreator {
     if (!defaultTheme || !themesDir) {
       return [];
     }
-    const cardsDir = path.join(themesDir, defaultTheme, 'cards');
+    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
     const cardPaths = new Set();
     const addCardsToSet = cardsDir => {
       if (!fs.existsSync(cardsDir)) {
@@ -83,7 +83,7 @@ class CardCreator {
         .filter(dirent => !dirent.isFile())
         .forEach(dirent => cardPaths.add(path.join('cards', dirent.name)));
     };
-    [cardsDir, 'cards'].forEach(dir => addCardsToSet(dir));
+    [themeCardsDir, 'cards'].forEach(dir => addCardsToSet(dir));
     return Array.from(cardPaths);
   }
 

--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -76,7 +76,7 @@ class CardCreator {
     const cardsDir = path.join(themesDir, defaultTheme, 'cards');
     return fs.readdirSync(cardsDir, { withFileTypes: true })
       .filter(dirent => !dirent.isFile())
-      .map(dirent => path.join(cardsDir, dirent.name));
+      .map(dirent => path.join('cards', dirent.name));
   }
 
   /**
@@ -113,13 +113,14 @@ class CardCreator {
     }
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
-    if (fs.existsSync(templateCardFolder)) {
+    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
+    if (fs.existsSync(themeCardFolder)) {
       !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
       !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
-      fs.copySync(templateCardFolder, cardFolder);
+      fs.copySync(themeCardFolder, cardFolder);
       this._renameCardComponent(cardFolderName, cardFolder);
     } else {
-      throw new UserError(`The folder ${templateCardFolder} does not exist`);
+      throw new UserError(`The folder ${themeCardFolder} does not exist`);
     }
   }
 

--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -74,9 +74,17 @@ class CardCreator {
       return [];
     }
     const cardsDir = path.join(themesDir, defaultTheme, 'cards');
-    return fs.readdirSync(cardsDir, { withFileTypes: true })
-      .filter(dirent => !dirent.isFile())
-      .map(dirent => path.join('cards', dirent.name));
+    const cardPaths = new Set();
+    const addCardsToSet = cardsDir => {
+      if (!fs.existsSync(cardsDir)) {
+        return;
+      }
+      fs.readdirSync(cardsDir, { withFileTypes: true })
+        .filter(dirent => !dirent.isFile())
+        .forEach(dirent => cardPaths.add(path.join('cards', dirent.name)));
+    };
+    [cardsDir, 'cards'].forEach(dir => addCardsToSet(dir));
+    return Array.from(cardPaths);
   }
 
   /**
@@ -112,16 +120,23 @@ class CardCreator {
       throw new UserError(`A folder with name ${cardFolderName} already exists`);
     }
 
-    const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
+    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
+    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
+    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
+    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
+    fs.copySync(originalCardFolder, newCardFolder);
+    this._renameCardComponent(cardFolderName, newCardFolder);
+  }
+
+  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
+    if (fs.existsSync(templateCardFolder)) {
+      return templateCardFolder
+    } 
     const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
     if (fs.existsSync(themeCardFolder)) {
-      !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
-      !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
-      fs.copySync(themeCardFolder, cardFolder);
-      this._renameCardComponent(cardFolderName, cardFolder);
-    } else {
-      throw new UserError(`The folder ${themeCardFolder} does not exist`);
+      return themeCardFolder;
     }
+    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
   }
 
   _renameCardComponent(customCardName, cardFolder) {

--- a/commands/directanswercardcreator.js
+++ b/commands/directanswercardcreator.js
@@ -76,7 +76,7 @@ class DirectAnswerCardCreator {
     const daCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
     return fs.readdirSync(daCardsDir, { withFileTypes: true })
       .filter(dirent => !dirent.isFile())
-      .map(dirent => path.join(daCardsDir, dirent.name));
+      .map(dirent => path.join('directanswercards', dirent.name));
   }
 
   /**
@@ -113,13 +113,14 @@ class DirectAnswerCardCreator {
     }
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
-    if (fs.existsSync(templateCardFolder)) {
+    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
+    if (fs.existsSync(themeCardFolder)) {
       !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
       !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
-      fs.copySync(templateCardFolder, cardFolder);
+      fs.copySync(themeCardFolder, cardFolder);
       this._renameCardComponent(cardFolderName, cardFolder);
     } else {
-      throw new UserError(`The folder ${templateCardFolder} does not exist`);
+      throw new UserError(`The folder ${themeCardFolder} does not exist`);
     }
   }
 

--- a/commands/directanswercardcreator.js
+++ b/commands/directanswercardcreator.js
@@ -73,7 +73,7 @@ class DirectAnswerCardCreator {
     if (!defaultTheme || !themesDir) {
       return [];
     }
-    const daCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
+    const themeCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
     const cardPaths = new Set();
     const addCardsToSet = cardsDir => {
       if (!fs.existsSync(cardsDir)) {
@@ -83,7 +83,7 @@ class DirectAnswerCardCreator {
         .filter(dirent => !dirent.isFile())
         .forEach(dirent => cardPaths.add(path.join('directanswercards', dirent.name)));
     };
-    [daCardsDir, 'directanswercards'].forEach(dir => addCardsToSet(dir));
+    [themeCardsDir, 'directanswercards'].forEach(dir => addCardsToSet(dir));
     return Array.from(cardPaths);
   }
 

--- a/commands/directanswercardcreator.js
+++ b/commands/directanswercardcreator.js
@@ -74,9 +74,17 @@ class DirectAnswerCardCreator {
       return [];
     }
     const daCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
-    return fs.readdirSync(daCardsDir, { withFileTypes: true })
-      .filter(dirent => !dirent.isFile())
-      .map(dirent => path.join('directanswercards', dirent.name));
+    const cardPaths = new Set();
+    const addCardsToSet = cardsDir => {
+      if (!fs.existsSync(cardsDir)) {
+        return;
+      }
+      fs.readdirSync(cardsDir, { withFileTypes: true })
+        .filter(dirent => !dirent.isFile())
+        .forEach(dirent => cardPaths.add(path.join('directanswercards', dirent.name)));
+    };
+    [daCardsDir, 'directanswercards'].forEach(dir => addCardsToSet(dir));
+    return Array.from(cardPaths);
   }
 
   /**
@@ -112,16 +120,23 @@ class DirectAnswerCardCreator {
       throw new UserError(`A folder with name ${cardFolderName} already exists`);
     }
 
-    const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
+    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
+    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
+    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
+    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
+    fs.copySync(originalCardFolder, newCardFolder);
+    this._renameCardComponent(cardFolderName, newCardFolder);
+  }
+
+  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
+    if (fs.existsSync(templateCardFolder)) {
+      return templateCardFolder
+    } 
     const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
     if (fs.existsSync(themeCardFolder)) {
-      !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
-      !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
-      fs.copySync(themeCardFolder, cardFolder);
-      this._renameCardComponent(cardFolderName, cardFolder);
-    } else {
-      throw new UserError(`The folder ${themeCardFolder} does not exist`);
+      return themeCardFolder;
     }
+    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
   }
 
   _renameCardComponent(customCardName, cardFolder) {


### PR DESCRIPTION
This commit removes the need to prefix all card/dacards paths with
"themes/answers-hitchhiker-theme" for the jambo card command.
Additionally, this also adds top-level cards to the jambo describes for
the card and dacard commands.

J=SLAP-1137
TEST=manual

test that the card command still works
test that the dacard command still works
run jambo describe, and see that card and dacard paths do not have the prefix. also see top level cards