### PR TITLE
update "search this area" button to be visible in no results

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -245,13 +245,14 @@
     }
 
     &-centerTop {
-      position: absolute;
+      display: flex;
+      margin-top: 11px;
       color: black;
-      top: calc(var(--yxt-maps-mobile-results-header-height) + 8px);
-      left: 50%;
       z-index: 1;
 
       @include bpgte($desktop-break-point-min) {
+        position: fixed;
+        margin-top: 0;
         top: 16px;
         left: calc(50% + calc(var(--yxt-maps-desktop-results-container-width) / 2));
       }
@@ -260,12 +261,18 @@
     &-searchThisAreaWrapper {
       display: none;
       position: relative;
-      left: -50%;
       background-color: var(--yxt-maps-search-this-area-background-color);
       color: var(--yxt-maps-search-this-area-text-color);
+      margin-left: auto;
+      margin-right: auto;
       padding: 10px 16px;
       border-radius: var(--yxt-border-radius);
       box-shadow: 1px 1px 2px rgba(0,0,0,0.25);
+      pointer-events: all;
+
+      @include bpgte($desktop-break-point-min) {
+        left: -50%;
+      }
     }
 
     &-searchThisAreaWrapper:focus-within {
@@ -444,6 +451,13 @@
       &-viewListText
       {
         display: none;
+      }
+
+      &-centerTop
+      {
+        @include bplte($mobile-break-point-max) {
+          display: none;
+        }
       }
     }
   }

--- a/templates/vertical-full-page-map/page.html.hbs
+++ b/templates/vertical-full-page-map/page.html.hbs
@@ -57,15 +57,15 @@
               </div>
             </div>
           </div>
+          <div class="Answers-centerTop">
+            {{> templates/vertical-full-page-map/markup/searchthisareabutton }}
+          </div>
           <div class="Answers-stickyBottom" role="region" aria-label="{{ translate phrase="Map controls" }}">
             {{> templates/vertical-full-page-map/markup/searchthisareatoggle modifier="desktop"}}
             {{> templates/vertical-full-page-map/markup/locationbias modifier="main"}}
           </div>
         </div>
         <div class="Answers-mapWrapper" role="region" aria-label="{{ translate phrase="Map" }}">
-          <div class="Answers-centerTop">
-            {{> templates/vertical-full-page-map/markup/searchthisareabutton }}
-          </div>
           {{> templates/vertical-full-page-map/markup/map }}
           <div class="Answers-mapFooter">
               {{> templates/vertical-full-page-map/markup/searchthisareatoggle modifier="mobileMap"}}


### PR DESCRIPTION
This commit makes the "search this area" button visible
during the no results state. Before this commit, the no
results block would cover up "search this area".

This was done by moving "search this area" directly
below Answers-resultsWrapper in the html.
In order for this to work, the css for "search this area"
was changed to use static positioning on mobile.

getBoundingClientRect() was used to calculate the new
margin-top for Answers-centerTop

J=SLAP-1225
TEST=manual

open up a side by side of a maps page before and after this commit
see that on mobile and desktop, the "search this area" button is in
the same position
see that I can swap back and forth between list and map view on mobile
see that in the no results state, the "search this area" button is directly
below the no results block, instead of being covered up by it