### PR TITLE
adding rich text conditional to doc-search card

### DIFF
--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -13,10 +13,16 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
    */
   dataForRender(type, answer, relatedItem, snippet) {
     const relatedItemData = relatedItem.data || {};
+    var snippetValue = "";
+    if (answer.fieldType == "rich_text" && snippet) {
+      snippetValue = ANSWERS.formatRichText(snippet);
+    } else if (snippet) {
+      snippetValue = Formatter.highlightField(snippet.value, snippet.matchedSubstrings);
+    }
 
     return {
       value: answer.value,
-      snippet: snippet && Formatter.highlightField(snippet.value, snippet.matchedSubstrings), // Text snippet to include alongside the answer
+      snippet: snippetValue, // Text snippet to include alongside the answer
       viewDetailsText: relatedItemData.fieldValues && relatedItemData.fieldValues.name, // Text below the direct answer and snippet
       viewDetailsLink: relatedItemData.website || (relatedItemData.fieldValues && relatedItemData.fieldValues.landingPageUrl), // Link for the "view details" text
       viewDetailsEventOptions: this.addDefaultEventOptions({


### PR DESCRIPTION
Check if the type of field for a snippet is rich text, if so, use the RTF formatter (`ANSWERS.formatRichText`) instead of `highlightField`.

TEST: confirmed using the test site that existing rich text snippet still works.

Also considered putting this in a switch statement, but after consulting with the rest of the product team, we don't foresee other field types anytime soon (so for performance reasons stuck with the regular if else). 