### PR TITLE
Update the Theme to use SDK v1.8 by default.

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "1.7", // The version of the Answers SDK to use
+  "sdkVersion": "1.8", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -137,9 +137,7 @@
     {{/babel}}
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>
-    <!-- TODO: change back to versioned answers script when 1.8 of the SDK has been cut -->
-    <!-- <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.css"> --->
-    <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/dev/release-v1.8/answers.css">
+    <link rel="stylesheet" type="text/css" href="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/answers.css">
     <link rel="stylesheet" type="text/css" href="{{relativePath}}/bundle.css" data-webpack-inline>
   </head>
   <body>

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -4,9 +4,7 @@
     console.error('ERROR: no sdkVersion specified, please specify an sdkVersion in the global_config.');
   }
 </script>
-<!-- TODO: change back to versioned answers script when 1.8 of the SDK has been cut -->
-<!-- <script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answerstemplates.compiled.min.js" defer></script> -->
-<script src="https://assets.sitescdn.net/answers/dev/release-v1.8/answerstemplates.compiled.min.js" defer></script>
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answerstemplates.compiled.min.js" defer></script>
 <script>
 {{#babel}}
   function initAnswers() {
@@ -83,6 +81,4 @@
   }
 {{/babel}}
 </script>
-<!-- TODO: change back to versioned answers script when 1.8 of the SDK has been cut -->
-<!-- <script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answers.min.js" onload="initAnswers()" defer></script> -->
-<script src="https://assets.sitescdn.net/answers/dev/release-v1.8/answers.min.js" onload="initAnswers()" defer></script>
+<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if params.sdkLocaleOverride}}{{#unless (eq params.sdkLocaleOverride 'en')}}{{params.sdkLocaleOverride}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}{{/if}}answers.min.js" onload="initAnswers()" defer></script>


### PR DESCRIPTION
This PR updates the SDK version used by default in the `global_config`. Because
SDK v1.8 has now been released, we no longer want the Theme to point to the
`dev/release-v1.8` branch.

TEST=manual

Verified that the SDK v1.8 assets were pulled down correctly for a Theme v1.20
site.