### PR TITLE
vertical-full-page-map: Fix panning map on initial results

### DIFF
--- a/static/js/theme-map/Renderer/MapRenderTarget.js
+++ b/static/js/theme-map/Renderer/MapRenderTarget.js
@@ -90,10 +90,8 @@ class MapRenderTarget extends RenderTarget {
     const pins = Object.values(this._pins);
     const coordinates = pins.map(pin => pin.getCoordinate());
 
-    if (coordinates.length) {
-      if (data.updateZoom) {
-        this._map.fitCoordinates(coordinates);
-      }
+    if (coordinates.length && data.fitCoordinates) {
+      this._map.fitCoordinates(coordinates);
     }
 
     if (this._pinClusterer) {

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -407,17 +407,17 @@ class ThemeMap extends ANSWERS.Component {
       ); 
     }
 
-    let updateZoom = numConcurrentSearchThisAreaCalls <= 0;
+    let fitCoordinates = numConcurrentSearchThisAreaCalls <= 0;
 
     const isNoResults = data.resultsContext === 'no-results';
     if (isNoResults && !this.config.displayAllResultsOnNoResults) {
       entityData = [];
-      updateZoom = false;
+      fitCoordinates = false;
     }
 
     const renderData = {
       response: { entities: entityData },
-      updateZoom: updateZoom
+      fitCoordinates: fitCoordinates
     };
 
     if (this.renderReady) {

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -398,7 +398,7 @@ class ThemeMap extends ANSWERS.Component {
     let entityData = verticalData.length ? verticalData : universalData;
 
     const numConcurrentSearchThisAreaCalls = 
-      this.core.storage.get(StorageKeys.LOCATOR_NUM_CONCURRENT_SEARCH_THIS_AREA_CALLS);
+      this.core.storage.get(StorageKeys.LOCATOR_NUM_CONCURRENT_SEARCH_THIS_AREA_CALLS) || 0;
 
     if (numConcurrentSearchThisAreaCalls > 0) {
       this.core.storage.set(


### PR DESCRIPTION
Previously, on the initial search of the map, the results would not show
on the map if there was a populated search on load. This is because the
num concurrent search this area calls storage key wouldn't exist and
would give `undefined` instead of `0`. We set a default for when the key
doesn't exist so we can check a number range.

This suggests we should re-name `updateZoom` to `fitCoordinates` as with
this bug, we were seeing both the coordinates not fit and the zoom not
changing.

J=None
TEST=manual

Test that you can see the results on a refresh of the site with a query
or a default initial search of ''.

Test that coordinates are not fit when you Search This Area or zoom
into a cluster.