### PR TITLE
Pass page wrapper CSS to vertical-full-page-map

### DIFF
--- a/templates/vertical-full-page-map/page.html.hbs
+++ b/templates/vertical-full-page-map/page.html.hbs
@@ -1,4 +1,4 @@
-{{#> layouts/html }}
+{{#> layouts/html pageWrapperCss="YxtPage-wrapper--mobileListView" }}
   {{#> script/core }}
     {{> cards/all }}
     {{!-- {{> templates/vertical-full-page-map/collapsible-filters/page-setup }} --}}


### PR DESCRIPTION
Pass the proper css class to the vertical-full-page-map

Set the pageWrapper CSS so that the mobile styling is set on page load

This was mean to be part of #703, however the change didn't make it in by accident. 

J=SLAP-1230
TEST=manual

Use this new template and smoke test. Confirm that the CSS class is set on page load for mobile. Confirm that is it removed on desktop.