### PR TITLE
updating map-pin.hbs to use new pin fallbacks

### DIFF
--- a/templates/universal-standard/script/map-pin.hbs
+++ b/templates/universal-standard/script/map-pin.hbs
@@ -3,9 +3,9 @@
     label: marker.label.toString() || '',
     height: {{#if pin.height}}{{pin.height}}{{else}}26{{/if}},
     width: {{#if pin.width}}{{pin.width}}{{else}}22{{/if}},
-    backgroundColor: '{{#if pin.backgroundColor}}{{pin.backgroundColor}}{{else}}#5387d7{{/if}}',
-    labelColor: '{{#if pin.labelColor}}{{pin.labelColor}}{{else}}white{{/if}}',
-    strokeColor: '{{#if pin.strokeColor}}{{pin.strokeColor}}{{else}}black{{/if}}',
+    backgroundColor: '{{#if pin.backgroundColor}}{{pin.backgroundColor}}{{else if pin.default.backgroundColor}}{{pin.default.backgroundColor}}{{else}}#5387d7{{/if}}',
+    labelColor: '{{#if pin.labelColor}}{{pin.labelColor}}{{else if pin.default.labelColor}}{{pin.default.labelColor}}{{else}}white{{/if}}',
+    strokeColor: '{{#if pin.strokeColor}}{{pin.strokeColor}}{{else if pin.default.strokeColor}}{{pin.default.strokeColor}}{{else}}black{{/if}}',
   }
 
   const svg =


### PR DESCRIPTION
If someone is using the new maps, the pin on universal should fallback to the default pin on vertical. 

TEST: manual, using the theme test site, verified that both of these set the universal pin color as expected:

```json
"pin": {
          "backgroundColor": "purple", // Enter a hex value or color for the pin background
          "strokeColor": "#2a446b",
          "labelColor": "white",
          "default": { // The pin in its normal state
            "backgroundColor": "#5387d7", // Enter a hex value or color for the pin background
            "strokeColor": "#2a446b",
            "labelColor": "white"
          },
//etc
        }
```


```json
"pin": {
          "backgroundColor": "purple", // Enter a hex value or color for the pin background
          "strokeColor": "#2a446b",
          "labelColor": "white"
//etc
        }
```
