### PR TITLE
Have `vertical` command set `verticalKey` in the `defaultInitialSearch`.

### DIFF
--- a/commands/addvertical.js
+++ b/commands/addvertical.js
@@ -275,13 +275,10 @@ class VerticalAdder {
    */
   _configureVerticalPage(name, verticalKey, cardName) {
     const configFile = `config/${name}.json`;
-    let parsedConfig = parse(fs.readFileSync(configFile, { encoding: 'utf-8' }));
 
-    parsedConfig.verticalKey = verticalKey;
-
-    parsedConfig.verticalsToConfig[verticalKey] = 
-      parsedConfig.verticalsToConfig['<REPLACE ME>'];
-    delete parsedConfig.verticalsToConfig['<REPLACE ME>'];
+    let rawConfig = fs.readFileSync(configFile, { encoding: 'utf-8' });
+    rawConfig = rawConfig.replace(/\<REPLACE ME\>/g, verticalKey);
+    const parsedConfig = parse(rawConfig);
 
     parsedConfig.verticalsToConfig[verticalKey].cardType = cardName;
 


### PR DESCRIPTION
Recently, Rose merged a change that uncommented the `pageSettings.search` block in all vertical page templates. This was so that pages built with these templates have a `defaultInitialSearch` set by default. The block also contains a `verticalKey`. This key needs to be configured properly by the `vertical` command.

To support this, the `_configureVerticalPage` command was altered somewhat. Now, instead of immediately invoking `parse` on the page configuration, some regexs are run on the raw config first. The regex replaces all instances of `<REPLACE ME>` with the `verticalKey`. By using a regex, then calling `parse`, we will not need to update the `vertical` command in the future if additional `verticalKey` placeholders are added to the template page configs.

J=SLAP-1187
TEST=manual

Ran the `vertical` command with one of the page templates. Verified that the `pageSettings.search` block had the correct `verticalKey`. When I loaded the vertical page, a default empty initial search was correctly fired. 