### PR TITLE
vertical-full-page-map: location card click listener only on desktop

### DIFF
--- a/static/js/theme-map/CardListenerAssigner.js
+++ b/static/js/theme-map/CardListenerAssigner.js
@@ -9,6 +9,20 @@ class CardListenerAssigner {
      * @type {Answers.Component}
      */
     this.card = card;
+
+    /**
+     * The upper bound (inclusive) of the mobile breakpoint in px
+     *
+     * @type {Number}
+     */
+    this.mobileBreakpointMax = 991;
+
+    /**
+     * The matcher to determine if the window width is within the mobile breakpoint
+     *
+     * @type {MediaQueryList}
+     */
+    this.mediaMatcher = window.matchMedia(`(max-width: ${this.mobileBreakpointMax}px)`);
   }
 
   /**
@@ -24,6 +38,10 @@ class CardListenerAssigner {
    */
   _addCardClickListener () {
     this.card._container.parentElement.addEventListener('click', () => {
+      if (this.mediaMatcher.matches) {
+        return;
+      }
+
       const index = this._getCardIndex();
       this._storeCardFocusIndex(index);
       this._removePinFocusFromAllCards();
@@ -38,6 +56,10 @@ class CardListenerAssigner {
   _addLinkFocusListeners() {
     this.card._container.querySelectorAll('a').forEach((el) => {
       el.addEventListener('focus', () => {
+        if (this.mediaMatcher.matches) {
+          return;
+        }
+
         const index = this._getCardIndex();
         this._storeCardFocusIndex(index);
         this._removePinFocusFromAllCards();

--- a/static/js/theme-map/CardListenerAssigner.js
+++ b/static/js/theme-map/CardListenerAssigner.js
@@ -11,18 +11,11 @@ class CardListenerAssigner {
     this.card = card;
 
     /**
-     * The upper bound (inclusive) of the mobile breakpoint in px
-     *
-     * @type {Number}
-     */
-    this.mobileBreakpointMax = 991;
-
-    /**
      * The matcher to determine if the window width is within the mobile breakpoint
      *
      * @type {MediaQueryList}
      */
-    this.mediaMatcher = window.matchMedia(`(max-width: ${this.mobileBreakpointMax}px)`);
+    this.mobileMediaMatcher = window.matchMedia(`(max-width: 991px)`);
   }
 
   /**
@@ -38,7 +31,7 @@ class CardListenerAssigner {
    */
   _addCardClickListener () {
     this.card._container.parentElement.addEventListener('click', () => {
-      if (this.mediaMatcher.matches) {
+      if (this.mobileMediaMatcher.matches) {
         return;
       }
 
@@ -56,7 +49,7 @@ class CardListenerAssigner {
   _addLinkFocusListeners() {
     this.card._container.querySelectorAll('a').forEach((el) => {
       el.addEventListener('focus', () => {
-        if (this.mediaMatcher.matches) {
+        if (this.mobileMediaMatcher.matches) {
           return;
         }
 


### PR DESCRIPTION
Previously, if you were on a mobile device and you clicked on a card,
the "selecting" behavior from desktop would occur. That is, the card
would enter its selected state, which is opening a detail card. This is
not correct because the only entry to a selected result should be
through a pin click on the map view when on mobile.

To fix this, we only enact the selected listeners on card click when we
are on desktop.

J=SLAP-1202
TEST=manual

Test that on mobile/tablet
* Clicking on a result card does not hide the card anymore
* Clicking on a pin in the map view will show a detail card

Test that on desktop
* Clicking on a result card still selects the correct pin (the selected
  styling on the pin shows).
* Clicking on a result card also selects a cluster pin if applicable.