### PR TITLE
dynamically resize the map on no results

### DIFF
--- a/static/js/collapsible-filters/interactions.js
+++ b/static/js/collapsible-filters/interactions.js
@@ -214,8 +214,7 @@ export default class Interactions {
     if (!this._disableScrollToTopOnToggle) {
       this.scrollToTop();
     }
-    const filterLink = ANSWERS.components.getActiveComponent('FilterLink');
-    filterLink && filterLink.setState({
+    ANSWERS.components.getActiveComponent('FilterLink').setState({
       panelIsDisplayed: !shouldCollapseFilters
     });
   }

--- a/static/js/collapsible-filters/interactions.js
+++ b/static/js/collapsible-filters/interactions.js
@@ -214,7 +214,8 @@ export default class Interactions {
     if (!this._disableScrollToTopOnToggle) {
       this.scrollToTop();
     }
-    ANSWERS.components.getActiveComponent('FilterLink').setState({
+    const filterLink = ANSWERS.components.getActiveComponent('FilterLink');
+    filterLink && filterLink.setState({
       panelIsDisplayed: !shouldCollapseFilters
     });
   }

--- a/static/js/constants/results-context.js
+++ b/static/js/constants/results-context.js
@@ -1,0 +1,11 @@
+/**
+ * ResultsContext is an ENUM that provides context
+ * for the results that we are storing from server
+ * data
+ * @enum {string}
+ */
+const ResultsContext = {
+  NORMAL: 'normal',
+  NO_RESULTS: 'no-results'
+};
+export default ResultsContext;

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -12,6 +12,7 @@ import { MapboxMaps } from './Maps/Providers/Mapbox.js';
 
 import ThemeMapConfig from './ThemeMapConfig.js'
 import StorageKeys from '../constants/storage-keys.js';
+import ResultsContext from '../constants/results-context.js';
 
 /**
  * The component to create and control the functionality of a map,
@@ -409,7 +410,7 @@ class ThemeMap extends ANSWERS.Component {
 
     let fitCoordinates = numConcurrentSearchThisAreaCalls <= 0;
 
-    const isNoResults = data.resultsContext === 'no-results';
+    const isNoResults = data.resultsContext === ResultsContext.NO_RESULTS;
     if (isNoResults && !this.config.displayAllResultsOnNoResults) {
       entityData = [];
       fitCoordinates = false;

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -505,7 +505,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       return;
     }
     const noResults = this._noResultsContainer;
-    const map = document.querySelector(this._mapContainerSelector);
+    const map = this._container.querySelector(this._mapContainerSelector);
     if (!noResults || !map) {
       return;
     }

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -514,9 +514,10 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       const noResultsHeight = noResults.getBoundingClientRect().height;
       map.style.top =
         `calc(var(--yxt-maps-mobile-results-header-height) + ${noResultsHeight}px)`;
-      const headerFooterHeight = 
-        'var(--yxt-maps-mobile-results-header-height) - var(--yxt-maps-mobile-results-footer-height)';
-      map.style.height = `calc(100% - ${headerFooterHeight} - ${noResultsHeight}px)`;
+      map.style.height = 'calc(100%' +
+      ' - var(--yxt-maps-mobile-results-header-height)' + 
+      ' - var(--yxt-maps-mobile-results-footer-height) ' + 
+      ` - ${noResultsHeight}px)`;
     } else {
       map.style.top = '';
       map.style.height = '';

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -21,12 +21,13 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
     /**
      * The container in the DOM for the interactive map
-     * @type {HTMLElement}
+     * @type {string}
      */
     this._mapContainerSelector = '#js-answersMap';
 
     /**
      * The container in the DOM for the no results block.
+     * @type {HTMLElement}
      */
     this._noResultsContainer = document.querySelector('.js-answersNoResults');
 


### PR DESCRIPTION
This commit dynamically resizes the map when the no results
state appears/disappears. This is because the no results info
that pops up would otherwise cover up part of the map. This
would be a problem primarily if somebody had displayAllResults
set to true for the map, in which case a majority of the pins
would be blocked by alternative verticals suggestions.

J=SLAP-1237
TEST=manual

on no results, the map dynamically resizes
refreshing the page while on no results goes to the list
view, and the map is not visible
desktop looks correct for no results and regular results
"search this area" button is visible in no results