### PR TITLE
vertical-full-page-map: Hide page footer on open detail card

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -643,4 +643,8 @@
   .Answers-footer {
     display: none;
   }
+
+  .YxtFooter {
+    display: none;
+  }
 }


### PR DESCRIPTION
When the detail card is opened in the map view, we need to hide it
like how we hide the Answers-footer. This is from feedback on the Maps
QA.

J=SLAP-1199
TEST=manual

Test that if you add a footer in layouts/footer.hbs in a Jambo repo,
the footer is not visible if you scroll when a detail card is open.

```
<footer class="YxtFooter"> i want it i got it </footer>
```