### PR TITLE
vertical-full-page-map: Fix Alternative Verts always showing on No Results

### DIFF
--- a/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
+++ b/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
@@ -5,7 +5,7 @@
       {{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel escapeHTML=false}}
     {{/if}}
   </div>
-  {{#if (all verticalSuggestions query)}}
+  {{#if (all verticalSuggestions.length query)}}
     <div class="yxt-AlternativeVerticals-suggestionsWrapper">
       <div class="yxt-AlternativeVerticals-details">
         {{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' count=verticalSuggestions.length query=query escapeHTML=false}}


### PR DESCRIPTION
Because the `all` hbs helper uses JavaScript falsy values, we need to
change how we look at the `verticalSuggestions` object. The effect of
this is that alternative verticals messaging would show when the
verticalSuggestions array is empty.

Instead, we pass the `all` helper `verticalSuggestions.length` which hbs
defaults to undefined if `verticalSuggestions` is undefined so we can be
sure the array always has a length.

J=None
TEST=manual

Test on an experience with vertical suggestions and without that you see
them correctly.

I tested with the query `wallet` for our test account and `askjdhaksjd`
to see alternative verticals messaging show in the former and not the
latter.