### PR TITLE
Custom command patches for v1.20

### DIFF
--- a/patches/v1.15-and-earlier-commands-upgrade.patch
+++ b/patches/v1.15-and-earlier-commands-upgrade.patch
@@ -1,0 +1,856 @@
+From 1d63dd4677a64ff84858eb061b6183943147c9cc Mon Sep 17 00:00:00 2001
+From: Connor Anderson <canderson@yext.com>
+Date: Wed, 31 Mar 2021 20:45:00 -0400
+Subject: [PATCH] v1.15-and-earlier-commands-upgrade
+
+---
+ .../commands/addvertical.js                   | 288 ++++++++++++++++++
+ .../commands/cardcreator.js                   | 176 +++++++++++
+ .../commands/directanswercardcreator.js       | 181 +++++++++++
+ .../commands/helpers/errors/usererror.js      |  20 ++
+ .../helpers/utils/argumentmetadata.js         |  60 ++++
+ .../helpers/utils/jamboconfigutils.js         |  69 +++++
+ 6 files changed, 794 insertions(+)
+ create mode 100644 themes/answers-hitchhiker-theme/commands/addvertical.js
+ create mode 100644 themes/answers-hitchhiker-theme/commands/cardcreator.js
+ create mode 100644 themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
+ create mode 100644 themes/answers-hitchhiker-theme/commands/helpers/errors/usererror.js
+ create mode 100644 themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
+ create mode 100644 themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
+
+diff --git a/themes/answers-hitchhiker-theme/commands/addvertical.js b/themes/answers-hitchhiker-theme/commands/addvertical.js
+new file mode 100644
+index 0000000..5936f5d
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/addvertical.js
+@@ -0,0 +1,288 @@
++const fs = require('fs-extra');
++const path = require('path');
++const { parse, stringify } = require('comment-json');
++const { spawnSync } = require('child_process');
++
++const UserError = require('./helpers/errors/usererror');
++const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
++
++/**
++ * VerticalAdder represents the `vertical` custom jambo command. The command adds
++ * a new page for the given Vertical and associates a card type with it.
++ */
++class VerticalAdder {
++  constructor(jamboConfig) {
++    this.config = jamboConfig;
++  }
++
++  /**
++   * @returns {string} the alias for the add vertical command.
++   */
++  static getAlias() {
++    return 'vertical';
++  }
++
++  /**
++   * @returns {string} a short description of the add vertical command.
++   */
++  static getShortDescription() {
++    return 'create the page for a vertical';
++  }
++
++  /**
++   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
++   *                                             the add vertical command, keyed by name
++   */
++  static args() {
++    return {
++      name: new ArgumentMetadata(ArgumentType.STRING, 'name of the vertical\'s page', true),
++      verticalKey: new ArgumentMetadata(ArgumentType.STRING, 'the vertical\'s key', true),
++      cardName: new ArgumentMetadata(
++        ArgumentType.STRING, 'card to use with vertical', false),
++      template: new ArgumentMetadata(
++        ArgumentType.STRING, 'page template to use within theme', true),
++      locales: new ArgumentMetadata(
++        ArgumentType.ARRAY,
++        'additional locales to generate the page for',
++        false,
++        [],
++        ArgumentType.STRING)
++    };
++  }
++
++  /**
++   * @returns {Object} description of the vertical command and its parameters.
++   */
++  static describe(jamboConfig) {
++    return {
++      displayName: 'Add Vertical',
++      params: {
++        name: {
++          displayName: 'Page Name',
++          required: true,
++          type: 'string'
++        },
++        verticalKey: {
++          displayName: 'Vertical Key',
++          required: true,
++          type: 'string',
++        },
++        cardName: {
++          displayName: 'Card Name',
++          type: 'singleoption',
++          options: this._getAvailableCards(jamboConfig)
++        },
++        template: {
++          displayName: 'Page Template',
++          required: true,
++          type: 'singleoption',
++          options: this._getPageTemplates(jamboConfig)
++        },
++        locales: {
++          displayName: 'Additional Page Locales',
++          type: 'multioption',
++          options: this._getAdditionalPageLocales(jamboConfig)
++        }
++      }
++    };
++  }
++
++  /**
++   * @param {Object} jamboConfig The Jambo configuration of the site.
++   * @returns {Array<string>} The additional locales that are configured in 
++   *                          locale_config.json
++   */
++  static _getAdditionalPageLocales(jamboConfig) {
++    if (!jamboConfig) {
++      return [];
++    }
++
++    const configDir = jamboConfig.dirs.config;
++    if (!configDir) {
++      return [];
++    }
++
++    const localeConfig = path.resolve(configDir, 'locale_config.json');
++    if (!fs.existsSync(localeConfig)) {
++      return [];
++    }
++
++    const localeContentsRaw = fs.readFileSync(localeConfig, 'utf-8');
++    let localeContentsJson;
++    try {
++      localeContentsJson = parse(localeContentsRaw);
++    } catch(err) {
++      throw new UserError('Could not parse locale_config.json ', err.stack);
++    }
++
++    const defaultLocale = localeContentsJson.default;
++    const pageLocales = [];
++    for (const locale in localeContentsJson.localeConfig) {
++      // don't list the default locale as an option
++      if (locale !== defaultLocale) {
++        pageLocales.push(locale);
++      }
++    }
++    return pageLocales;
++  }
++
++  /**
++   * @returns {Array<string>} the names of the available cards in the Theme
++   */
++  static _getAvailableCards(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
++
++    const cards = fs.readdirSync(themeCardsDir, { withFileTypes: true })
++      .filter(dirent => !dirent.isFile())
++      .map(dirent => dirent.name);
++
++    const customCardsDir = 'cards';
++    if (fs.existsSync(customCardsDir)) {
++      fs.readdirSync(customCardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile() && !cards.includes(dirent.name))
++        .forEach(dirent => cards.push(dirent.name));
++    }
++
++    return cards;
++  }
++
++  /**
++   * @returns {Array<string>} The page templates available in the current theme
++   */
++  static _getPageTemplates(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const pageTemplatesDir = path.resolve(themesDir, defaultTheme, 'templates');
++    return fs.readdirSync(pageTemplatesDir);
++  }
++
++  /**
++   * Executes the add vertical command with the provided arguments.
++   * 
++   * @param {Object<string, string>} args The arguments, keyed by name 
++   */
++  execute(args) {
++    this._validateArgs(args);
++    this._createVerticalPage(args.name, args.template, args.locales);
++    const cardName = args.cardName || this._getCardDefault(args.template);
++    this._configureVerticalPage(args.name, args.verticalKey, cardName);
++  }
++
++
++  /**
++   * Structural validation (missing required parameters, etc.) is handled by YArgs. This
++   * method provides an additional validation layer to ensure the provided template,
++   * cardName, and locales are valid. Any issue will result in a {@link UserError} being thrown.
++   * 
++   * @param {Object} args The command parameters.
++   */
++  _validateArgs(args) {
++    if (args.template === 'universal-standard') {
++      throw new UserError('A vertical cannot be initialized with the universal template');
++    }
++
++    const themeDir = this._getThemeDirectory(this.config);
++    const templateDir = path.join(themeDir, 'templates', args.template);
++    if (!fs.existsSync(templateDir)) {
++      throw new UserError(`${args.template} is not a valid template in the Theme`);
++    }
++
++    const availableCards = VerticalAdder._getAvailableCards(this.config);
++    if (args.cardName && !availableCards.includes(args.cardName)) {
++      throw new UserError(`${args.cardName} is not a valid card`);
++    }
++
++    if (args.locales.length) {
++      const supportedLocales = VerticalAdder._getAdditionalPageLocales(this.config);
++      args.locales.forEach(locale => {
++        if (!supportedLocales.includes(locale)) {
++          throw new UserError(`${locale} is not a locale supported by your site`);
++        }
++      })
++    }
++  }
++
++  /**
++   * Determines the default card type to use for a vertical. This is done by parsing the
++   * provided vertical template's page-config.json to find the cardType, if it exists.
++   * If the parsed JSON has no cardType, the 'standard' card is reported as the default.
++   * 
++   * @param {string} template The vertical's template name.
++   * @returns {string} The default card type.
++   */
++  _getCardDefault(template) {
++    const themeDir = this._getThemeDirectory(this.config);
++    const templateDir = path.join(themeDir, 'templates', template);
++
++    const pageConfig = parse(
++      fs.readFileSync(path.join(templateDir, 'page-config.json'), 'utf-8'));
++    const verticalConfig = pageConfig.verticalsToConfig['<REPLACE ME>'];
++    
++    return verticalConfig.cardType || 'standard';
++  }
++
++  /**
++   * Returns the path to the defaultTheme. If there is no defaultTheme, or
++   * the themes directory does not exist, null is returned.
++   * 
++   * @param {Object} jamboConfig The Jambo configuration for the site.
++   * @returns The path to the defaultTheme, relative to the top-level of the site.
++   */
++  _getThemeDirectory(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return null;
++    }
++
++    return path.join(themesDir, defaultTheme);
++  }
++
++  /**
++   * Creates a page for the vertical using the provided name and template. If additional
++   * locales are provided, localized copies of the vertical page will be created as well.
++   * Any output from the `jambo page` command is piped through.
++   * 
++   * @param {string} name The name of the vertical's page.
++   * @param {string} template The template to use.
++   * @param {Array<string>} locales The additional locales to generate the page for.
++   */
++  _createVerticalPage(name, template, locales) {
++    const args = ['--name', name, '--template', template];
++
++    if (locales.length) {
++      args.push('--locales', locales.join(' '));
++    }
++
++    spawnSync('npx jambo page', args, { shell: true, stdio: 'inherit' });
++  }
++
++  /**
++   * Updates the vertical page's configuration file. Specifically, placeholders for
++   * vertical key and card type are replaced with the provided values.
++   * 
++   * @param {string} name The page name.
++   * @param {string} verticalKey The vertical's key.
++   * @param {string} cardName The card to be used with the vertical.
++   */
++  _configureVerticalPage(name, verticalKey, cardName) {
++    const configFile = `config/${name}.json`;
++
++    let rawConfig = fs.readFileSync(configFile, { encoding: 'utf-8' });
++    rawConfig = rawConfig.replace(/\<REPLACE ME\>/g, verticalKey);
++    const parsedConfig = parse(rawConfig);
++
++    parsedConfig.verticalsToConfig[verticalKey].cardType = cardName;
++
++    fs.writeFileSync(configFile, stringify(parsedConfig, null, 2));
++  }
++}
++module.exports = VerticalAdder;
+\ No newline at end of file
+diff --git a/themes/answers-hitchhiker-theme/commands/cardcreator.js b/themes/answers-hitchhiker-theme/commands/cardcreator.js
+new file mode 100644
+index 0000000..28f8ce8
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/cardcreator.js
+@@ -0,0 +1,176 @@
++const fs = require('fs-extra');
++const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
++const path = require('path');
++const UserError = require('./helpers/errors/usererror');
++const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
++
++/**
++ * CardCreator represents the `card` custom jambo command.
++ * The command creates a new, custom card in the top-level 'cards' directory
++ * of a jambo repo.
++ */
++class CardCreator {
++  constructor(jamboConfig) {
++    this.config = jamboConfig;
++    this._customCardsDir = 'cards';
++  }
++
++  /**
++   * @returns {string} the alias for the create card command.
++   */
++  static getAlias() {
++    return 'card';
++  }
++
++  /**
++   * @returns {string} a short description of the create card command.
++   */
++  static getShortDescription() {
++    return 'add a new card for use in the site';
++  }
++
++  /**
++   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
++   *                                             the create card command, keyed by name
++   */
++  static args() {
++    return {
++      'name': new ArgumentMetadata(ArgumentType.STRING, 'name for the new card', true),
++      'templateCardFolder': new ArgumentMetadata(ArgumentType.STRING, 'folder of card to fork', true)
++    };
++  }
++
++  /**
++   * @returns {Object} description of the card command, including paths to 
++   *                   all available cards
++   */
++  static describe(jamboConfig) {
++    const cardPaths = this._getCardPaths(jamboConfig);
++    return {
++      displayName: 'Add Card',
++      params: {
++        name: {
++          displayName: 'Card Name',
++          required: true,
++          type: 'string'
++        },
++        templateCardFolder: {
++          displayName: 'Template Card Folder',
++          required: true,
++          type: 'singleoption',
++          options: cardPaths
++        }
++      }
++    };
++  }
++
++  /**
++   * @returns {Array<string>} the paths of the available cards
++   */
++  static _getCardPaths(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
++    const cardPaths = new Set();
++    const addCardsToSet = cardsDir => {
++      if (!fs.existsSync(cardsDir)) {
++        return;
++      }
++      fs.readdirSync(cardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile())
++        .forEach(dirent => cardPaths.add(path.join('cards', dirent.name)));
++    };
++    [themeCardsDir, 'cards'].forEach(dir => addCardsToSet(dir));
++    return Array.from(cardPaths);
++  }
++
++  /**
++   * Executes the create card command with the provided arguments.
++   * 
++   * @param {Object<string, string>} args The arguments, keyed by name 
++   */
++  execute(args) {
++    this._create(args.name, args.templateCardFolder);
++  }
++
++  /**
++   * Creates a new, custom card in the top-level 'Cards' directory. This card
++   * will be based off either an existing custom card or one supplied by the
++   * Theme.
++   * 
++   * @param {string} cardName           The name of the new card. A folder with a
++   *                                    lowercased version of this name will be
++   *                                    created.
++   * @param {string} templateCardFolder The folder of the existing card on which
++   *                                    the new one will be based.
++   */
++  _create(cardName, templateCardFolder) {
++    const defaultTheme = this.config.defaultTheme;
++    const themeCardsDir =
++      `${this.config.dirs.themes}/${defaultTheme}/${this._customCardsDir}`;
++
++    const cardFolderName = cardName.toLowerCase();
++    const isFolderInUse =
++      fs.existsSync(`${themeCardsDir}/${cardFolderName}`) ||
++      fs.existsSync(`${this._customCardsDir}/${cardFolderName}`);
++    if (isFolderInUse) {
++      throw new UserError(`A folder with name ${cardFolderName} already exists`);
++    }
++
++    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
++    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
++    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
++    fs.copySync(originalCardFolder, newCardFolder);
++    this._renameCardComponent(cardFolderName, newCardFolder);
++  }
++
++  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
++    if (fs.existsSync(templateCardFolder)) {
++      return templateCardFolder
++    } 
++    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
++    if (fs.existsSync(themeCardFolder)) {
++      return themeCardFolder;
++    }
++    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
++  }
++
++  _renameCardComponent(customCardName, cardFolder) {
++    const cardComponentPath = path.resolve(cardFolder, 'component.js');
++    const originalComponent = fs.readFileSync(cardComponentPath).toString();
++    const renamedComponent =
++      this._getRenamedCardComponent(originalComponent, customCardName);
++    fs.writeFileSync(cardComponentPath, renamedComponent);
++  }
++
++  /**
++   * Returns the internal contents for a newly-created card, updated based on
++   * the given customCardName. (e.g. StandardCardComponent -> [CustomName]CardComponent)
++   * @param {string} content
++   * @param {string} customCardName
++   * @returns {string}
++   */
++  _getRenamedCardComponent(content, customCardName) {
++    const cardNameSuffix = 'CardComponent';
++    const registerComponentTypeRegex = /\([\w_]+CardComponent\)/g;
++    const regexArray = [...content.matchAll(/componentName\s*=\s*'(.*)'/g)];
++    if (regexArray.length === 0 || regexArray[0].length < 2) {
++      return content;
++    }
++    const originalComponentName = regexArray[0][1];
++
++    const customComponentClassName =
++      customCardName.replace(/-/g, '_') + cardNameSuffix;
++
++    return content
++      .replace(/class (.*) extends/g, `class ${customComponentClassName} extends`)
++      .replace(registerComponentTypeRegex, `(${customComponentClassName})`)
++      .replace(new RegExp(originalComponentName, 'g'), customCardName)
++      .replace(/cards[/_](.*)[/_]template/g, `cards/${customCardName}/template`);
++  }
++}
++module.exports = CardCreator;
+diff --git a/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js b/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
+new file mode 100644
+index 0000000..211f3af
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
+@@ -0,0 +1,181 @@
++const fs = require('fs-extra');
++const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
++const path = require('path');
++const UserError = require('./helpers/errors/usererror');
++const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
++
++/**
++ * DirectAnswerCardCreator represents the `directanswercard` custom jambo command.
++ * The command creates a new, custom direct answer card in the top-level
++ * 'directanswercards' directory of a jambo repo.
++ */
++class DirectAnswerCardCreator {
++  constructor(jamboConfig) {
++    this.config = jamboConfig;
++    this._customCardsDir = 'directanswercards';
++  }
++
++  /**
++   * @returns {string} the alias for the create direct answer card command.
++   */
++  static getAlias() {
++    return 'directanswercard';
++  }
++
++  /**
++   * @returns {string} a short description of the create direct answer card command.
++   */
++  static getShortDescription() {
++    return 'add a new direct answer card for use in the site';
++  }
++
++  /**
++   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
++   *                                             the create direct answer card command, keyed by name
++   */
++  static args() {
++    return {
++      'name': new ArgumentMetadata(ArgumentType.STRING, 'name for the new direct answer card', true),
++      'templateCardFolder': new ArgumentMetadata(ArgumentType.STRING, 'folder of direct answer card to fork', true)
++    };
++  }
++
++  /**
++   * @returns {Object} description of the direct answer card command, including paths to 
++   *                   all available direct answer cards
++   */
++  static describe(jamboConfig) {
++    const directAnswerCardPaths = this._getDirectAnswerCardPaths(jamboConfig);
++    return {
++      displayName: 'Add Direct Answer Card',
++      params: {
++        name: {
++          displayName: 'Direct Answer Card Name',
++          required: true,
++          type: 'string'
++        },
++        templateCardFolder: {
++          displayName: 'Template Card Folder',
++          required: true,
++          type: 'singleoption',
++          options: directAnswerCardPaths
++        }
++      }
++    };
++  }
++
++  /**
++   * @returns {Array<string>} the paths of the available direct answer cards
++   */
++  static _getDirectAnswerCardPaths(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
++    const cardPaths = new Set();
++    const addCardsToSet = cardsDir => {
++      if (!fs.existsSync(cardsDir)) {
++        return;
++      }
++      fs.readdirSync(cardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile())
++        .forEach(dirent => cardPaths.add(path.join('directanswercards', dirent.name)));
++    };
++    [themeCardsDir, 'directanswercards'].forEach(dir => addCardsToSet(dir));
++    return Array.from(cardPaths);
++  }
++
++  /**
++   * Executes the create direct answer card command with the provided arguments.
++   * 
++   * @param {Object<string, string} args The arguments, keyed by name 
++   */
++  execute(args) {
++    this._create(args.name, args.templateCardFolder);
++  }
++
++  /**
++   * Creates a new, custom direct answer card in the top-level 'directanswercards'
++   * directory. This card will be based off either an existing custom card or one
++   * supplied by the Theme.
++   * 
++   * @param {string} cardName           The name of the new card. A folder with a
++   *                                    lowercased version of this name will be
++   *                                    created.
++   * @param {string} templateCardFolder The folder of the existing card on which
++   *                                    the new one will be based.
++   */
++  _create(cardName, templateCardFolder) {
++    const defaultTheme = this.config.defaultTheme;
++    const themeCardsDir =
++      `${this.config.dirs.themes}/${defaultTheme}/${this._customCardsDir}`;
++
++    const cardFolderName = cardName.toLowerCase();
++    const isFolderInUse =
++      fs.existsSync(`${themeCardsDir}/${cardFolderName}`) ||
++      fs.existsSync(`${this._customCardsDir}/${cardFolderName}`);
++    if (isFolderInUse) {
++      throw new UserError(`A folder with name ${cardFolderName} already exists`);
++    }
++
++    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
++    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
++    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
++    fs.copySync(originalCardFolder, newCardFolder);
++    this._renameCardComponent(cardFolderName, newCardFolder);
++  }
++
++  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
++    if (fs.existsSync(templateCardFolder)) {
++      return templateCardFolder
++    } 
++    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
++    if (fs.existsSync(themeCardFolder)) {
++      return themeCardFolder;
++    }
++    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
++  }
++
++  _renameCardComponent(customCardName, cardFolder) {
++    const cardComponentPath = path.resolve(cardFolder, 'component.js');
++    const originalComponent = fs.readFileSync(cardComponentPath).toString();
++    const renamedComponent =
++      this._getRenamedCardComponent(originalComponent, customCardName);
++    fs.writeFileSync(cardComponentPath, renamedComponent);
++  }
++
++  /**
++   * Returns the internal contents for a newly-created direct answer card, updated
++   * based on the given customCardName. (e.g. allfields_standardComponent ->
++   * [CustomName]Component)
++   * 
++   * @param {string} content
++   * @param {string} customCardName
++   * @returns {string}
++   */
++  _getRenamedCardComponent(content, customCardName) {
++    const cardNameSuffix = 'Component';
++    const registerComponentTypeRegex = /\([\w_]+Component\)/g;
++    const regexArray = [...content.matchAll(/componentName\s*=\s*'(.*)'/g)];
++    if (regexArray.length === 0 || regexArray[0].length < 2) {
++      return content;
++    }
++    const originalComponentName = regexArray[0][1];
++
++    const customComponentClassName =
++      customCardName.replace(/-/g, '_') + cardNameSuffix;
++
++    return content
++      .replace(/class (.*) extends/g, `class ${customComponentClassName} extends`)
++      .replace(registerComponentTypeRegex, `(${customComponentClassName})`)
++      .replace(new RegExp(originalComponentName, 'g'), customCardName)
++      .replace(
++        /directanswercards[/_](.*)[/_]template/g,
++        `directanswercards/${customCardName}/template`);
++  }
++}
++
++module.exports = DirectAnswerCardCreator;
+diff --git a/themes/answers-hitchhiker-theme/commands/helpers/errors/usererror.js b/themes/answers-hitchhiker-theme/commands/helpers/errors/usererror.js
+new file mode 100644
+index 0000000..d815b29
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/helpers/errors/usererror.js
+@@ -0,0 +1,20 @@
++/**
++ * Represents errors that we may reasonably expect a user to make
++ */
++class UserError extends Error {  
++  constructor(message, stack) {
++    super(message);
++
++    if (stack) {
++      this.stack = stack;
++      this.message = message;
++    } else {
++      Error.captureStackTrace(this, this.constructor);
++    }
++
++    this.name = 'UserError'
++    this.exitCode = 13;
++  }
++}
++
++module.exports = UserError;
+\ No newline at end of file
+diff --git a/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js b/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
+new file mode 100644
+index 0000000..49c5469
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
+@@ -0,0 +1,60 @@
++/**
++ * An enum describing the different kinds of argument that are supported.
++ */
++const ArgumentType = {
++  STRING: 'string',
++  NUMBER: 'number',
++  BOOLEAN: 'boolean',
++  ARRAY: 'array'
++}
++Object.freeze(ArgumentType);
++
++/**
++ * A class outlining the metadata for a {@link Command}'s argument. This includes
++ * the type of the argument's values, if it is required, and an optional default.
++ */
++class ArgumentMetadata {
++  constructor(type, description, isRequired, defaultValue, itemType) {
++    this._type = type;
++    this._isRequired = isRequired;
++    this._defaultValue = defaultValue;
++    this._description = description;
++    this._itemType = itemType;
++  }
++
++  /**
++   * @returns {ArgumentType} The type of the argument, e.g. STRING, BOOLEAN, etc.
++   */
++  getType() {
++    return this._type;
++  }
++
++  /**
++   * @returns {ArgumentType} The type of the elements of an array argument.
++   */
++  getItemType() {
++    return this._itemType;
++  }
++
++  /**
++   * @returns {string} The description of the argument.
++   */
++  getDescription() {
++    return this._description
++  }
++
++  /**
++   * @returns {boolean} A boolean indicating if the argument is required.
++   */
++  isRequired() {
++    return !!this._isRequired;
++  }
++
++  /**
++   * @returns {string|boolean|number} Optional, a default value for the argument. 
++   */
++  defaultValue() {
++    return this._defaultValue;
++  }
++}
++module.exports = { ArgumentMetadata, ArgumentType };
+\ No newline at end of file
+diff --git a/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js b/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
+new file mode 100644
+index 0000000..c356cba
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
+@@ -0,0 +1,69 @@
++const fs = require('file-system');
++const path = require('path');
++const mergeOptions = require('merge-options');
++const {
++  parse,
++  stringify
++} = require('comment-json');
++const UserError = require('../errors/usererror');
++
++/**
++ * Parses the repository's Jambo config file. If certain attributes are not
++ * present, defaults will be applied.
++ * 
++ * @returns {Object} The parsed Jambo configuration, as an {@link Object}. 
++ */
++exports.parseJamboConfig = function () {
++  try {
++    let config = mergeOptions(
++      {
++        dirs: {
++          themes: 'themes',
++          config: 'config',
++          output: 'public',
++          pages: 'pages',
++          partials: ['partials'],
++        }
++      },
++      parse(fs.readFileSync('jambo.json', 'utf8'))
++    );
++    return config;
++  } catch (err) {
++    throw new UserError('Error parsing jambo.json', err.stack);
++  }
++}
++
++/**
++ * Registers a new set of Handlebars partials in the Jambo configuration
++ * file. The set will not be registered if it has been already or if it
++ * comes from a Theme's 'static' directory.
++ * 
++ * @param {string} partialsPath The local path to the set of partials. 
++ */
++exports.addToPartials = function (partialsPath) {
++  const jamboConfig = parseJamboConfig();
++  const existingPartials = jamboConfig.dirs.partials;
++
++  const shouldAddNewPartialsPath =
++    !existingPartials.includes(partialsPath) &&
++    partialsPath.split(path.sep)[0] !== 'static';
++
++  if (shouldAddNewPartialsPath) {
++    existingPartials.push(partialsPath);
++    fs.writeFileSync('jambo.json', stringify(jamboConfig, null, 2));
++  }
++}
++
++/**
++ * Returns whether or not the partialsPath exists in the partials object in the
++ * Jambo config
++ *
++ * @param {Object} jamboConfig The parsed jambo config
++ * @param {string} partialsPath The local path to the set of partials. 
++ * @returns {boolean}
++ */
++exports.containsPartial = function (jamboConfig, partialsPath) {
++  return jamboConfig.dirs
++    && jamboConfig.dirs.partials
++    && jamboConfig.dirs.partials.includes(partialsPath);
++}
+-- 
+2.30.2
+

