### PR TITLE
vertical-full-page-map: Scroll to top of window on view toggle

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -362,6 +362,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       if (!listToggle.dataset.listened) {
         listToggle.dataset.listened = 'true';
         listToggle.addEventListener('click', () => {
+          window.scrollTo(0, 0);
           this._container.classList.toggle('VerticalFullPageMap--listShown');
           this._container.classList.toggle('VerticalFullPageMap--mapShown');
           this._container.classList.remove('VerticalFullPageMap--detailShown');


### PR DESCRIPTION
Previously, when you clicked on the map/list view toggle on a mobile
experience, the current scroll would carry over into the next view. That
is, if you were scrolled a lot on the long results list, you would be
moved to the bottom of the footer when you clicked on the Map view
toggle. That made it so you don't see things like the Search This Area
button or zoom controls (as they are cut off on the top).

To fix this, we make it so transitioning views scrolls the window to the
top automatically.

J=SLAP-1200
TEST=manual

Test on iPhone 8 Plus, MBP, iPad Chrome + Safari

Scrolling down the results list and clicking the map toggle will take
you to the top of the page, allowing you to see the whole map.

Clicking back to the list view will show you the top the results.