### PR TITLE
vertical-full-page-map: Add translations

### DIFF
--- a/translations/de.po
+++ b/translations/de.po
@@ -121,3 +121,24 @@ msgstr[1] "[[count]] Ergebnisse anzeigen"
 msgctxt "Close is a verb"
 msgid "Close Card"
 msgstr "Karte schließen"
+
+#: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
+msgctxt "A button that conducts a search in the current map area"
+msgid "Search When Map Moves"
+msgstr "Suchergebnisse beim Verschieben der Karte aktualisieren"
+
+#: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
+msgctxt "A toggle for automatically searching when the map moves"
+msgid "Search This Area"
+msgstr "In diesem Bereich suchen"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
+msgctxt "The label of a toggle for displaying a list of results"
+msgid "List"
+msgstr "Liste"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
+msgctxt "The label of a toggle for viewing a visual map"
+msgid "Map"
+msgstr "Karte"
+

--- a/translations/es.po
+++ b/translations/es.po
@@ -121,3 +121,23 @@ msgstr[1] "Ver [[count]] resultados"
 msgctxt "Close is a verb"
 msgid "Close Card"
 msgstr "Cerrar tarjeta"
+
+#: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
+msgctxt "A button that conducts a search in the current map area"
+msgid "Search When Map Moves"
+msgstr "Buscar cuando el mapa se mueve"
+
+#: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
+msgctxt "A toggle for automatically searching when the map moves"
+msgid "Search This Area"
+msgstr "Buscar en esta zona"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
+msgctxt "The label of a toggle for displaying a list of results"
+msgid "List"
+msgstr "Lista"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
+msgctxt "The label of a toggle for viewing a visual map"
+msgid "Map"
+msgstr "Mapa"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -121,3 +121,23 @@ msgstr[1] "Afficher [[count]] résultats"
 msgctxt "Close is a verb"
 msgid "Close Card"
 msgstr "Fermer la carte"
+
+#: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
+msgctxt "A button that conducts a search in the current map area"
+msgid "Search When Map Moves"
+msgstr "Rechercher quand la carte est déplacée"
+
+#: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
+msgctxt "A toggle for automatically searching when the map moves"
+msgid "Search This Area"
+msgstr "Rechercher dans cette zone"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
+msgctxt "The label of a toggle for displaying a list of results"
+msgid "List"
+msgstr "Liste"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
+msgctxt "The label of a toggle for viewing a visual map"
+msgid "Map"
+msgstr "Carte"

--- a/translations/it.po
+++ b/translations/it.po
@@ -121,3 +121,23 @@ msgstr[1] "Visualizza [[count]] risultati"
 msgctxt "Close is a verb"
 msgid "Close Card"
 msgstr "Chiudi scheda"
+
+#: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
+msgctxt "A button that conducts a search in the current map area"
+msgid "Search When Map Moves"
+msgstr "Cerca quando la mappa si sposta"
+
+#: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
+msgctxt "A toggle for automatically searching when the map moves"
+msgid "Search This Area"
+msgstr "Cerca in questa area"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
+msgctxt "The label of a toggle for displaying a list of results"
+msgid "List"
+msgstr "Elenco"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
+msgctxt "The label of a toggle for viewing a visual map"
+msgid "Map"
+msgstr "Mappa"

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -120,3 +120,23 @@ msgstr[0] "[[count]]件の結果を表示"
 msgctxt "Close is a verb"
 msgid "Close Card"
 msgstr "カードを閉じる"
+
+#: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
+msgctxt "A button that conducts a search in the current map area"
+msgid "Search When Map Moves"
+msgstr "マップが移動したときに検索"
+
+#: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
+msgctxt "A toggle for automatically searching when the map moves"
+msgid "Search This Area"
+msgstr "このエリアを検索"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
+msgctxt "The label of a toggle for displaying a list of results"
+msgid "List"
+msgstr "リスト"
+
+#: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
+msgctxt "The label of a toggle for viewing a visual map"
+msgid "Map"
+msgstr "マップ"


### PR DESCRIPTION
Add all translations from .pot files from Smartling manually.

J=SLAP-1168
TEST=manual

Test on the benchmark experience that you can see all the new translated
strings. Specifically tested the `fr` locale.