### PR TITLE
vertical-full-page-map: Keep height on map view fixed

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -365,6 +365,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
           window.scrollTo(0, 0);
           this._container.classList.toggle('VerticalFullPageMap--listShown');
           this._container.classList.toggle('VerticalFullPageMap--mapShown');
+          this._pageWrapperEl.classList.toggle('YxtPage-wrapper--mapShown');
           this._container.classList.remove('VerticalFullPageMap--detailShown');
         });
       }

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -175,7 +175,12 @@
       top: 0;
 
       @include bplte($mobile-break-point-max) {
-        max-height: 100vh;
+        overflow: auto;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
       }
     }
 
@@ -188,7 +193,7 @@
 
       @include bplte($mobile-break-point-max)
       {
-        top: var(--yxt-maps-mobile-results-header-height);
+        top: 0;
         transition: height 0.3s ease-out;
         height: calc(100% - var(--yxt-maps-mobile-results-header-height) - var(--yxt-maps-mobile-results-footer-height));
       }
@@ -447,6 +452,10 @@
 
   &.VerticalFullPageMap--mapShown
   {
+    .Answers-map {
+      top: var(--yxt-maps-mobile-results-header-height);
+    }
+
     .Answers-mapFooter {
       display: flex;
     }
@@ -573,7 +582,7 @@
     }
 
     @include bplte($mobile-break-point-max) {
-      position: absolute;
+      position: fixed;
       bottom: 0;
       left: 0;
       width: 100%;
@@ -636,6 +645,16 @@
         position: fixed;
       }
     }
+  }
+}
+
+.YxtPage-wrapper--mapShown {
+  .YxtPage-content {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
Previously, on mobile phone browsers with navigation bars, we would see
that 100vh would not necessarily be the 100% of the viewport visible to
the user. For instance, on Chrome mobile for iOS, 100vh is obscured by
about 60px to make room for the Chrome navigation tools. This is not a
problem in the mock-mobile on Chrome desktop.

We keep the height of the map view fixed when it is in view. That way,
you are always seeing the important parts of the map. and cannot scroll
away from it. Because of this change, we must fix a few other things,
including the detail card and the wrapper of the map (so we cannot
invisibly scroll to the hidden footer).

NOTE: The Answers logo footer and the customer footer will no longer be
visible on the map view. They will only be visible on the list view.

NOTE: Browserstack s21 Chrome, Firefox will NOT work currently, because
there is a bug with the Navigation component styling causing an overflow.

J=SLAP-1207
TEST=manual

Test on physical iOS device (iPhone 8+) Chrome Safari
Browserstack iPhone 12 Chrome, Safari
Test on Chrome, Firefox, Safari locally on MacOS

You scroll down the results list and see the Answers logo footer and
custom footer.

You can click the map toggle and see the Search This Area and Location
Bias immediately. It is not obscured by any navigation tools or cut off
in the viewport. You cannot scroll in the map view.

You can click on a pin and see its detail card with the correct height.