### PR TITLE
Comment in default initial search

### DIFF
--- a/templates/vertical-full-page-map/page-config.json
+++ b/templates/vertical-full-page-map/page-config.json
@@ -5,12 +5,10 @@
   // "canonicalUrl": "", // The link tag for canonical URL as well as the meta tag for open graph url
   // "keywords": "", // The meta tag for keywords
   "pageSettings": {
-    /**
     "search": {
       "verticalKey": "<REPLACE ME>", // The vertical key from your search configuration
       "defaultInitialSearch": "" // Enter a default search term
     }
-    **/
   },
   "componentSettings": {
     /**

--- a/templates/vertical-grid/page-config.json
+++ b/templates/vertical-grid/page-config.json
@@ -5,12 +5,10 @@
   // "canonicalUrl": "", // The link tag for canonical URL as well as the meta tag for open graph url
   // "keywords": "", // The meta tag for keywords
   "pageSettings": {
-    /**
      "search": {
        "verticalKey": "<REPLACE ME>", // The vertical key from your search configuration
        "defaultInitialSearch": "" // Enter a default search term
      }
-    **/
   },  
   "componentSettings": {
     /**

--- a/templates/vertical-map/page-config.json
+++ b/templates/vertical-map/page-config.json
@@ -5,12 +5,10 @@
   // "canonicalUrl": "", // The link tag for canonical URL as well as the meta tag for open graph url
   // "keywords": "", // The meta tag for keywords
   "pageSettings": {
-    /**
     "search": {
       "verticalKey": "<REPLACE ME>", // The vertical key from your search configuration
       "defaultInitialSearch": "" // Enter a default search term
     }
-    **/
   },
   "componentSettings": {
     /**

--- a/templates/vertical-standard/page-config.json
+++ b/templates/vertical-standard/page-config.json
@@ -5,12 +5,10 @@
   // "canonicalUrl": "", // The link tag for canonical URL as well as the meta tag for open graph url
   // "keywords": "", // The meta tag for keywords
   "pageSettings": {
-    /**
      "search": {
        "verticalKey": "<REPLACE ME>", // The vertical key from your search configuration
        "defaultInitialSearch": "" // Enter a default search term
      }
-    **/
   },  
   "componentSettings": {
     /**


### PR DESCRIPTION
Now that we have add vertical in the theme, we can have a default initial search set by default. 

(Note the search bar config already allows an empty search by default in all of the page config templates)