### PR TITLE
Set anchorX and anchorY in ThemeMapConfig

### DIFF
--- a/static/js/theme-map/Maps/Providers/Google.js
+++ b/static/js/theme-map/Maps/Providers/Google.js
@@ -143,7 +143,7 @@ class GooglePin extends ProviderPin {
 
     if (icon) {
       options.icon = {
-        anchor: new google.maps.Point(pinProperties.getAnchorX() * width, pinProperties.getAnchorY() * height),
+        anchor: new google.maps.Point(anchorX * width, anchorY * height),
         scaledSize: new google.maps.Size(width, height),
         url: this._icons[pinProperties.getIcon()]
       }

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -303,7 +303,10 @@ class ThemeMap extends ANSWERS.Component {
         const properties = new PinProperties()
           .setIcon(status.hovered || status.focused || status.selected ? 'hovered' : 'default')
           .setWidth(28)
-          .setHeight(28);
+          .setHeight(28)
+          .setAnchorX(this.config.pinClusterAnchors.anchorX)
+          .setAnchorY(this.config.pinClusterAnchors.anchorY);
+
 
         return properties;
       })
@@ -339,7 +342,9 @@ class ThemeMap extends ANSWERS.Component {
         const properties = new PinProperties()
           .setIcon(status.selected ? 'selected' : ((status.hovered || status.focused) ? 'hovered' : 'default'))
           .setSRText(index)
-          .setZIndex(status.selected ? 1 : ((status.hovered || status.focused) ? 2 : 0));
+          .setZIndex(status.selected ? 1 : ((status.hovered || status.focused) ? 2 : 0))
+          .setAnchorX(this.config.pinAnchors.anchorX)
+          .setAnchorY(this.config.pinAnchors.anchorY);
 
         properties.setWidth(24);
         properties.setHeight(28);

--- a/static/js/theme-map/ThemeMapConfig.js
+++ b/static/js/theme-map/ThemeMapConfig.js
@@ -26,6 +26,7 @@ export default class ThemeMapConfig {
 
     /**
      * Controls the visual offset of each pin.
+     * @type {Object}
      */
     this.pinAnchors = {
       anchorX: 0.5,
@@ -34,6 +35,7 @@ export default class ThemeMapConfig {
 
     /**
      * Controls the visual offset of each cluster pin.
+     * @type {Object}
      */
     this.pinClusterAnchors = {
       anchorX: 0.5,

--- a/static/js/theme-map/ThemeMapConfig.js
+++ b/static/js/theme-map/ThemeMapConfig.js
@@ -25,6 +25,22 @@ export default class ThemeMapConfig {
     this.apiKey = jsonConfig.apiKey;
 
     /**
+     * Controls the visual offset of each pin.
+     */
+    this.pinAnchors = {
+      anchorX: 0.5,
+      anchorY: 0.5
+    };
+
+    /**
+     * Controls the visual offset of each cluster pin.
+     */
+    this.pinClusterAnchors = {
+      anchorX: 0.5,
+      anchorY: 0.5
+    };
+
+    /**
      * The client id for the map provider (if applicable)
      * @type {string}
      */


### PR DESCRIPTION
This commit sets anchorX and anchorY for map pins
and cluster pins using config specified in ThemeMapConfig.js

J=SLAP-1114
TEST=manual

test that I can set the anchor values, and when I check the
transform: translate(percentX, percentY) in dev tools, the
css transform is the expected value for the anchorX/Y I set