### PR TITLE
Document search card tweaks

### DIFF
--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -18,7 +18,7 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
       value: answer.value,
       snippet: snippet && Formatter.highlightField(snippet.value, snippet.matchedSubstrings), // Text snippet to include alongside the answer
       viewDetailsText: relatedItemData.fieldValues && relatedItemData.fieldValues.name, // Text below the direct answer and snippet
-      viewDetailsLink: relatedItemData.website, // Link for the "view details" text
+      viewDetailsLink: relatedItemData.website || relatedItemData.fieldValues && relatedItemData.fieldValues.landingPageUrl, // Link for the "view details" text
       viewDetailsEventOptions: this.addDefaultEventOptions({
         ctaLabel: 'VIEW_DETAILS'
       }), // The event options for viewDetails click analytics

--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -18,7 +18,7 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
       value: answer.value,
       snippet: snippet && Formatter.highlightField(snippet.value, snippet.matchedSubstrings), // Text snippet to include alongside the answer
       viewDetailsText: relatedItemData.fieldValues && relatedItemData.fieldValues.name, // Text below the direct answer and snippet
-      viewDetailsLink: relatedItemData.website || relatedItemData.fieldValues && relatedItemData.fieldValues.landingPageUrl, // Link for the "view details" text
+      viewDetailsLink: relatedItemData.website || (relatedItemData.fieldValues && relatedItemData.fieldValues.landingPageUrl), // Link for the "view details" text
       viewDetailsEventOptions: this.addDefaultEventOptions({
         ctaLabel: 'VIEW_DETAILS'
       }), // The event options for viewDetails click analytics

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -31,7 +31,7 @@
 {{#*inline 'view_details_link'}}
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerDocumentSearchStandard-viewMoreWrapper">
-    Read more from
+    Read more about
     <a class="HitchhikerDocumentSearchStandard-viewMore"
         href="{{#unless (isNonRelativeUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"


### PR DESCRIPTION
Addressing two QA items:

1) Fall back to relatedItemData.fieldValues.landingPageUrl

2) Update the default on the documentsearch card to be "Read more about" instead of "Read more from"

