### PR TITLE
display "search this area" button for no results

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -513,7 +513,7 @@
   }
 
   // TODO move to js
-  &.VerticalFullPageMap--showSearchThisArea:not(.VerticalFullPageMap--noResults) {
+  &.VerticalFullPageMap--showSearchThisArea {
     .Answers-searchThisAreaWrapper {
       display: flex;
     }


### PR DESCRIPTION
This commit makes the "search this area" button visible for no results.
The button will still hide itself after clicking it, even if the resulting
search returns the no results state.

J=SLAP-1223
TEST=manual

test that I can click "search this area", get no results, then move
my map around and "search this area" will appear again