### PR TITLE
Fix long titles on vertical full page map

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -562,9 +562,8 @@
     }
 
     &-closeCardButtonWrapper {
-      position: absolute;
-      right: 16px;
-      top: 16px;
+      position: relative;
+      top: 2px;
     }
 
     &-closeCardButton {

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -564,6 +564,7 @@
     &-closeCardButtonWrapper {
       position: relative;
       top: 2px;
+      margin-left: auto;
     }
 
     &-closeCardButton {

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -563,7 +563,7 @@
 
     &-closeCardButtonWrapper {
       position: relative;
-      top: 2px;
+      top: 1px;
       margin-left: auto;
     }
 


### PR DESCRIPTION
Fix a bug where long titles overflowed into the card distance and the close card button.

Using relative rather than absolute causes long texts to wrap rather than overflow into the location distance. I adjusted it by 1px so that the distance to the top of the card is the same as before the change.

On mobile detail view, this causes the card body to be pushed down slightly. I spoke with product and they were okay with the extra spacing.

J=none
TEST=manual

Test this on the turtle head tacos site were this was originally reported, and test this on the theme test site. Confirm that long titles wrap rather than overflow into the distance text. Test the location standard, professional location card, and the financial professional location cards.
