### PR TITLE
make all location card CTAs wrap to the bottom on full page map

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -535,6 +535,17 @@
     }
   }
 
+  .HitchhikerProfessionalLocation,
+  .HitchhikerFinancialProfessionalLocation {
+    &-contentWrapper {
+      flex-direction: column;
+    }
+
+    &-ctasWrapper {
+      margin-top: calc(var(--yxt-base-spacing) / 2);
+    }
+  }
+
   .HitchhikerLocationCard {
     position: relative;
 


### PR DESCRIPTION
This commit makes all CTAs for location cards wrap to the bottom of the
card while on the full page map. This was the intended design during
prototyping. Hoowever, only the location-standard card was exercising
this behavior - the professional-location and financial-professional-location
cards were not. Checked with Rose that the spacing of the CTAs should match
what we currently have for these cards on mobile screens.

J=none
TEST=manual

test that the professional-location, financial-professional-location, and
multilang variants have CTAs at the bottom of the card, and 10px
margin-top on the ctasWrapper