### PR TITLE
vertical-full-page-map: Support no results display all results

### DIFF
--- a/static/js/theme-map/ThemeMapConfig.js
+++ b/static/js/theme-map/ThemeMapConfig.js
@@ -142,13 +142,13 @@ export default class ThemeMapConfig {
      */
     this.enablePinClustering = jsonConfig.enablePinClustering;
 
-    const noResultsConfig = jsonConfig.noResults || {};
+    const noResultsConfig = jsonConfig.noResultsConfig || {};
 
     /**
      * Whether the map should display all results on no results
      * @type {boolean}
      */
-    this.displayAllResultsOnNoResults = noResultsConfig.displayAllResultsOnNoResults;
+    this.displayAllResultsOnNoResults = noResultsConfig.displayAllResults;
 
     /**
      * Callback for when a non-cluster pin is selected

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -92,13 +92,17 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
      */
     this.searchOnMapMove = !config.disableSearchOnMapMove;
 
-    const noResultsConfig = config.noResults || {};
+    /**
+     * The configuration for the no results state
+     * @type {Object}
+     */
+    this.noResultsConfig = config.noResults || {};
 
     /**
      * Whether the map should display all results on no results
      * @type {boolean}
      */
-    this.displayAllResultsOnNoResults = noResultsConfig.displayAllResults;
+    this.displayAllResultsOnNoResults = this.noResultsConfig.displayAllResults;
 
     /**
      * The mobile breakpoint (inclusive max) in px


### PR DESCRIPTION
Fix the ThemeMap and VerticalFullPageMapOrchestrator to support
`displayAllResults` in the noResults config of the map config. This
makes it so the toggle appears and the map updates to fit the
coordinates of the results.

J=SLAP-1232
TEST=manual

Test that when you have (below) in both the VerticalResults and
MapConfig noResults field, you will see the results display on a No
Results query (e.g. "askjdhakjsd"), the mobile view toggle will show and
the coordinates will fit on the map.
```
{
        "displayAllResults": true
}
```