### PR TITLE
show/hide "search this area" when map move checkbox is toggled

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -128,6 +128,11 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     searchThisAreaToggleEls.forEach((el) => {
       el.addEventListener('click', (e) => {
         this.searchOnMapMove = e.target.checked;
+        if (this.searchOnMapMove) {
+          this._container.classList.remove('VerticalFullPageMap--showSearchThisArea');
+        } else {
+          this._container.classList.add('VerticalFullPageMap--showSearchThisArea');
+        }
       });
     });
 


### PR DESCRIPTION
This commit shows or hides the "search this area" button when the
"search on map move" checkbox is checked or unchecked. A future
enhancement would be to only display the "search this area" button
if the current search results do not reflect the current area.

J=SLAP-1212
TEST=manual

test that when I check/uncheck the checkbox, the search this area button
appears and disappears