### PR TITLE
Fix behavior when clicking away from detail cards

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -111,6 +111,12 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
      * @type {SearchDebouncer}
      */
     this.searchDebouncer = new SearchDebouncer();
+
+    /**
+     * The detail card which apears on mobile after clicking a pin
+     * @type {Element}
+     */
+    this._detailCard = null;
   }
 
   onCreate () {
@@ -313,6 +319,8 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       el.classList.remove('yxt-Card--pinFocused');
     });
 
+    this._detailCard && this._detailCard.remove();
+
     this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, null);
   }
 
@@ -338,27 +346,24 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').forEach((el) => el.remove());
       const isDetailCardOpened = document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').length;
 
-      const cardCopy = card.cloneNode(true);
-      cardCopy.classList.add('yxt-Card--isVisibleOnMobileMap');
-      this._container.appendChild(cardCopy);
+      this._detailCard = card.cloneNode(true);
+      this._detailCard.classList.add('yxt-Card--isVisibleOnMobileMap');
+      this._container.appendChild(this._detailCard);
 
       if (!isDetailCardOpened) {
         window.requestAnimationFrame(function(){
-          cardCopy.style = 'height: 0;';
+          this._detailCard.style = 'height: 0;';
           window.requestAnimationFrame(function(){
-            cardCopy.style = '';
+            this._detailCard.style = '';
           });
         });
       }
 
       const buttonSelector = '.js-HitchhikerLocationCard-closeCardButton';
 
-      cardCopy.querySelectorAll(buttonSelector).forEach((el) => {
+      this._detailCard.querySelectorAll(buttonSelector).forEach((el) => {
         el.addEventListener('click', () => {
-          card.classList.remove('yxt-Card--pinFocused');
-          cardCopy.remove();
-          this._container.classList.remove('VerticalFullPageMap--detailShown');
-          this._pageWrapperEl.classList.remove('YxtPage-wrapper--detailShown');
+          this.removeResultFocusedStates();
         });
       });
 

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -351,9 +351,9 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       this._container.appendChild(this._detailCard);
 
       if (!isDetailCardOpened) {
-        window.requestAnimationFrame(function(){
+        window.requestAnimationFrame(() => {
           this._detailCard.style = 'height: 0;';
-          window.requestAnimationFrame(function(){
+          window.requestAnimationFrame(() => {
             this._detailCard.style = '';
           });
         });

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -222,7 +222,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       zoomChangedListener: zoomChangedListener,
       zoomEndListener: zoomEndListener,
       panHandler: panHandler,
-      canvasClickListener: () => this.removeResultFocusedStates()
+      canvasClickListener: () => this.deselectAllResults()
     }));
   }
 
@@ -309,9 +309,10 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
   }
 
   /**
-   * Remove the result focused state styling from all cards and pins on the page
+   * Deselect all results by updating CSS classes, removing the detail card if present, and
+   * updating global storage.
    */
-  removeResultFocusedStates () {
+  deselectAllResults () {
     this._container.classList.remove('VerticalFullPageMap--detailShown');
     this._pageWrapperEl.classList.remove('YxtPage-wrapper--detailShown');
 
@@ -363,7 +364,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
       this._detailCard.querySelectorAll(buttonSelector).forEach((el) => {
         el.addEventListener('click', () => {
-          this.removeResultFocusedStates();
+          this.deselectAllResults();
         });
       });
 


### PR DESCRIPTION
Fixes the problem that occurs when a users clicks away from a mobile detail card

Previously, the behavior when a user closed a detail card by clicking on the map and by clicking the close card button. This PR updates the behavior so that both methods of closing the detail card results in the same behavior. This fixes the bug where the detail card would be present below the results when the users switches back to list view

J=SLAP-1205
TEST=manual

Verify that the bug is no longer present. Test that closing a card by clicking on the map and by clicking on the 'x' button results in the same behavior.