### PR TITLE
vertical-full-page-map: Move default VerticalResults noResults

### DIFF
--- a/templates/vertical-full-page-map/page-config.json
+++ b/templates/vertical-full-page-map/page-config.json
@@ -35,8 +35,7 @@
     },
     "VerticalResults": {
       "noResults": {
-        "displayAllResults": false, // Optional, whether to display all results in the vertical when no results are found.
-        "template": "<span></span>"
+        "displayAllResults": false // Optional, whether to display all results in the vertical when no results are found.
       },
       "hideResultsHeader": true
     },

--- a/templates/vertical-full-page-map/script/verticalresults.hbs
+++ b/templates/vertical-full-page-map/script/verticalresults.hbs
@@ -50,7 +50,12 @@ ANSWERS.addComponent("VerticalResults", Object.assign({}, {
       {{#if cardType}}cardType: "{{{cardType}}}",{{/if}}
     },
   {{/with}}
-}, {{{ json componentSettings.VerticalResults }}}));
+}, {{{ json componentSettings.VerticalResults }}}, {
+  noResults: Object.assign({},
+    { template: "<span></span>" },
+    {{{ json componentSettings.VerticalResults.noResults }}}
+  )
+}));
 
 {{!--
   Prints the vertical label according to specific logic


### PR DESCRIPTION
We move from the page-config.json to the script.hbs. This was a request
from Product to not expose this default "hacky" behavior in the JSON.

For context: We must do this because the AlternativeVerticals cannot
live as a standalone component with the current SDK. We need AVs to show
on both the list view and the map view. Thus we make our outside of the
Vertical Results and empty the template for the Vertical Results.

NOTE: If you change the template in the JSON config, you will
effectively show two AVs on the page. This is a detail that Product is
going to show in documentation of how to edit No Results for the map
page.

J=None
TEST=manual

Test that the JSON config always supersedes the default noResults in
script.hbs.

Test that when noResults isn't in the JSON config, we default to the
empty template.

Test creating a new vertical and by default only one AV component shows.