### PR TITLE
vertical-full-page-map: Fix styling for iFrame experience

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -63,6 +63,8 @@ $container-width: 1000px;
   --yxt-maps-desktop-results-container-width: 410px;
   --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
+  --yxt-maps-desktop-height: 950px;
+  --yxt-maps-mobile-height: 620px;
 }
 
 // breakpoint variables for use in media queries within the theme styling

--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -63,7 +63,7 @@ $container-width: 1000px;
   --yxt-maps-desktop-results-container-width: 410px;
   --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
-  --yxt-maps-desktop-height: 870px;
+  --yxt-maps-desktop-height: 820px;
   --yxt-maps-mobile-height: 620px;
 }
 

--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -63,7 +63,7 @@ $container-width: 1000px;
   --yxt-maps-desktop-results-container-width: 410px;
   --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
-  --yxt-maps-desktop-height: 950px;
+  --yxt-maps-desktop-height: 870px;
   --yxt-maps-mobile-height: 620px;
 }
 

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -62,7 +62,7 @@ $container-width: 1000px;
   --yxt-maps-desktop-results-container-width: 410px;
   --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
-  --yxt-maps-desktop-height: 870px;
+  --yxt-maps-desktop-height: 820px;
   --yxt-maps-mobile-height: 620px;
 }
 

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -62,6 +62,8 @@ $container-width: 1000px;
   --yxt-maps-desktop-results-container-width: 410px;
   --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
+  --yxt-maps-desktop-height: 950px;
+  --yxt-maps-mobile-height: 620px;
 }
 
 // breakpoint variables for use in media queries within the theme styling

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -62,7 +62,7 @@ $container-width: 1000px;
   --yxt-maps-desktop-results-container-width: 410px;
   --yxt-maps-mobile-results-header-height: 185px;
   --yxt-maps-mobile-results-footer-height: 97px;
-  --yxt-maps-desktop-height: 950px;
+  --yxt-maps-desktop-height: 870px;
   --yxt-maps-mobile-height: 620px;
 }
 

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -19,7 +19,11 @@
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
-  height: 100vh;
+  height: var(--yxt-maps-mobile-height);
+
+  @include bpgte($desktop-break-point-min) {
+    height: var(--yxt-maps-desktop-height);
+  }
 
   .Answers 
   {
@@ -44,7 +48,6 @@
       @include bplte($mobile-break-point-max)
       {
         flex-direction: column-reverse;
-        min-height: 100vh;
       }
     }
 
@@ -88,7 +91,6 @@
         pointer-events: none;
         position: static;
         height: 100%;
-        min-height: 100vh;
       }
     }
 
@@ -99,6 +101,7 @@
       flex-grow: 1;
       background-color: white;
       padding: 0;
+      overflow-y: scroll;
 
       @include bpgte($desktop-break-point-min) {
         display: flex;
@@ -202,7 +205,7 @@
     &-mobileToggles
     {
       display: none;
-      position: fixed;
+      position: absolute;
       bottom: 72px;
       right: 16px;
       z-index: 4;
@@ -423,10 +426,6 @@
   // TODO make this the default
   &.VerticalFullPageMap--listShown
   {
-    @include bplte($mobile-break-point-max) {
-      height: 100%;
-    }
-
     .Answers
     {
       &-resultsWrapper
@@ -649,6 +648,8 @@
 }
 
 .YxtPage-wrapper--mapShown {
+  min-height: var(--yxt-maps-mobile-height);
+
   .YxtPage-content {
     position: fixed;
     top: 0;

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -410,8 +410,7 @@
     }
 
     &-resultsHeader {
-      display: flex;
-      flex-direction: column;
+      display: block;
       padding-left: 0;
 
       @include bplte($mobile-break-point-max) {


### PR DESCRIPTION
Previously, the map would resize indefinitely when iframed. This is
because the library we use, the iFrame resizer, listens for changes to
the height of the content in the child frame. In turn, the child frame
is listening for changes to the height in its frame. This is because we
are relying on 100vh heights for the map to give a full screen effect.

This is a know bug (below) with the iframe resizing library that is used
with all of our current iframe experiences.

iframe-resizer/issues/ 692

In order to fix this, we set an explicit height for the maps on mobile
and desktop. This allows the content to not rely on its viewport height.
We set the heights to defaults that look good across many mobile
browsers and desktop browsers.

An important part in the height decision was being able to see the
Location Bias right away when you landed on a page with results.

NOTE: As a result of this, we had to change our result list from being
very long on mobile to being inner scrolled. This has a UI effect of two
scroll bars.

NOTE: Because we are optimizing for iframes, you will notice that the
mobile toggle will be a bit higher on the mobile list view than the
mobile map view in the non-iframed experience. This is so that the
height issues for map are resolved. The mobile toggle is not this way
on an iFramed experience. If you want the normal experience to have
better spaced mobile toggles, use 100vh as your mobile maps height.

J=SLAP-1201
TEST=manual

Create a ./iframe_test.html with the correct iframe div and a script tag
referencing a local iframe.js

Make sure there are JAMBO_INJECTED_DATA in your env variables set
to use localhost as a staging domain. This makes it so the iframe shows
a local iFrame.

Test on Samsung s21 / Pixel 4 / Pixel 5 Chrome
Test on iPhone 12 / iPhone 8 Plus / iPad Safari, Chrome
Test on IE11, Chrome, Firefox Desktop

That interactions still work, the difference on an iframe is that the height
is set and not necessarily the entire height of the device.