--- a/patches/v1.16-commands-upgrade.patch
+++ b/patches/v1.16-commands-upgrade.patch
@@ -1,0 +1,655 @@
+From b9e6a4ddc84eecaa0cbb123bbd62152ae685ee11 Mon Sep 17 00:00:00 2001
+From: Connor Anderson <canderson@yext.com>
+Date: Wed, 31 Mar 2021 20:36:13 -0400
+Subject: [PATCH] v1.16-commands-upgrade
+
+---
+ .../commands/addvertical.js                   | 288 ++++++++++++++++++
+ .../commands/cardcreator.js                   |  69 +++--
+ .../commands/directanswercardcreator.js       |  68 +++--
+ .../helpers/utils/argumentmetadata.js         |  14 +-
+ .../helpers/utils/jamboconfigutils.js         |  16 +-
+ 5 files changed, 390 insertions(+), 65 deletions(-)
+ create mode 100644 themes/answers-hitchhiker-theme/commands/addvertical.js
+
+diff --git a/themes/answers-hitchhiker-theme/commands/addvertical.js b/themes/answers-hitchhiker-theme/commands/addvertical.js
+new file mode 100644
+index 0000000..5936f5d
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/addvertical.js
+@@ -0,0 +1,288 @@
++const fs = require('fs-extra');
++const path = require('path');
++const { parse, stringify } = require('comment-json');
++const { spawnSync } = require('child_process');
++
++const UserError = require('./helpers/errors/usererror');
++const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
++
++/**
++ * VerticalAdder represents the `vertical` custom jambo command. The command adds
++ * a new page for the given Vertical and associates a card type with it.
++ */
++class VerticalAdder {
++  constructor(jamboConfig) {
++    this.config = jamboConfig;
++  }
++
++  /**
++   * @returns {string} the alias for the add vertical command.
++   */
++  static getAlias() {
++    return 'vertical';
++  }
++
++  /**
++   * @returns {string} a short description of the add vertical command.
++   */
++  static getShortDescription() {
++    return 'create the page for a vertical';
++  }
++
++  /**
++   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
++   *                                             the add vertical command, keyed by name
++   */
++  static args() {
++    return {
++      name: new ArgumentMetadata(ArgumentType.STRING, 'name of the vertical\'s page', true),
++      verticalKey: new ArgumentMetadata(ArgumentType.STRING, 'the vertical\'s key', true),
++      cardName: new ArgumentMetadata(
++        ArgumentType.STRING, 'card to use with vertical', false),
++      template: new ArgumentMetadata(
++        ArgumentType.STRING, 'page template to use within theme', true),
++      locales: new ArgumentMetadata(
++        ArgumentType.ARRAY,
++        'additional locales to generate the page for',
++        false,
++        [],
++        ArgumentType.STRING)
++    };
++  }
++
++  /**
++   * @returns {Object} description of the vertical command and its parameters.
++   */
++  static describe(jamboConfig) {
++    return {
++      displayName: 'Add Vertical',
++      params: {
++        name: {
++          displayName: 'Page Name',
++          required: true,
++          type: 'string'
++        },
++        verticalKey: {
++          displayName: 'Vertical Key',
++          required: true,
++          type: 'string',
++        },
++        cardName: {
++          displayName: 'Card Name',
++          type: 'singleoption',
++          options: this._getAvailableCards(jamboConfig)
++        },
++        template: {
++          displayName: 'Page Template',
++          required: true,
++          type: 'singleoption',
++          options: this._getPageTemplates(jamboConfig)
++        },
++        locales: {
++          displayName: 'Additional Page Locales',
++          type: 'multioption',
++          options: this._getAdditionalPageLocales(jamboConfig)
++        }
++      }
++    };
++  }
++
++  /**
++   * @param {Object} jamboConfig The Jambo configuration of the site.
++   * @returns {Array<string>} The additional locales that are configured in 
++   *                          locale_config.json
++   */
++  static _getAdditionalPageLocales(jamboConfig) {
++    if (!jamboConfig) {
++      return [];
++    }
++
++    const configDir = jamboConfig.dirs.config;
++    if (!configDir) {
++      return [];
++    }
++
++    const localeConfig = path.resolve(configDir, 'locale_config.json');
++    if (!fs.existsSync(localeConfig)) {
++      return [];
++    }
++
++    const localeContentsRaw = fs.readFileSync(localeConfig, 'utf-8');
++    let localeContentsJson;
++    try {
++      localeContentsJson = parse(localeContentsRaw);
++    } catch(err) {
++      throw new UserError('Could not parse locale_config.json ', err.stack);
++    }
++
++    const defaultLocale = localeContentsJson.default;
++    const pageLocales = [];
++    for (const locale in localeContentsJson.localeConfig) {
++      // don't list the default locale as an option
++      if (locale !== defaultLocale) {
++        pageLocales.push(locale);
++      }
++    }
++    return pageLocales;
++  }
++
++  /**
++   * @returns {Array<string>} the names of the available cards in the Theme
++   */
++  static _getAvailableCards(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
++
++    const cards = fs.readdirSync(themeCardsDir, { withFileTypes: true })
++      .filter(dirent => !dirent.isFile())
++      .map(dirent => dirent.name);
++
++    const customCardsDir = 'cards';
++    if (fs.existsSync(customCardsDir)) {
++      fs.readdirSync(customCardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile() && !cards.includes(dirent.name))
++        .forEach(dirent => cards.push(dirent.name));
++    }
++
++    return cards;
++  }
++
++  /**
++   * @returns {Array<string>} The page templates available in the current theme
++   */
++  static _getPageTemplates(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const pageTemplatesDir = path.resolve(themesDir, defaultTheme, 'templates');
++    return fs.readdirSync(pageTemplatesDir);
++  }
++
++  /**
++   * Executes the add vertical command with the provided arguments.
++   * 
++   * @param {Object<string, string>} args The arguments, keyed by name 
++   */
++  execute(args) {
++    this._validateArgs(args);
++    this._createVerticalPage(args.name, args.template, args.locales);
++    const cardName = args.cardName || this._getCardDefault(args.template);
++    this._configureVerticalPage(args.name, args.verticalKey, cardName);
++  }
++
++
++  /**
++   * Structural validation (missing required parameters, etc.) is handled by YArgs. This
++   * method provides an additional validation layer to ensure the provided template,
++   * cardName, and locales are valid. Any issue will result in a {@link UserError} being thrown.
++   * 
++   * @param {Object} args The command parameters.
++   */
++  _validateArgs(args) {
++    if (args.template === 'universal-standard') {
++      throw new UserError('A vertical cannot be initialized with the universal template');
++    }
++
++    const themeDir = this._getThemeDirectory(this.config);
++    const templateDir = path.join(themeDir, 'templates', args.template);
++    if (!fs.existsSync(templateDir)) {
++      throw new UserError(`${args.template} is not a valid template in the Theme`);
++    }
++
++    const availableCards = VerticalAdder._getAvailableCards(this.config);
++    if (args.cardName && !availableCards.includes(args.cardName)) {
++      throw new UserError(`${args.cardName} is not a valid card`);
++    }
++
++    if (args.locales.length) {
++      const supportedLocales = VerticalAdder._getAdditionalPageLocales(this.config);
++      args.locales.forEach(locale => {
++        if (!supportedLocales.includes(locale)) {
++          throw new UserError(`${locale} is not a locale supported by your site`);
++        }
++      })
++    }
++  }
++
++  /**
++   * Determines the default card type to use for a vertical. This is done by parsing the
++   * provided vertical template's page-config.json to find the cardType, if it exists.
++   * If the parsed JSON has no cardType, the 'standard' card is reported as the default.
++   * 
++   * @param {string} template The vertical's template name.
++   * @returns {string} The default card type.
++   */
++  _getCardDefault(template) {
++    const themeDir = this._getThemeDirectory(this.config);
++    const templateDir = path.join(themeDir, 'templates', template);
++
++    const pageConfig = parse(
++      fs.readFileSync(path.join(templateDir, 'page-config.json'), 'utf-8'));
++    const verticalConfig = pageConfig.verticalsToConfig['<REPLACE ME>'];
++    
++    return verticalConfig.cardType || 'standard';
++  }
++
++  /**
++   * Returns the path to the defaultTheme. If there is no defaultTheme, or
++   * the themes directory does not exist, null is returned.
++   * 
++   * @param {Object} jamboConfig The Jambo configuration for the site.
++   * @returns The path to the defaultTheme, relative to the top-level of the site.
++   */
++  _getThemeDirectory(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return null;
++    }
++
++    return path.join(themesDir, defaultTheme);
++  }
++
++  /**
++   * Creates a page for the vertical using the provided name and template. If additional
++   * locales are provided, localized copies of the vertical page will be created as well.
++   * Any output from the `jambo page` command is piped through.
++   * 
++   * @param {string} name The name of the vertical's page.
++   * @param {string} template The template to use.
++   * @param {Array<string>} locales The additional locales to generate the page for.
++   */
++  _createVerticalPage(name, template, locales) {
++    const args = ['--name', name, '--template', template];
++
++    if (locales.length) {
++      args.push('--locales', locales.join(' '));
++    }
++
++    spawnSync('npx jambo page', args, { shell: true, stdio: 'inherit' });
++  }
++
++  /**
++   * Updates the vertical page's configuration file. Specifically, placeholders for
++   * vertical key and card type are replaced with the provided values.
++   * 
++   * @param {string} name The page name.
++   * @param {string} verticalKey The vertical's key.
++   * @param {string} cardName The card to be used with the vertical.
++   */
++  _configureVerticalPage(name, verticalKey, cardName) {
++    const configFile = `config/${name}.json`;
++
++    let rawConfig = fs.readFileSync(configFile, { encoding: 'utf-8' });
++    rawConfig = rawConfig.replace(/\<REPLACE ME\>/g, verticalKey);
++    const parsedConfig = parse(rawConfig);
++
++    parsedConfig.verticalsToConfig[verticalKey].cardType = cardName;
++
++    fs.writeFileSync(configFile, stringify(parsedConfig, null, 2));
++  }
++}
++module.exports = VerticalAdder;
+\ No newline at end of file
+diff --git a/themes/answers-hitchhiker-theme/commands/cardcreator.js b/themes/answers-hitchhiker-theme/commands/cardcreator.js
+index 7174819..28f8ce8 100644
+--- a/themes/answers-hitchhiker-theme/commands/cardcreator.js
++++ b/themes/answers-hitchhiker-theme/commands/cardcreator.js
+@@ -1,5 +1,5 @@
+ const fs = require('fs-extra');
+-const { addToPartials } = require('./helpers/utils/jamboconfigutils');
++const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
+ const path = require('path');
+ const UserError = require('./helpers/errors/usererror');
+ const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
+@@ -12,22 +12,20 @@ const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmeta
+ class CardCreator {
+   constructor(jamboConfig) {
+     this.config = jamboConfig;
+-    this.themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
+-    this.defaultTheme = jamboConfig.defaultTheme;
+     this._customCardsDir = 'cards';
+   }
+ 
+   /**
+    * @returns {string} the alias for the create card command.
+    */
+-  getAlias() {
++  static getAlias() {
+     return 'card';
+   }
+ 
+   /**
+    * @returns {string} a short description of the create card command.
+    */
+-  getShortDescription() {
++  static getShortDescription() {
+     return 'add a new card for use in the site';
+   }
+ 
+@@ -35,7 +33,7 @@ class CardCreator {
+    * @returns {Object<string, ArgumentMetadata>} description of each argument for 
+    *                                             the create card command, keyed by name
+    */
+-  args() {
++  static args() {
+     return {
+       'name': new ArgumentMetadata(ArgumentType.STRING, 'name for the new card', true),
+       'templateCardFolder': new ArgumentMetadata(ArgumentType.STRING, 'folder of card to fork', true)
+@@ -46,8 +44,8 @@ class CardCreator {
+    * @returns {Object} description of the card command, including paths to 
+    *                   all available cards
+    */
+-  describe() {
+-    const cardPaths = this._getCardPaths();
++  static describe(jamboConfig) {
++    const cardPaths = this._getCardPaths(jamboConfig);
+     return {
+       displayName: 'Add Card',
+       params: {
+@@ -69,14 +67,24 @@ class CardCreator {
+   /**
+    * @returns {Array<string>} the paths of the available cards
+    */
+-  _getCardPaths() {
+-    if (!this.defaultTheme || !this.themesDir) {
++  static _getCardPaths(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
+       return [];
+     }
+-    const cardsDir = path.join(this.themesDir, this.defaultTheme, 'cards');
+-    return fs.readdirSync(cardsDir, { withFileTypes: true })
+-      .filter(dirent => !dirent.isFile())
+-      .map(dirent => path.join(cardsDir, dirent.name));
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
++    const cardPaths = new Set();
++    const addCardsToSet = cardsDir => {
++      if (!fs.existsSync(cardsDir)) {
++        return;
++      }
++      fs.readdirSync(cardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile())
++        .forEach(dirent => cardPaths.add(path.join('cards', dirent.name)));
++    };
++    [themeCardsDir, 'cards'].forEach(dir => addCardsToSet(dir));
++    return Array.from(cardPaths);
+   }
+ 
+   /**
+@@ -112,14 +120,23 @@ class CardCreator {
+       throw new UserError(`A folder with name ${cardFolderName} already exists`);
+     }
+ 
+-    const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
++    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
++    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
++    fs.copySync(originalCardFolder, newCardFolder);
++    this._renameCardComponent(cardFolderName, newCardFolder);
++  }
++
++  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
+     if (fs.existsSync(templateCardFolder)) {
+-      !fs.existsSync(this._customCardsDir) && this._createCustomCardsDir();
+-      fs.copySync(templateCardFolder, cardFolder);
+-      this._renameCardComponent(cardFolderName, cardFolder);
+-    } else {
+-      throw new UserError(`The folder ${templateCardFolder} does not exist`);
++      return templateCardFolder
++    } 
++    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
++    if (fs.existsSync(themeCardFolder)) {
++      return themeCardFolder;
+     }
++    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
+   }
+ 
+   _renameCardComponent(customCardName, cardFolder) {
+@@ -155,15 +172,5 @@ class CardCreator {
+       .replace(new RegExp(originalComponentName, 'g'), customCardName)
+       .replace(/cards[/_](.*)[/_]template/g, `cards/${customCardName}/template`);
+   }
+-
+-  /**
+-   * Creates the 'cards' directory in the Jambo repository and adds the newly 
+-   * created directory to the list of partials in the Jambo config.
+-   */
+-  _createCustomCardsDir() {
+-    fs.mkdirSync(this._customCardsDir);
+-    addToPartials(this._customCardsDir);
+-  }
+ }
+-
+-module.exports = jamboConfig => new CardCreator(jamboConfig);
++module.exports = CardCreator;
+diff --git a/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js b/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
+index fc98e22..211f3af 100644
+--- a/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
++++ b/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
+@@ -1,5 +1,5 @@
+ const fs = require('fs-extra');
+-const { addToPartials } = require('./helpers/utils/jamboconfigutils');
++const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
+ const path = require('path');
+ const UserError = require('./helpers/errors/usererror');
+ const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
+@@ -12,22 +12,20 @@ const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmeta
+ class DirectAnswerCardCreator {
+   constructor(jamboConfig) {
+     this.config = jamboConfig;
+-    this.themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
+-    this.defaultTheme = jamboConfig.defaultTheme;
+     this._customCardsDir = 'directanswercards';
+   }
+ 
+   /**
+    * @returns {string} the alias for the create direct answer card command.
+    */
+-  getAlias() {
++  static getAlias() {
+     return 'directanswercard';
+   }
+ 
+   /**
+    * @returns {string} a short description of the create direct answer card command.
+    */
+-  getShortDescription() {
++  static getShortDescription() {
+     return 'add a new direct answer card for use in the site';
+   }
+ 
+@@ -35,7 +33,7 @@ class DirectAnswerCardCreator {
+    * @returns {Object<string, ArgumentMetadata>} description of each argument for 
+    *                                             the create direct answer card command, keyed by name
+    */
+-  args() {
++  static args() {
+     return {
+       'name': new ArgumentMetadata(ArgumentType.STRING, 'name for the new direct answer card', true),
+       'templateCardFolder': new ArgumentMetadata(ArgumentType.STRING, 'folder of direct answer card to fork', true)
+@@ -46,8 +44,8 @@ class DirectAnswerCardCreator {
+    * @returns {Object} description of the direct answer card command, including paths to 
+    *                   all available direct answer cards
+    */
+-  describe() {
+-    const directAnswerCardPaths = this._getDirectAnswerCardPaths();
++  static describe(jamboConfig) {
++    const directAnswerCardPaths = this._getDirectAnswerCardPaths(jamboConfig);
+     return {
+       displayName: 'Add Direct Answer Card',
+       params: {
+@@ -69,14 +67,24 @@ class DirectAnswerCardCreator {
+   /**
+    * @returns {Array<string>} the paths of the available direct answer cards
+    */
+-  _getDirectAnswerCardPaths() {
+-    if (!this.defaultTheme || !this.themesDir) {
++  static _getDirectAnswerCardPaths(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
+       return [];
+     }
+-    const daCardsDir = path.join(this.themesDir, this.defaultTheme, 'directanswercards');
+-    return fs.readdirSync(daCardsDir, { withFileTypes: true })
+-      .filter(dirent => !dirent.isFile())
+-      .map(dirent => path.join(daCardsDir, dirent.name));
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
++    const cardPaths = new Set();
++    const addCardsToSet = cardsDir => {
++      if (!fs.existsSync(cardsDir)) {
++        return;
++      }
++      fs.readdirSync(cardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile())
++        .forEach(dirent => cardPaths.add(path.join('directanswercards', dirent.name)));
++    };
++    [themeCardsDir, 'directanswercards'].forEach(dir => addCardsToSet(dir));
++    return Array.from(cardPaths);
+   }
+ 
+   /**
+@@ -112,14 +120,23 @@ class DirectAnswerCardCreator {
+       throw new UserError(`A folder with name ${cardFolderName} already exists`);
+     }
+ 
+-    const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
++    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
++    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
++    fs.copySync(originalCardFolder, newCardFolder);
++    this._renameCardComponent(cardFolderName, newCardFolder);
++  }
++
++  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
+     if (fs.existsSync(templateCardFolder)) {
+-      !fs.existsSync(this._customCardsDir) && this._createCustomCardsDir();
+-      fs.copySync(templateCardFolder, cardFolder);
+-      this._renameCardComponent(cardFolderName, cardFolder);
+-    } else {
+-      throw new UserError(`The folder ${templateCardFolder} does not exist`);
++      return templateCardFolder
++    } 
++    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
++    if (fs.existsSync(themeCardFolder)) {
++      return themeCardFolder;
+     }
++    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
+   }
+ 
+   _renameCardComponent(customCardName, cardFolder) {
+@@ -159,15 +176,6 @@ class DirectAnswerCardCreator {
+         /directanswercards[/_](.*)[/_]template/g,
+         `directanswercards/${customCardName}/template`);
+   }
+-
+-  /**
+-   * Creates the 'directanswercards' directory in the Jambo repository and adds the newly 
+-   * created directory to the list of partials in the Jambo config.
+-   */
+-  _createCustomCardsDir() {
+-    fs.mkdirSync(this._customCardsDir);
+-    addToPartials(this._customCardsDir);
+-  }
+ }
+ 
+-module.exports = jamboConfig => new DirectAnswerCardCreator(jamboConfig);
++module.exports = DirectAnswerCardCreator;
+diff --git a/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js b/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
+index 2047695..49c5469 100644
+--- a/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
++++ b/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
+@@ -4,7 +4,8 @@
+ const ArgumentType = {
+   STRING: 'string',
+   NUMBER: 'number',
+-  BOOLEAN: 'boolean'
++  BOOLEAN: 'boolean',
++  ARRAY: 'array'
+ }
+ Object.freeze(ArgumentType);
+ 
+@@ -13,11 +14,12 @@ Object.freeze(ArgumentType);
+  * the type of the argument's values, if it is required, and an optional default.
+  */
+ class ArgumentMetadata {
+-  constructor(type, description, isRequired, defaultValue) {
++  constructor(type, description, isRequired, defaultValue, itemType) {
+     this._type = type;
+     this._isRequired = isRequired;
+     this._defaultValue = defaultValue;
+     this._description = description;
++    this._itemType = itemType;
+   }
+ 
+   /**
+@@ -27,6 +29,13 @@ class ArgumentMetadata {
+     return this._type;
+   }
+ 
++  /**
++   * @returns {ArgumentType} The type of the elements of an array argument.
++   */
++  getItemType() {
++    return this._itemType;
++  }
++
+   /**
+    * @returns {string} The description of the argument.
+    */
+@@ -47,6 +56,5 @@ class ArgumentMetadata {
+   defaultValue() {
+     return this._defaultValue;
+   }
+-
+ }
+ module.exports = { ArgumentMetadata, ArgumentType };
+\ No newline at end of file
+diff --git a/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js b/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
+index 2e91f22..c356cba 100644
+--- a/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
++++ b/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
+@@ -52,4 +52,18 @@ exports.addToPartials = function (partialsPath) {
+     existingPartials.push(partialsPath);
+     fs.writeFileSync('jambo.json', stringify(jamboConfig, null, 2));
+   }
+-}
+\ No newline at end of file
++}
++
++/**
++ * Returns whether or not the partialsPath exists in the partials object in the
++ * Jambo config
++ *
++ * @param {Object} jamboConfig The parsed jambo config
++ * @param {string} partialsPath The local path to the set of partials. 
++ * @returns {boolean}
++ */
++exports.containsPartial = function (jamboConfig, partialsPath) {
++  return jamboConfig.dirs
++    && jamboConfig.dirs.partials
++    && jamboConfig.dirs.partials.includes(partialsPath);
++}
+-- 
+2.30.2
+

--- a/patches/v1.17-through-v1.19-commands-update.patch
+++ b/patches/v1.17-through-v1.19-commands-update.patch
@@ -1,0 +1,546 @@
+From 56a0163383ef99178038d13d699ac975803761c0 Mon Sep 17 00:00:00 2001
+From: Connor Anderson <canderson@yext.com>
+Date: Wed, 31 Mar 2021 20:30:45 -0400
+Subject: [PATCH] Upgrade the commands of Themes v1.17 through v1.19
+
+---
+ .../commands/addvertical.js                   | 288 ++++++++++++++++++
+ .../commands/cardcreator.js                   |  48 +--
+ .../commands/directanswercardcreator.js       |  48 +--
+ .../helpers/utils/argumentmetadata.js         |  14 +-
+ .../helpers/utils/jamboconfigutils.js         |  16 +-
+ 5 files changed, 370 insertions(+), 44 deletions(-)
+ create mode 100644 themes/answers-hitchhiker-theme/commands/addvertical.js
+
+diff --git a/themes/answers-hitchhiker-theme/commands/addvertical.js b/themes/answers-hitchhiker-theme/commands/addvertical.js
+new file mode 100644
+index 0000000..5936f5d
+--- /dev/null
++++ b/themes/answers-hitchhiker-theme/commands/addvertical.js
+@@ -0,0 +1,288 @@
++const fs = require('fs-extra');
++const path = require('path');
++const { parse, stringify } = require('comment-json');
++const { spawnSync } = require('child_process');
++
++const UserError = require('./helpers/errors/usererror');
++const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
++
++/**
++ * VerticalAdder represents the `vertical` custom jambo command. The command adds
++ * a new page for the given Vertical and associates a card type with it.
++ */
++class VerticalAdder {
++  constructor(jamboConfig) {
++    this.config = jamboConfig;
++  }
++
++  /**
++   * @returns {string} the alias for the add vertical command.
++   */
++  static getAlias() {
++    return 'vertical';
++  }
++
++  /**
++   * @returns {string} a short description of the add vertical command.
++   */
++  static getShortDescription() {
++    return 'create the page for a vertical';
++  }
++
++  /**
++   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
++   *                                             the add vertical command, keyed by name
++   */
++  static args() {
++    return {
++      name: new ArgumentMetadata(ArgumentType.STRING, 'name of the vertical\'s page', true),
++      verticalKey: new ArgumentMetadata(ArgumentType.STRING, 'the vertical\'s key', true),
++      cardName: new ArgumentMetadata(
++        ArgumentType.STRING, 'card to use with vertical', false),
++      template: new ArgumentMetadata(
++        ArgumentType.STRING, 'page template to use within theme', true),
++      locales: new ArgumentMetadata(
++        ArgumentType.ARRAY,
++        'additional locales to generate the page for',
++        false,
++        [],
++        ArgumentType.STRING)
++    };
++  }
++
++  /**
++   * @returns {Object} description of the vertical command and its parameters.
++   */
++  static describe(jamboConfig) {
++    return {
++      displayName: 'Add Vertical',
++      params: {
++        name: {
++          displayName: 'Page Name',
++          required: true,
++          type: 'string'
++        },
++        verticalKey: {
++          displayName: 'Vertical Key',
++          required: true,
++          type: 'string',
++        },
++        cardName: {
++          displayName: 'Card Name',
++          type: 'singleoption',
++          options: this._getAvailableCards(jamboConfig)
++        },
++        template: {
++          displayName: 'Page Template',
++          required: true,
++          type: 'singleoption',
++          options: this._getPageTemplates(jamboConfig)
++        },
++        locales: {
++          displayName: 'Additional Page Locales',
++          type: 'multioption',
++          options: this._getAdditionalPageLocales(jamboConfig)
++        }
++      }
++    };
++  }
++
++  /**
++   * @param {Object} jamboConfig The Jambo configuration of the site.
++   * @returns {Array<string>} The additional locales that are configured in 
++   *                          locale_config.json
++   */
++  static _getAdditionalPageLocales(jamboConfig) {
++    if (!jamboConfig) {
++      return [];
++    }
++
++    const configDir = jamboConfig.dirs.config;
++    if (!configDir) {
++      return [];
++    }
++
++    const localeConfig = path.resolve(configDir, 'locale_config.json');
++    if (!fs.existsSync(localeConfig)) {
++      return [];
++    }
++
++    const localeContentsRaw = fs.readFileSync(localeConfig, 'utf-8');
++    let localeContentsJson;
++    try {
++      localeContentsJson = parse(localeContentsRaw);
++    } catch(err) {
++      throw new UserError('Could not parse locale_config.json ', err.stack);
++    }
++
++    const defaultLocale = localeContentsJson.default;
++    const pageLocales = [];
++    for (const locale in localeContentsJson.localeConfig) {
++      // don't list the default locale as an option
++      if (locale !== defaultLocale) {
++        pageLocales.push(locale);
++      }
++    }
++    return pageLocales;
++  }
++
++  /**
++   * @returns {Array<string>} the names of the available cards in the Theme
++   */
++  static _getAvailableCards(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
++
++    const cards = fs.readdirSync(themeCardsDir, { withFileTypes: true })
++      .filter(dirent => !dirent.isFile())
++      .map(dirent => dirent.name);
++
++    const customCardsDir = 'cards';
++    if (fs.existsSync(customCardsDir)) {
++      fs.readdirSync(customCardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile() && !cards.includes(dirent.name))
++        .forEach(dirent => cards.push(dirent.name));
++    }
++
++    return cards;
++  }
++
++  /**
++   * @returns {Array<string>} The page templates available in the current theme
++   */
++  static _getPageTemplates(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return [];
++    }
++    const pageTemplatesDir = path.resolve(themesDir, defaultTheme, 'templates');
++    return fs.readdirSync(pageTemplatesDir);
++  }
++
++  /**
++   * Executes the add vertical command with the provided arguments.
++   * 
++   * @param {Object<string, string>} args The arguments, keyed by name 
++   */
++  execute(args) {
++    this._validateArgs(args);
++    this._createVerticalPage(args.name, args.template, args.locales);
++    const cardName = args.cardName || this._getCardDefault(args.template);
++    this._configureVerticalPage(args.name, args.verticalKey, cardName);
++  }
++
++
++  /**
++   * Structural validation (missing required parameters, etc.) is handled by YArgs. This
++   * method provides an additional validation layer to ensure the provided template,
++   * cardName, and locales are valid. Any issue will result in a {@link UserError} being thrown.
++   * 
++   * @param {Object} args The command parameters.
++   */
++  _validateArgs(args) {
++    if (args.template === 'universal-standard') {
++      throw new UserError('A vertical cannot be initialized with the universal template');
++    }
++
++    const themeDir = this._getThemeDirectory(this.config);
++    const templateDir = path.join(themeDir, 'templates', args.template);
++    if (!fs.existsSync(templateDir)) {
++      throw new UserError(`${args.template} is not a valid template in the Theme`);
++    }
++
++    const availableCards = VerticalAdder._getAvailableCards(this.config);
++    if (args.cardName && !availableCards.includes(args.cardName)) {
++      throw new UserError(`${args.cardName} is not a valid card`);
++    }
++
++    if (args.locales.length) {
++      const supportedLocales = VerticalAdder._getAdditionalPageLocales(this.config);
++      args.locales.forEach(locale => {
++        if (!supportedLocales.includes(locale)) {
++          throw new UserError(`${locale} is not a locale supported by your site`);
++        }
++      })
++    }
++  }
++
++  /**
++   * Determines the default card type to use for a vertical. This is done by parsing the
++   * provided vertical template's page-config.json to find the cardType, if it exists.
++   * If the parsed JSON has no cardType, the 'standard' card is reported as the default.
++   * 
++   * @param {string} template The vertical's template name.
++   * @returns {string} The default card type.
++   */
++  _getCardDefault(template) {
++    const themeDir = this._getThemeDirectory(this.config);
++    const templateDir = path.join(themeDir, 'templates', template);
++
++    const pageConfig = parse(
++      fs.readFileSync(path.join(templateDir, 'page-config.json'), 'utf-8'));
++    const verticalConfig = pageConfig.verticalsToConfig['<REPLACE ME>'];
++    
++    return verticalConfig.cardType || 'standard';
++  }
++
++  /**
++   * Returns the path to the defaultTheme. If there is no defaultTheme, or
++   * the themes directory does not exist, null is returned.
++   * 
++   * @param {Object} jamboConfig The Jambo configuration for the site.
++   * @returns The path to the defaultTheme, relative to the top-level of the site.
++   */
++  _getThemeDirectory(jamboConfig) {
++    const defaultTheme = jamboConfig.defaultTheme;
++    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
++    if (!defaultTheme || !themesDir) {
++      return null;
++    }
++
++    return path.join(themesDir, defaultTheme);
++  }
++
++  /**
++   * Creates a page for the vertical using the provided name and template. If additional
++   * locales are provided, localized copies of the vertical page will be created as well.
++   * Any output from the `jambo page` command is piped through.
++   * 
++   * @param {string} name The name of the vertical's page.
++   * @param {string} template The template to use.
++   * @param {Array<string>} locales The additional locales to generate the page for.
++   */
++  _createVerticalPage(name, template, locales) {
++    const args = ['--name', name, '--template', template];
++
++    if (locales.length) {
++      args.push('--locales', locales.join(' '));
++    }
++
++    spawnSync('npx jambo page', args, { shell: true, stdio: 'inherit' });
++  }
++
++  /**
++   * Updates the vertical page's configuration file. Specifically, placeholders for
++   * vertical key and card type are replaced with the provided values.
++   * 
++   * @param {string} name The page name.
++   * @param {string} verticalKey The vertical's key.
++   * @param {string} cardName The card to be used with the vertical.
++   */
++  _configureVerticalPage(name, verticalKey, cardName) {
++    const configFile = `config/${name}.json`;
++
++    let rawConfig = fs.readFileSync(configFile, { encoding: 'utf-8' });
++    rawConfig = rawConfig.replace(/\<REPLACE ME\>/g, verticalKey);
++    const parsedConfig = parse(rawConfig);
++
++    parsedConfig.verticalsToConfig[verticalKey].cardType = cardName;
++
++    fs.writeFileSync(configFile, stringify(parsedConfig, null, 2));
++  }
++}
++module.exports = VerticalAdder;
+\ No newline at end of file
+diff --git a/themes/answers-hitchhiker-theme/commands/cardcreator.js b/themes/answers-hitchhiker-theme/commands/cardcreator.js
+index dfe5ca9..28f8ce8 100644
+--- a/themes/answers-hitchhiker-theme/commands/cardcreator.js
++++ b/themes/answers-hitchhiker-theme/commands/cardcreator.js
+@@ -1,5 +1,5 @@
+ const fs = require('fs-extra');
+-const { addToPartials } = require('./helpers/utils/jamboconfigutils');
++const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
+ const path = require('path');
+ const UserError = require('./helpers/errors/usererror');
+ const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
+@@ -73,10 +73,18 @@ class CardCreator {
+     if (!defaultTheme || !themesDir) {
+       return [];
+     }
+-    const cardsDir = path.join(themesDir, defaultTheme, 'cards');
+-    return fs.readdirSync(cardsDir, { withFileTypes: true })
+-      .filter(dirent => !dirent.isFile())
+-      .map(dirent => path.join(cardsDir, dirent.name));
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'cards');
++    const cardPaths = new Set();
++    const addCardsToSet = cardsDir => {
++      if (!fs.existsSync(cardsDir)) {
++        return;
++      }
++      fs.readdirSync(cardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile())
++        .forEach(dirent => cardPaths.add(path.join('cards', dirent.name)));
++    };
++    [themeCardsDir, 'cards'].forEach(dir => addCardsToSet(dir));
++    return Array.from(cardPaths);
+   }
+ 
+   /**
+@@ -112,14 +120,23 @@ class CardCreator {
+       throw new UserError(`A folder with name ${cardFolderName} already exists`);
+     }
+ 
+-    const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
++    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
++    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
++    fs.copySync(originalCardFolder, newCardFolder);
++    this._renameCardComponent(cardFolderName, newCardFolder);
++  }
++
++  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
+     if (fs.existsSync(templateCardFolder)) {
+-      !fs.existsSync(this._customCardsDir) && this._createCustomCardsDir();
+-      fs.copySync(templateCardFolder, cardFolder);
+-      this._renameCardComponent(cardFolderName, cardFolder);
+-    } else {
+-      throw new UserError(`The folder ${templateCardFolder} does not exist`);
++      return templateCardFolder
++    } 
++    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
++    if (fs.existsSync(themeCardFolder)) {
++      return themeCardFolder;
+     }
++    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
+   }
+ 
+   _renameCardComponent(customCardName, cardFolder) {
+@@ -155,14 +172,5 @@ class CardCreator {
+       .replace(new RegExp(originalComponentName, 'g'), customCardName)
+       .replace(/cards[/_](.*)[/_]template/g, `cards/${customCardName}/template`);
+   }
+-
+-  /**
+-   * Creates the 'cards' directory in the Jambo repository and adds the newly 
+-   * created directory to the list of partials in the Jambo config.
+-   */
+-  _createCustomCardsDir() {
+-    fs.mkdirSync(this._customCardsDir);
+-    addToPartials(this._customCardsDir);
+-  }
+ }
+ module.exports = CardCreator;
+diff --git a/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js b/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
+index b4c0652..211f3af 100644
+--- a/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
++++ b/themes/answers-hitchhiker-theme/commands/directanswercardcreator.js
+@@ -1,5 +1,5 @@
+ const fs = require('fs-extra');
+-const { addToPartials } = require('./helpers/utils/jamboconfigutils');
++const { containsPartial, addToPartials } = require('./helpers/utils/jamboconfigutils');
+ const path = require('path');
+ const UserError = require('./helpers/errors/usererror');
+ const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
+@@ -73,10 +73,18 @@ class DirectAnswerCardCreator {
+     if (!defaultTheme || !themesDir) {
+       return [];
+     }
+-    const daCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
+-    return fs.readdirSync(daCardsDir, { withFileTypes: true })
+-      .filter(dirent => !dirent.isFile())
+-      .map(dirent => path.join(daCardsDir, dirent.name));
++    const themeCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
++    const cardPaths = new Set();
++    const addCardsToSet = cardsDir => {
++      if (!fs.existsSync(cardsDir)) {
++        return;
++      }
++      fs.readdirSync(cardsDir, { withFileTypes: true })
++        .filter(dirent => !dirent.isFile())
++        .forEach(dirent => cardPaths.add(path.join('directanswercards', dirent.name)));
++    };
++    [themeCardsDir, 'directanswercards'].forEach(dir => addCardsToSet(dir));
++    return Array.from(cardPaths);
+   }
+ 
+   /**
+@@ -112,14 +120,23 @@ class DirectAnswerCardCreator {
+       throw new UserError(`A folder with name ${cardFolderName} already exists`);
+     }
+ 
+-    const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const newCardFolder = `${this._customCardsDir}/${cardFolderName}`;
++    const originalCardFolder = this._getOriginalCardFolder(defaultTheme, templateCardFolder);
++    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
++    !containsPartial(this._customCardsDir) && addToPartials(this._customCardsDir);
++    fs.copySync(originalCardFolder, newCardFolder);
++    this._renameCardComponent(cardFolderName, newCardFolder);
++  }
++
++  _getOriginalCardFolder(defaultTheme, templateCardFolder) {
+     if (fs.existsSync(templateCardFolder)) {
+-      !fs.existsSync(this._customCardsDir) && this._createCustomCardsDir();
+-      fs.copySync(templateCardFolder, cardFolder);
+-      this._renameCardComponent(cardFolderName, cardFolder);
+-    } else {
+-      throw new UserError(`The folder ${templateCardFolder} does not exist`);
++      return templateCardFolder
++    } 
++    const themeCardFolder = path.join(this.config.dirs.themes, defaultTheme, templateCardFolder);
++    if (fs.existsSync(themeCardFolder)) {
++      return themeCardFolder;
+     }
++    throw new UserError(`The folder ${themeCardFolder} does not exist at the root or in the theme.`);
+   }
+ 
+   _renameCardComponent(customCardName, cardFolder) {
+@@ -159,15 +176,6 @@ class DirectAnswerCardCreator {
+         /directanswercards[/_](.*)[/_]template/g,
+         `directanswercards/${customCardName}/template`);
+   }
+-
+-  /**
+-   * Creates the 'directanswercards' directory in the Jambo repository and adds the newly 
+-   * created directory to the list of partials in the Jambo config.
+-   */
+-  _createCustomCardsDir() {
+-    fs.mkdirSync(this._customCardsDir);
+-    addToPartials(this._customCardsDir);
+-  }
+ }
+ 
+ module.exports = DirectAnswerCardCreator;
+diff --git a/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js b/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
+index 2047695..49c5469 100644
+--- a/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
++++ b/themes/answers-hitchhiker-theme/commands/helpers/utils/argumentmetadata.js
+@@ -4,7 +4,8 @@
+ const ArgumentType = {
+   STRING: 'string',
+   NUMBER: 'number',
+-  BOOLEAN: 'boolean'
++  BOOLEAN: 'boolean',
++  ARRAY: 'array'
+ }
+ Object.freeze(ArgumentType);
+ 
+@@ -13,11 +14,12 @@ Object.freeze(ArgumentType);
+  * the type of the argument's values, if it is required, and an optional default.
+  */
+ class ArgumentMetadata {
+-  constructor(type, description, isRequired, defaultValue) {
++  constructor(type, description, isRequired, defaultValue, itemType) {
+     this._type = type;
+     this._isRequired = isRequired;
+     this._defaultValue = defaultValue;
+     this._description = description;
++    this._itemType = itemType;
+   }
+ 
+   /**
+@@ -27,6 +29,13 @@ class ArgumentMetadata {
+     return this._type;
+   }
+ 
++  /**
++   * @returns {ArgumentType} The type of the elements of an array argument.
++   */
++  getItemType() {
++    return this._itemType;
++  }
++
+   /**
+    * @returns {string} The description of the argument.
+    */
+@@ -47,6 +56,5 @@ class ArgumentMetadata {
+   defaultValue() {
+     return this._defaultValue;
+   }
+-
+ }
+ module.exports = { ArgumentMetadata, ArgumentType };
+\ No newline at end of file
+diff --git a/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js b/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
+index 2e91f22..c356cba 100644
+--- a/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
++++ b/themes/answers-hitchhiker-theme/commands/helpers/utils/jamboconfigutils.js
+@@ -52,4 +52,18 @@ exports.addToPartials = function (partialsPath) {
+     existingPartials.push(partialsPath);
+     fs.writeFileSync('jambo.json', stringify(jamboConfig, null, 2));
+   }
+-}
+\ No newline at end of file
++}
++
++/**
++ * Returns whether or not the partialsPath exists in the partials object in the
++ * Jambo config
++ *
++ * @param {Object} jamboConfig The parsed jambo config
++ * @param {string} partialsPath The local path to the set of partials. 
++ * @returns {boolean}
++ */
++exports.containsPartial = function (jamboConfig, partialsPath) {
++  return jamboConfig.dirs
++    && jamboConfig.dirs.partials
++    && jamboConfig.dirs.partials.includes(partialsPath);
++}
+-- 
+2.30.2
+


### PR DESCRIPTION
Add patches which update sites with older theme versions to have the same commands as v1.20

These patches allow developers to use CBD with older theme versions, and they are not necessary if a site is on theme v1.20. These patches are the updated versions of the patches from #590

This PR contains 3 patches:
- A patch for 1.15 and earlier
- A patch for 1.16
- A patch for themes 1.17 through 1.19

After applying the patch, the files must be committed, and then the CBD session need to be restarted

To use these patches, click on the branch name of this PR, open a desired patch file from inside the patches folder, click 'Raw', and copy the URL. In SGS CBD, supply that URL for the diff to apply.

J=SLAP-1013
TEST=manual

Open a site in SGS CBD on theme 1.15 and test these patches using the 'Apply Diff' functionality. Also test on a 1.16 site and on a 1.19 site.