### PR TITLE
Support proper syntax highlighting for JSON with comments.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.json  linguist-language=JSON-with-Comments


### PR DESCRIPTION
This enables proper syntax highlighting in Github for JSON files with comments.

J=SLAP-1145
TEST=manual