### PR TITLE
vertical-full-page-map: Add `alternativeVerticalsConfig` passthrough

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -117,6 +117,15 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
      * @type {Element}
      */
     this._detailCard = null;
+
+    /**
+     * The passthrough config for the Alternative Verticals component
+     * NOTE This component is added as a child to this component because Alternative Verticals
+     * in the SDK is not designed to be a standalone component. In this layout, it cannot be
+     * a child of the Vertical Results in order to show on the map view.
+     * @type {Object}
+     */
+    this.alternativeVerticalsConfig = config.alternativeVerticalsConfig;
   }
 
   onCreate () {
@@ -490,16 +499,31 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
     if (this._isNoResults) {
       const altVerticalsData = this.core.storage.get(StorageKeys.ALTERNATIVE_VERTICALS);
+      console.log(
+        Object.assign({},
+          {
+            container: '.js-answersNoResults',
+            verticalsConfig: this.verticalsConfig,
+            baseUniversalUrl: this.getBaseUniversalUrl(),
+            isShowingResults: this.displayAllResultsOnNoResults && this._data.results,
+            name: 'AlternativeVerticals--resultsHeader'
+          },
+          this.alternativeVerticalsConfig
+        )
+      );
       this.addChild(
         altVerticalsData,
-        'AlternativeVerticals',
-        {
-          container: '.js-answersNoResults',
-          verticalsConfig: this.verticalsConfig,
-          baseUniversalUrl: this.getBaseUniversalUrl(),
-          isShowingResults: this.displayAllResultsOnNoResults && this._data.results,
-          name: 'AlternativeVerticals--resultsHeader',
-        }
+        'AlternativeVerticals', 
+        Object.assign({},
+          {
+            container: '.js-answersNoResults',
+            verticalsConfig: this.verticalsConfig,
+            baseUniversalUrl: this.getBaseUniversalUrl(),
+            isShowingResults: this.displayAllResultsOnNoResults && this._data.results,
+            name: 'AlternativeVerticals--resultsHeader'
+          },
+          this.alternativeVerticalsConfig
+        )
       );
     }
 

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -122,7 +122,8 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
      * The passthrough config for the Alternative Verticals component
      * NOTE This component is added as a child to this component because Alternative Verticals
      * in the SDK is not designed to be a standalone component. In this layout, it cannot be
-     * a child of the Vertical Results in order to show on the map view.
+     * a child of the Vertical Results because we want it to show on the map view. So we make it
+     * a child of the larger component.
      * @type {Object}
      */
     this.alternativeVerticalsConfig = config.alternativeVerticalsConfig;
@@ -499,18 +500,6 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
     if (this._isNoResults) {
       const altVerticalsData = this.core.storage.get(StorageKeys.ALTERNATIVE_VERTICALS);
-      console.log(
-        Object.assign({},
-          {
-            container: '.js-answersNoResults',
-            verticalsConfig: this.verticalsConfig,
-            baseUniversalUrl: this.getBaseUniversalUrl(),
-            isShowingResults: this.displayAllResultsOnNoResults && this._data.results,
-            name: 'AlternativeVerticals--resultsHeader'
-          },
-          this.alternativeVerticalsConfig
-        )
-      );
       this.addChild(
         altVerticalsData,
         'AlternativeVerticals', 

--- a/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
+++ b/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
@@ -1,0 +1,8 @@
+<div class="yxt-AlternativeVerticals{{#unless isShowingResults}} yxt-AlternativeVerticals--notShowingResults{{/unless}}">
+  <div class="yxt-AlternativeVerticals-noResultsInfo">
+    {{translate phrase='<em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">No results found</em> in [[currentVerticalLabel]].' currentVerticalLabel=currentVerticalLabel }}
+    {{#if isShowingResults}}
+      {{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel }}
+    {{/if}}
+  </div>
+</div>

--- a/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
+++ b/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
@@ -5,4 +5,48 @@
       {{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel escapeHTML=false}}
     {{/if}}
   </div>
+  {{#if (all verticalSuggestions query)}}
+    <div class="yxt-AlternativeVerticals-suggestionsWrapper">
+      <div class="yxt-AlternativeVerticals-details">
+        {{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' count=verticalSuggestions.length query=query escapeHTML=false}}
+      </div>
+      <ul class="yxt-AlternativeVerticals-suggestionsList">
+        {{#each verticalSuggestions}}
+          <li class="yxt-AlternativeVerticals-suggestion">
+            <a class="yxt-AlternativeVerticals-suggestionLink"
+                href="{{url}}">
+              {{#if hasIcon}}
+                <div class="yxt-AlternativeVerticals-verticalIconWrapper"
+                      data-component="IconComponent"
+                      data-opts='{
+                        "iconName": "{{iconName}}",
+                        "iconUrl": "{{iconUrl}}"
+                      }'>
+                </div>
+              {{/if}}
+              <div class="yxt-AlternativeVerticals-suggestionLink--copy">
+                <span class="yxt-AlternativeVerticals-suggestionLink--copyLabel">
+                  {{label}}
+                </span>
+                <span class="yxt-AlternativeVerticals-suggestionLink--copyResults">
+                  {{translate phrase='([[resultsCount]] result)' pluralForm='([[resultsCount]] results)' count=resultsCount resultsCount=resultsCount escapeHTML=false }}
+                </span>
+              </div>
+              <div class="yxt-AlternativeVerticals-arrowIconWrapper"
+                    data-component="IconComponent"
+                    data-opts='{
+                      "iconName": "chevron"
+                    }'>
+              </div>
+            </a>
+          </li>
+        {{/each}}
+      </ul>
+      {{#if universalUrl}}
+        <div class="yxt-AlternativeVerticals-universalDetails">
+          {{translate phrase='Alternatively, you can <a class="yxt-AlternativeVerticals-universalLink" href="[[universalUrl]]"> view results across all search categories</a>.' universalUrl=universalUrl escapeHTML=false}}
+        </div>
+      {{/if}}
+    </div>
+  {{/if}}
 </div>

--- a/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
+++ b/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
@@ -1,8 +1,8 @@
 <div class="yxt-AlternativeVerticals{{#unless isShowingResults}} yxt-AlternativeVerticals--notShowingResults{{/unless}}">
   <div class="yxt-AlternativeVerticals-noResultsInfo">
-    {{translate phrase='<em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">No results found</em> in [[currentVerticalLabel]].' currentVerticalLabel=currentVerticalLabel }}
+    {{translate phrase='<em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">No results found</em> in [[currentVerticalLabel]].' currentVerticalLabel=currentVerticalLabel escapeHTML=false}}
     {{#if isShowingResults}}
-      {{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel }}
+      {{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel escapeHTML=false}}
     {{/if}}
   </div>
 </div>

--- a/theme-components/vertical-full-page-map/script.js
+++ b/theme-components/vertical-full-page-map/script.js
@@ -51,7 +51,7 @@ ANSWERS.addComponent('VerticalFullPageMapOrchestrator', Object.assign({},
   ],
   alternativeVerticalsConfig: Object.assign({},
     {
-      template: `{{> theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals}}`
+      template: {{{ stringifyPartial (read 'theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals') }}}
     },
     {{{ json componentSettings.AlternativeVerticals }}},
   ),

--- a/theme-components/vertical-full-page-map/script.js
+++ b/theme-components/vertical-full-page-map/script.js
@@ -49,6 +49,12 @@ ANSWERS.addComponent('VerticalFullPageMapOrchestrator', Object.assign({},
       {{/if}}
     {{/each}}
   ],
+  alternativeVerticalsConfig: Object.assign({},
+    {
+      template: `{{> theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals}}`
+    },
+    {{{ json componentSettings.AlternativeVerticals }}},
+  ),
   searchbarConfig: Object.assign({}, 
     {
       container: ".js-answersSearch",

--- a/theme-components/vertical-full-page-map/script.js
+++ b/theme-components/vertical-full-page-map/script.js
@@ -55,15 +55,6 @@ ANSWERS.addComponent('VerticalFullPageMapOrchestrator', Object.assign({},
     },
     {{{ json componentSettings.AlternativeVerticals }}},
   ),
-  searchbarConfig: Object.assign({}, 
-    {
-      container: ".js-answersSearch",
-      {{#if verticalKey}}
-        verticalKey: "{{{verticalKey}}}",
-      {{/if}}
-    },
-    {{{ json componentSettings.SearchBar }}},
-  ),
 },
   {{#with (lookup verticalsToConfig verticalKey)}}
     {{#if mapConfig}}

--- a/translations/de.po
+++ b/translations/de.po
@@ -161,3 +161,19 @@ msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Keine E
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
 msgstr "Stattdessen werden <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alle [[currentVerticalLabel]]</em> gezeigt."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "Die folgenden Kategorie liefert Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Die folgenden Kategorien liefern Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "[[resultsCount]] Ergebnis"
+msgstr[1] "[[resultsCount]] Ergebnisse"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Sehen Sie alternativ <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> Ergebnisse aus allen Kategorien</a>."

--- a/translations/de.po
+++ b/translations/de.po
@@ -153,3 +153,11 @@ msgstr "Plan"
 #: templates/vertical-interactive-map/page.html.hbs:59
 msgid "Map controls"
 msgstr "Kartensteuerungselemente"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Keine Ergebnisse gefunden</em> in [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Stattdessen werden <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alle [[currentVerticalLabel]]</em> gezeigt."

--- a/translations/es.po
+++ b/translations/es.po
@@ -153,3 +153,11 @@ msgstr "Mapa"
 #: templates/vertical-interactive-map/page.html.hbs:59
 msgid "Map controls"
 msgstr "Controles del mapa"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Ningún resultado disponible</em> en [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Mostrando <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> en vez que [[currentVerticalLabel]]</em>."

--- a/translations/es.po
+++ b/translations/es.po
@@ -161,3 +161,19 @@ msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Ningún
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
 msgstr "Mostrando <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> en vez que [[currentVerticalLabel]]</em>."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La siguiente búsqueda ha generado categoría resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La siguiente búsqueda ha generado categorias resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "[[resultsCount]] resultado"
+msgstr[1] "[[resultsCount]] resultados"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "En su defecto, puede <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> ver los resultados para todas las categorías de búsqueda</a>."

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -153,3 +153,11 @@ msgstr "Carte"
 #: templates/vertical-interactive-map/page.html.hbs:59
 msgid "Map controls"
 msgstr "Commandes de carte"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Aucun resultat</em> in [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Voici <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> tous/toutes les [[currentVerticalLabel]]</em> à la place."

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -161,3 +161,19 @@ msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Aucun r
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
 msgstr "Voici <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> tous/toutes les [[currentVerticalLabel]]</em> à la place."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La catégorie de recherche suivante a produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Les catégories de recherche suivantes ont produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "([[resultsCount]] résultat)"
+msgstr[1] "([[resultsCount]] résultats)"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Autrement, vous pouvez <a class=\"yxt-AlternativeVerticals-universalLink\" href=[[universalUrl]]> voir les résultats à travers toutes les catégories</a>."

--- a/translations/it.po
+++ b/translations/it.po
@@ -153,3 +153,11 @@ msgstr "Mappa"
 #: templates/vertical-interactive-map/page.html.hbs:59
 msgid "Map controls"
 msgstr "Controlli mappa"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Non ci sono risultati disponibili</em> in [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Altrimenti, può <a class=\"yxt-AlternativeVerticals-universalLink\" href=[[universalUrl]]> vedere i risultati su tutte le categorie di ricerca</a>."

--- a/translations/it.po
+++ b/translations/it.po
@@ -161,3 +161,19 @@ msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Non ci 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
 msgstr "Altrimenti, può <a class=\"yxt-AlternativeVerticals-universalLink\" href=[[universalUrl]]> vedere i risultati su tutte le categorie di ricerca</a>."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La categoria di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La categorie di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "[[resultsCount]] risultato"
+msgstr[1] "[[resultsCount]] risultati"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Altrimenti, può <a class=\"yxt-AlternativeVerticals-universalLink\" href=[[universalUrl]]> vedere i risultati su tutte le categorie di ricerca</a>."

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -152,3 +152,11 @@ msgstr "マップ"
 #: templates/vertical-interactive-map/page.html.hbs:59
 msgid "Map controls"
 msgstr "マップコントロール"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "[[currentVerticalLabel]] で<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">結果は見つかりませんでした</em>。"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "代わりに<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">すべての[[currentVerticalLabel]]</em>を表示しています。"

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -160,3 +160,17 @@ msgstr "[[currentVerticalLabel]] で<em class=\"yxt-AlternativeVerticals-noResul
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
 msgstr "代わりに<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">すべての[[currentVerticalLabel]]</em>を表示しています。"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>の検索結果が見つかりました。"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "（[[resultsCount]]件の結果）"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "代わりに<a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">すべての検索カテゴリーの結果を表示することもできます</a>。"


### PR DESCRIPTION
Previously, the recommended other alternative verticals would show as a
suggestion, even if the query was an empty string. We have opted not to
show the vertical suggestions at all.

However, this is not toggle-able by the component in the SDK. In order
to remove that HTML, we must override the template to hide the HTML.

In order to pass a translated hbs file to the Alternative Verticals child of
the Vertical Full Page Map, we add an alternative verticals config
option to the Vertical Full Page Map component. This is better than just
a specific alternative verticals template config option.

We copy the `alternativeverticals.hbs` directly from the Answers Search
UI SDK except we add an exception for no-query suggested verticals. We
also escapeHTML all the translated files and copy the translations directly
from the Answers Search UI SDK .po files.

Note: An unused config option `searchbarConfig` was replaced with
this `alternativeVerticalsConfig` option.

J=SLAP-1203
TEST=manual

Test that when you get to a no results state on the new map, you will
not see alternative verticals show for any query.

Test that on the benchmark account, if you zoom into a search this
area search with no results (and no query) you do not get alternative
verticals. However, if you type e.g. `wallet`, you will get suggested
verticals to `products` (given you added the products vertical).