### PR TITLE
Fix Hitchhiker universal templates not being used for all verticals

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -1,3 +1,9 @@
+{{!-- Override the default VerticalResults template used in UniversalResults --}}
+ANSWERS.registerTemplate(
+  "results/verticalresults",
+  {{{ stringifyPartial (read "universalsectiontemplates/standard") }}}
+);
+
 ANSWERS.addComponent("UniversalResults", Object.assign({}, {
     container: ".js-answersUniversalResults",
     config: Object.assign({}, {
@@ -31,9 +37,7 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
 
 {{#*inline "VerticalConfig"}}
   {{#if universalSectionTemplate}}
-    template: `{{{read (concat "universalsectiontemplates/" universalSectionTemplate)}}}`,
-  {{else}}
-    template: `{{{read "universalsectiontemplates/standard"}}}`,
+    template: {{{ stringifyPartial (read (concat "universalsectiontemplates/" universalSectionTemplate)) }}},
   {{/if}}
   modifier: "{{{verticalKey}}}",
   {{#if url}}

--- a/test-site/config/index.json
+++ b/test-site/config/index.json
@@ -36,7 +36,7 @@
     },
     "KM": {
       "universalSectionTemplate": "grid-two-columns",
-      "cardType": "product-standard"
+      "cardType": "multilang-financial-professional-location"
     }
   }
 }

--- a/test-site/config/index.json
+++ b/test-site/config/index.json
@@ -35,7 +35,8 @@
       "label": "All" // The name of the universal tab in the navigation bar
     },
     "KM": {
-      "universalSectionTemplate": "grid-two-columns"
+      "universalSectionTemplate": "grid-two-columns",
+      "cardType": "product-standard"
     }
   }
 }

--- a/test-site/config/index.json
+++ b/test-site/config/index.json
@@ -3,6 +3,11 @@
   // "metaDescription": "", // The meta tag for open graph description
   // "canonicalUrl": "", // The link tag for canonical URL as well as the meta tag for open graph url
   // "keywords": "", // The meta tag for keywords
+  "pageSettings": {
+    "search": {
+      "defaultInitialSearch": "virginia" // Enter a default search term
+    }
+  },  
   "componentSettings": {
     /**
     "QASubmission": {
@@ -28,6 +33,9 @@
     "Universal": {
       "isFirst": "true", // Indicates that this should always appear first in the navigation bar
       "label": "All" // The name of the universal tab in the navigation bar
+    },
+    "KM": {
+      "universalSectionTemplate": "grid-two-columns"
     }
   }
 }

--- a/tests/templates/script/universalresults.js
+++ b/tests/templates/script/universalresults.js
@@ -164,7 +164,8 @@ describe('handles verticalLabel correctly', () => {
 function evalComponentConfig(templateData, mockGetInjectedProp) {
   const output = compiledTemplate(templateData);
   const ANSWERS = {
-    addComponent: jest.fn()
+    addComponent: jest.fn(),
+    registerTemplate: jest.fn()
   };
   const HitchhikerJS = {
     getInjectedProp: mockGetInjectedProp || jest.fn()


### PR DESCRIPTION
This commit fixes a bug where the Hitchhiker universal section template
was only being used for verticals that had pages made for them. For example,
if the backend returned a universal section for vertical "fruits", but I did
not have a page created with verticalKey "fruits", the SDK universal section
template would be used instead of the Hitchhiker one.

This was fixed by overriding the "results/verticalresults" template.

J=SLAP-1130
TEST=manual

test that I can specify a specific universal section template
see that the hitchhiker template is always used even for verticals
by making only a universal page and seeing the hitchhiker template for
all verticls