### PR TITLE
Keyboard support for "Search When Map Moves"

### DIFF
--- a/static/js/theme-map/Maps/Map.js
+++ b/static/js/theme-map/Maps/Map.js
@@ -461,6 +461,12 @@ class Map {
 
     this._panStartHandlerRunning = true;
 
+    // We assume that the pan trigger is the user if it was
+    // left unset by our locator code
+    if (this.getPanTrigger() === PanTriggers.UNSET) {
+      this.setPanTrigger(PanTriggers.USER);
+    }
+
     requestAnimationFrame(() => {
       this._panStartHandler(new GeoBounds(
         new Coordinate(this._currentBounds.sw),

--- a/static/js/theme-map/Maps/Map.js
+++ b/static/js/theme-map/Maps/Map.js
@@ -778,9 +778,7 @@ class Map {
   }
 
   /**
-   * The pan trigger is the initiator of the map pan, which can occur when a user
-   * moves the map, or when the map is automatically fit around a cluster or a set
-   * of results.
+   * Sets the PanTrigger which indicates the reason for the most recent map pan
    * @param {PanTriggers} panTrigger
    */
   setPanTrigger(panTrigger) {

--- a/static/js/theme-map/Maps/Map.js
+++ b/static/js/theme-map/Maps/Map.js
@@ -6,6 +6,7 @@ import { MapPinOptions } from './MapPin.js';
 import { MapProvider } from './MapProvider.js';
 import { ProviderMapOptions } from './ProviderMap.js';
 import ZoomTriggers from './ZoomTriggers.js';
+import PanTriggers from './PanTriggers.js';
 
 /**
  * The maximum percent of the map height or width that can be taken up by padding.
@@ -292,6 +293,7 @@ class Map {
     this._idlePromise = Promise.resolve();
     this._setIdle();
     this._zoomTrigger = ZoomTriggers.UNSET;
+    this._panTrigger = PanTriggers.UNSET;
 
     this.setPanHandler(options.panHandler);
     this.setPanStartHandler(options.panStartHandler);
@@ -438,9 +440,10 @@ class Map {
       this._panHandler(previousBounds, new GeoBounds(
         new Coordinate(this._currentBounds.sw),
         new Coordinate(this._currentBounds.ne)
-      ));
+      ), this.getPanTrigger());
 
       this._panHandlerRunning = false;
+      this.setPanTrigger(PanTriggers.UNSET);
     });
 
     this._setIdle();
@@ -462,7 +465,7 @@ class Map {
       this._panStartHandler(new GeoBounds(
         new Coordinate(this._currentBounds.sw),
         new Coordinate(this._currentBounds.ne)
-      ));
+      ), this.getPanTrigger());
 
       this._panStartHandlerRunning = false;
     });
@@ -647,6 +650,7 @@ class Map {
    * @param {boolean} [animated=false] Whether to transition smoothly to the new center
    */
   setCenter(coordinate, animated = false) {
+    this.setPanTrigger(PanTriggers.API);
     this._map.setCenter(new Coordinate(coordinate), animated);
   }
 
@@ -752,6 +756,7 @@ class Map {
    */
   setZoomCenter(zoom, center, animated = false) {
     this.setZoomTrigger(ZoomTriggers.API);
+    this.setPanTrigger(PanTriggers.API);
     this._map.setZoomCenter(zoom, center, animated);
   }
 
@@ -770,6 +775,23 @@ class Map {
    */
   getZoomTrigger() {
     return this._zoomTrigger;
+  }
+
+  /**
+   * The pan trigger is the initiator of the map pan, which can occur when a user
+   * moves the map, or when the map is automatically fit around a cluster or a set
+   * of results.
+   * @param {PanTriggers} panTrigger
+   */
+  setPanTrigger(panTrigger) {
+    this._panTrigger = panTrigger;
+  }
+
+  /**
+   * @return {PanTriggers} The trigger for the last pan
+   */
+  getPanTrigger() {
+    return this._panTrigger;
   }
 
   /**

--- a/static/js/theme-map/Maps/PanTriggers.js
+++ b/static/js/theme-map/Maps/PanTriggers.js
@@ -1,0 +1,9 @@
+/**
+ * Describes the types of triggers for a map pan
+ *
+ * @enum {string}
+ */
+export default {
+  UNSET: '',
+  API: 'api',
+};

--- a/static/js/theme-map/Maps/PanTriggers.js
+++ b/static/js/theme-map/Maps/PanTriggers.js
@@ -1,9 +1,23 @@
 /**
- * Describes the types of triggers for a map pan
+ * Describes the possible of triggers for a map pan
  *
  * @enum {string}
  */
 export default {
+  /**
+   * Indicates that the panTrigger is not set, and therefore there is no specific
+   * behavior that should occur if the panHandler is called with this PanTrigger.
+   * 
+   * This should be set if a user moves the map, or if a user clicks on a cluster.
+   */
   UNSET: '',
+  /** 
+   * Indicates that the map is panning due to programatic reason, and therefore a new
+   * search should not be ran if the panHandler is called while this PanTrigger is set
+   * on the Map.
+   * 
+   * This includes panning the map after a new search is ran, or centering the map over
+   * a focused pin after clicking or tabbing onto it.
+   */
   API: 'api',
 };

--- a/static/js/theme-map/Maps/PanTriggers.js
+++ b/static/js/theme-map/Maps/PanTriggers.js
@@ -1,5 +1,5 @@
 /**
- * Describes the possible of triggers for a map pan
+ * Describes the possible triggers for a map pan
  *
  * @enum {string}
  */
@@ -7,8 +7,6 @@ export default {
   /**
    * Indicates that the panTrigger is not set, and therefore there is no specific
    * behavior that should occur if the panHandler is called with this PanTrigger.
-   * 
-   * This should be set if a user moves the map, or if a user clicks on a cluster.
    */
   UNSET: '',
   /** 
@@ -16,8 +14,9 @@ export default {
    * search should not be ran if the panHandler is called while this PanTrigger is set
    * on the Map.
    * 
-   * This includes panning the map after a new search is ran, or centering the map over
-   * a focused pin after clicking or tabbing onto it.
+   * This includes the automatic centering of the map after a new search is ran, or the
+   * automatic centering of the map over a focused pin near the edge of the screen after
+   * clicking or tabbing onto it.
    */
   API: 'api',
 };

--- a/static/js/theme-map/Maps/PanTriggers.js
+++ b/static/js/theme-map/Maps/PanTriggers.js
@@ -5,10 +5,15 @@
  */
 export default {
   /**
-   * Indicates that the panTrigger is not set, and therefore there is no specific
-   * behavior that should occur if the panHandler is called with this PanTrigger.
+   * Indicates that the panTrigger is not set.
    */
   UNSET: '',
+  /**
+   * Indicates that the pan occured as a result of user interaction.
+   * 
+   * This includes moving the map or clicking on a pin cluster.
+   */
+  USER: 'user',
   /** 
    * Indicates that the map is panning due to programatic reason, and therefore a new
    * search should not be ran if the panHandler is called while this PanTrigger is set

--- a/static/js/theme-map/Maps/Providers/Google.js
+++ b/static/js/theme-map/Maps/Providers/Google.js
@@ -5,6 +5,7 @@ import { LoadScript } from '../../Performance/LoadContent.js';
 import { MapProviderOptions } from '../MapProvider.js';
 import { ProviderMap } from '../ProviderMap.js';
 import { ProviderPin } from '../ProviderPin.js';
+import { debounce } from '../../Util/helpers';
 
 /**
  * @static
@@ -47,16 +48,21 @@ class GoogleMap extends ProviderMap {
     this._zoomChangeListener = null;
 
     this._moving = false;
+
+    const debouncedIdleEvent = debounce(() => {
+      this._moving = false;
+      this._panHandler();
+    }, 250);
+
     google.maps.event.addListener(this.map, 'bounds_changed', () => {
       if (!this._moving) {
         this._moving = true;
         this._panStartHandler();
+      } else {
+        debouncedIdleEvent();
       }
     });
-    google.maps.event.addListener(this.map, 'idle', () => {
-      this._moving = false;
-      this._panHandler();
-    });
+    google.maps.event.addListener(this.map, 'idle', debouncedIdleEvent);
     google.maps.event.addListener(this.map, 'dragend', () => {
       this._dragEndHandler();
     });

--- a/static/js/theme-map/Maps/Providers/Google.js
+++ b/static/js/theme-map/Maps/Providers/Google.js
@@ -52,7 +52,7 @@ class GoogleMap extends ProviderMap {
     const debouncedIdleEvent = debounce(() => {
       this._moving = false;
       this._panHandler();
-    }, 250);
+    }, 100);
 
     google.maps.event.addListener(this.map, 'bounds_changed', () => {
       if (!this._moving) {

--- a/static/js/theme-map/SearchDebouncer.js
+++ b/static/js/theme-map/SearchDebouncer.js
@@ -34,6 +34,7 @@ class SearchDebouncer {
    * @param {Coordinate} mostRecentSearchMapCenter
    * @param {Coordinate} currentMapCenter
    * @param {number} currentZoom
+   * @returns {boolean}
    */
   isWithinDistanceThreshold ({ mostRecentSearchMapCenter, currentMapCenter, currentZoom }) {
     const distanceToLastSearch = currentMapCenter.distanceTo(mostRecentSearchMapCenter);
@@ -49,6 +50,7 @@ class SearchDebouncer {
    * 
    * @param {number} mostRecentSearchZoom
    * @param {number} currentZoom
+   * @returns {boolean}
    */
   isWithinZoomThreshold ({ mostRecentSearchZoom, currentZoom }) {
     const zoomDifference = Math.abs(currentZoom - mostRecentSearchZoom);

--- a/static/js/theme-map/SearchDebouncer.js
+++ b/static/js/theme-map/SearchDebouncer.js
@@ -28,43 +28,32 @@ class SearchDebouncer {
   }
 
   /**
-   * Determines whether or not a search should be debounced
+   * Determines if a search should be debounced based on the relative distance of the current map
+   * center to the previous map center.
    * 
-   * @param {Object} mostRecentSearchState
-   * @param {Coordinate} mostRecentSearchState.mapCenter
-   * @param {number} mostRecentSearchState.zoom
-   * @param {Object} currentMapState
-   * @param {Coordinate} currentMapState.mapCenter
-   * @param {number} currentMapState.zoom
-   * @retuns {boolean}
+   * @param {Coordinate} mostRecentSearchMapCenter
+   * @param {Coordinate} currentMapCenter
+   * @param {number} currentZoom
    */
-  shouldBeDebounced (mostRecentSearchState, currentMapState) {
-    this._validateMapStateObject(mostRecentSearchState);
-    this._validateMapStateObject(currentMapState);
+  isWithinDistanceThreshold ({ mostRecentSearchMapCenter, currentMapCenter, currentZoom }) {
+    const distanceToLastSearch = currentMapCenter.distanceTo(mostRecentSearchMapCenter);
+    const relativeDistance = this._calculateRelativeDistance(distanceToLastSearch, currentZoom);
 
-    const distanceToLastSearch = mostRecentSearchState.mapCenter.distanceTo(currentMapState.mapCenter);
 
-    const relativeDistance = this._calculateRelativeDistance(distanceToLastSearch, currentMapState.zoom);
-    const zoomDifference = Math.abs(currentMapState.zoom - mostRecentSearchState.zoom)
-
-    const isOutsideDistanceThreshold = relativeDistance >= this.relativeDistanceThreshold;
-    const isOutsideZoomThreshold = zoomDifference >= this.zoomThreshold;
-
-    return !isOutsideDistanceThreshold && !isOutsideZoomThreshold;
+    return relativeDistance <= this.relativeDistanceThreshold;
   }
 
   /**
-   * Throws an error if the object is missing any of the required params
+   * Determines if a search should be debounced based on the difference between the map zoom during
+   * the most recent search and the current map zoom.
    * 
-   * @param {Object}
+   * @param {number} mostRecentSearchZoom
+   * @param {number} currentZoom
    */
-  _validateMapStateObject (obj) {
-    if (!('mapCenter' in obj)) {
-      throw new Error('The search debouncer was passed an object which is missing the "mapCenter" property');
-    }
-    if (!('zoom' in obj)) {
-      throw new Error('The search debouncer was passed an object which is missing the "zoom" property');
-    }
+  isWithinZoomThreshold ({ mostRecentSearchZoom, currentZoom }) {
+    const zoomDifference = Math.abs(currentZoom - mostRecentSearchZoom);
+
+    return zoomDifference <= this.zoomThreshold;
   }
 
   /**

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -139,7 +139,10 @@ class ThemeMap extends ANSWERS.Component {
    */
   addMapInteractions(map) {
     this.map.idle().then(() => {
-      map.setPanHandler(() => this.updateMapPropertiesInStorage());
+      map.setPanHandler((prevousBounds, currentBounds) => {
+        this.updateMapPropertiesInStorage();
+        this.config.panHandler(prevousBounds, currentBounds);
+      });
       map.setDragEndHandler(() => {
         this.updateMapPropertiesInStorage();
         this.config.dragEndListener()

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -139,9 +139,9 @@ class ThemeMap extends ANSWERS.Component {
    */
   addMapInteractions(map) {
     this.map.idle().then(() => {
-      map.setPanHandler((prevousBounds, currentBounds) => {
+      map.setPanHandler((prevousBounds, currentBounds, zoomTrigger) => {
         this.updateMapPropertiesInStorage();
-        this.config.panHandler(prevousBounds, currentBounds);
+        this.config.panHandler(prevousBounds, currentBounds, zoomTrigger);
       });
       map.setDragEndHandler(() => {
         this.updateMapPropertiesInStorage();

--- a/static/js/theme-map/ThemeMapConfig.js
+++ b/static/js/theme-map/ThemeMapConfig.js
@@ -187,6 +187,12 @@ export default class ThemeMapConfig {
     this.dragEndListener = jsonConfig.dragEndListener || function () {};
 
     /**
+     * Callback for when a map pan event has finished
+     * @type {Function}
+     */
+    this.panHandler = jsonConfig.panHandler || function () {};
+
+    /**
      * Callback for when a map zoom event has fired
      * @type {Function}
      */

--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -82,9 +82,34 @@ const getNormalizedLongitude = (lng) => {
   return ((lng + 180) % range + range) % range - 180;
 }
 
+/**
+ * Returns a function, that, as long as it continues to be invoked, will not be triggered.
+ * The function will be called after it stops being called for `wait` milliseconds.
+ * 
+ * Source: https://levelup.gitconnected.com/debounce-in-javascript-improve-your-applications-performance-5b01855e086
+ * 
+ * @param {Function} func The function to debounce
+ * @param {number} wait The number of milliseconds that need to pass without the function
+ *                      being called before the provided function will execute
+ */
+const debounce = (func, wait) => {
+  let timeout;
+
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+};
+
 export {
   getLanguageForProvider,
   getEncodedSvg,
   getNormalizedLongitude,
-  isViewableWithinContainer
+  isViewableWithinContainer,
+  debounce
 }

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -159,7 +159,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     const pinClusterClickListener = () => this.searchOnMapMove && this.searchThisArea();
 
     /**
-     * The listener called when the map stops panning
+     * The listener called when the map pans
      */
     const panHandler = (prevousBounds, currentBounds, panTrigger) => {
       if (panTrigger === PanTriggers.API) {

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -175,7 +175,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     }
 
     /**
-     * Record the current zoom during a zoom event
+     * The listener called when the zoom changes
      *
      * @param {number} zoom The zoom during a zoom event
      * @param {ZoomTriggers} zoomTrigger The intitiator of the zoom

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -157,11 +157,16 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     const pinClusterClickListener = () => this.searchOnMapMove && this.searchThisArea();
 
     /**
-     * Dragging the map searches the new area, if desired
-     *
-     * @param {Map} map The map object
+     * The listener called when the map drag ends
      */
-    const dragEndListener = () => this.handleMapAreaChange();
+    const dragEndListener = () => {};
+
+    /**
+     * The listener called when the map stops panning
+     */
+    const panHandler = (prevousBounds, currentBounds) => {
+      this.handleMapCenterChange();
+    }
 
     /**
      * Record the current zoom during a zoom event
@@ -169,9 +174,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
      * @param {number} zoom The zoom during a zoom event
      * @param {ZoomTriggers} zoomTrigger The intitiator of the zoom
      */
-    const zoomChangedListener = (zoom, zoomTrigger) => {
-      this.currentZoom = zoom;
-    };
+    const zoomChangedListener = (zoom, zoomTrigger) => {};
 
     /**
      * User-initiated changes to the map zoom searches the new area, if desired
@@ -181,11 +184,13 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
      * @param {ZoomTriggers} zoomTrigger The intitiator of the zoom
      */
     const zoomEndListener = (zoom, zoomTrigger) => {
+      this.currentZoom = zoom;
+
       if (zoomTrigger !== ZoomTriggers.USER) {
         return;
       }
 
-      this.handleMapAreaChange();
+      this.handleMapZoomChange();
     };
 
     ANSWERS.addComponent('ThemeMap', Object.assign({}, {
@@ -210,6 +215,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       dragEndListener: dragEndListener,
       zoomChangedListener: zoomChangedListener,
       zoomEndListener: zoomEndListener,
+      panHandler: panHandler,
       canvasClickListener: () => this.removeResultFocusedStates()
     }));
   }
@@ -217,32 +223,56 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
   /**
    * Search the area or show the search the area button according to configurable logic
    */
-  handleMapAreaChange () {
+  handleMapCenterChange () {
     if (!this.searchOnMapMove) {
       this._container.classList.add('VerticalFullPageMap--showSearchThisArea');
       return;
     }
 
-    if (!this.shouldSearchBeDebounced()) {
+    if (!this.shouldSearchBeDebouncedBasedOnCenter()) {
       this.searchThisArea();
     }
   }
 
   /**
-   * Returns true if a search should be debounced and false otherwise
+   * Search the area or show the search the area button according to configurable logic
+   */
+  handleMapZoomChange () {
+    if (!this.searchOnMapMove) {
+      this._container.classList.add('InteractiveMap--showSearchThisArea');
+      return;
+    }
+
+    if (!this.shouldSearchBeDebouncedBasedOnZoom()) {
+      this.searchThisArea();
+    }
+  }
+
+  /**
+   * Returns true if a search should be debounced based on the center of the current map
+   * and the center of the map during the most recent search
    * 
    * @returns {boolean}
    */
-  shouldSearchBeDebounced () {
-    const mostRecentSearchState = {
-      mapCenter: this.mostRecentSearchLocation,
-      zoom: this.mostRecentSearchZoom,
-    }
-    const currentMapState = {
-      mapCenter: this.getCurrentMapCenter(),
-      zoom: this.currentZoom
-    }
-    return this.searchDebouncer.shouldBeDebounced(mostRecentSearchState, currentMapState);
+  shouldSearchBeDebouncedBasedOnCenter () {
+    return this.searchDebouncer.isWithinDistanceThreshold({
+      mostRecentSearchMapCenter: this.mostRecentSearchLocation,
+      currentMapCenter: this.getCurrentMapCenter(),
+      currentZoom: this.currentZoom
+    });
+  }
+
+  /**
+   * Returns true if a search should be debounced based on the previous search zoom level and
+   * the current zoom level
+   * 
+   * @returns {boolean}
+   */
+  shouldSearchBeDebouncedBasedOnZoom () {
+    return this.searchDebouncer.isWithinZoomThreshold({
+      mostRecentSearchZoom: this.mostRecentSearchZoom,
+      currentZoom: this.currentZoom
+    });
   }
 
   /**

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -5,6 +5,8 @@ import { SearchDebouncer } from './SearchDebouncer';
 import { defaultCenterCoordinate } from './constants.js';
 
 import ZoomTriggers from './Maps/ZoomTriggers.js';
+import PanTriggers from './Maps/PanTriggers.js';
+
 import StorageKeys from '../storage-keys.js';
 
 /**
@@ -164,7 +166,11 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     /**
      * The listener called when the map stops panning
      */
-    const panHandler = (prevousBounds, currentBounds) => {
+    const panHandler = (prevousBounds, currentBounds, panTrigger) => {
+      if (panTrigger === PanTriggers.API) {
+        return;
+      }
+
       this.handleMapCenterChange();
     }
 

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -159,11 +159,6 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     const pinClusterClickListener = () => this.searchOnMapMove && this.searchThisArea();
 
     /**
-     * The listener called when the map drag ends
-     */
-    const dragEndListener = () => {};
-
-    /**
      * The listener called when the map stops panning
      */
     const panHandler = (prevousBounds, currentBounds, panTrigger) => {
@@ -218,7 +213,6 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       onPostMapRender: onPostMapRender,
       pinFocusListener: (index, id) => this.pinFocusListener(index, id),
       pinClusterClickListener: pinClusterClickListener,
-      dragEndListener: dragEndListener,
       zoomChangedListener: zoomChangedListener,
       zoomEndListener: zoomEndListener,
       panHandler: panHandler,


### PR DESCRIPTION
Make the "Search When Map Moves" feature work with the keyboard

Previously the "Search When Map Moves" feature only worked with the mouse because it was relying on the `dragEndHandler` rather than the `panHandler`. By switching to the `panHandler`, the feature will work with the keyboard. As a result of this change, I split up the denouncer so that zoom changes and map center changes are debounced separately.

Also, after a user runs a search, or after a user focuses on a pin which is at the edge of the screen, we don't want to run a new search. To prevent this, I created `PanTriggers` which are analogous to `ZoomTriggers` so that we could prevent running new searches in these cases.

The Google Maps 'idle' event is called repeatedly when the map is moves with the keyboard, which I believe is a bug, so in order to get around this I used a debouncer so that Google Maps only fires the `panHandler`once the map is idle for 100ms.

J=SLAP-1141
TEST=manual

Test on both Mapbox and on Google Maps that "Search When Map Moves" works when navigating the map with the keyboard. Confirm that running a search or focusing on a pin near the edge of the screen doesn't run a new search. Confirm that clicking on a cluster does run a new search after zooming in. Test that I can tab through results without new searches being ran