### PR TITLE
dont duplicate vertical-full-page-map page-setup

### DIFF
--- a/templates/vertical-full-page-map/page-setup.js
+++ b/templates/vertical-full-page-map/page-setup.js
@@ -1,11 +1,11 @@
-if (window.locatorBundleLoaded) {
+function loadFullPageMap() {
   {{> theme-components/theme-map/script}}
   {{> theme-components/vertical-full-page-map/script}}
+}
+
+if (window.locatorBundleLoaded) {
+  loadFullPageMap();
 } else {
   const locatorBundleScript = document.querySelector('script#js-answersLocatorBundleScript');
-
-  locatorBundleScript.onload = function() {
-    {{> theme-components/theme-map/script}}
-    {{> theme-components/vertical-full-page-map/script}}
-  };
+  locatorBundleScript.onload = loadFullPageMap;
 }


### PR DESCRIPTION
This commit slightly reduces the amount of code
in the full page map's setup by reusing a function
instead of having two copies of the same js partials

J=none
TEST=manual

see that ANSWERS.registerTemplate("theme-components/theme-map only occurs
once in the final build's html, and that before this change it would be in the
html twice
smoke test the map