### PR TITLE
hide map properly going from map view -> filters on mobile

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -464,7 +464,7 @@
 
   &.VerticalFullPageMap--mapShown
   {
-    .Answers-map {
+    &:not(.CollapsibleFilters--expanded) .Answers-map {
       top: var(--yxt-maps-mobile-results-header-height);
     }
 


### PR DESCRIPTION
This commit fixes an issue where, when in the map view on mobile,
if you click "filter results" some of the map still sticks out
from the bottom

J=SLAP-1233
TEST=manual

test that the map no longer sticks out going from map -> filters view
test toggling between map and list view and filters view