### PR TITLE
Fix styling of nlp filters, when no collapsible-filters present

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -348,7 +348,6 @@
 
     &-resultsHeaderTop {
       display: flex;
-      justify-content: space-between;
       padding-left: 16px;
     }
 

--- a/test-site/config-overrides/locations_full_page_map_with_filters.json
+++ b/test-site/config-overrides/locations_full_page_map_with_filters.json
@@ -1,0 +1,9 @@
+{
+  "componentSettings": {
+    "Facets": {
+      "expand": false,
+      "showMore": false,
+      "searchOnChange": true
+    }
+  }
+}

--- a/test-site/pages-patches/locations_full_page_map_with_filters.html.hbs.patch
+++ b/test-site/pages-patches/locations_full_page_map_with_filters.html.hbs.patch
@@ -1,0 +1,45 @@
+--- locations_full_page_map_with_filters.html.hbs
++++ locations_full_page_map_with_filters.html.hbs
+@@ -1,7 +1,7 @@
+ {{#> layouts/html pageWrapperCss="YxtPage-wrapper--mobileListView" }}
+   {{#> script/core }}
+     {{> cards/all }}
+-    {{!-- {{> templates/vertical-full-page-map/collapsible-filters/page-setup }} --}}
++    {{> templates/vertical-full-page-map/collapsible-filters/page-setup }}
+     {{> templates/vertical-full-page-map/page-setup }}
+     {{> templates/vertical-full-page-map/script/searchbar }}
+     {{> templates/vertical-full-page-map/script/spellcheck }}
+@@ -9,7 +9,7 @@
+     {{> templates/vertical-full-page-map/script/verticalresultscount }}
+     {{> templates/vertical-full-page-map/script/appliedfilters }}
+     {{!-- {{> templates/vertical-full-page-map/script/sortoptions }} --}}
+-    {{!-- {{> templates/vertical-full-page-map/script/facets }} --}}
++    {{> templates/vertical-full-page-map/script/facets }}
+     {{!-- {{> templates/vertical-full-page-map/script/filterbox }} --}}
+     {{> templates/vertical-full-page-map/script/verticalresults }}
+     {{> templates/vertical-full-page-map/script/pagination }}
+@@ -32,19 +32,19 @@
+             <div class="Answers-resultsHeaderTop">
+               {{> templates/vertical-full-page-map/markup/verticalresultscount }}
+               {{> templates/vertical-full-page-map/markup/appliedfilters }}
+-              {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/filterlink }} --}}
+-              {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }} --}}
++              {{> templates/vertical-full-page-map/collapsible-filters/markup/filterlink }}
++              {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }}
+             </div>
+             <div class="Answers-resultsHeaderBottom">
+               {{> templates/vertical-full-page-map/markup/alternativeresults }}
+             </div>
+           </div>
+           <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
+-          {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
++          <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive">
+             {{!-- {{> templates/vertical-full-page-map/markup/sortoptions }} --}}
+-            {{!-- {{> templates/vertical-full-page-map/markup/facets }} --}}
++            {{> templates/vertical-full-page-map/markup/facets }}
+             {{!-- {{> templates/vertical-full-page-map/markup/filterbox }} --}}
+-          {{!-- </div> --}}
++          </div>
+           <div class="Answers-resultsWrapper js-locator-resultsWrapper">
+             <div class="Answers-resultsContainer js-locator-resultsContainer js-answersResultsWrapper">
+               <div class="js-answersResultsColumn">

--- a/test-site/scripts/create-verticals.js
+++ b/test-site/scripts/create-verticals.js
@@ -25,6 +25,11 @@ const verticalConfiguration = {
     template: 'vertical-full-page-map',
     cardName: 'location-standard'
   },
+  locations_full_page_map_with_filters: {
+    verticalKey: 'KM',
+    template: 'vertical-full-page-map',
+    cardName: 'location-standard'
+  },
   people: {
     verticalKey: 'people',
     template: 'vertical-grid',

--- a/tests/percy/snapshots.js
+++ b/tests/percy/snapshots.js
@@ -70,4 +70,12 @@ async function captureVerticalFullPageMapSearch (page, percySnapshot) {
   await page.click(mapboxPinSelector);
   await waitTillHTMLRendered(page)
   await percySnapshot('vertical-full-page-map-mobile-detail-view', mobileWidth);
+
+  await page.goto(`${TEST_SITE}/locations_full_page_map?query=virginia`);
+  await waitTillHTMLRendered(page)
+  await percySnapshot('vertical-full-page-map-desktop-view-nlp-filters', desktopWidth);
+
+  await page.goto(`${TEST_SITE}/locations_full_page_map_with_filters?query=virginia`);
+  await waitTillHTMLRendered(page)
+  await percySnapshot('vertical-full-page-map-with-filters-desktop-view-nlp-filters', desktopWidth);
 }


### PR DESCRIPTION
This commit fixes the styling of nlp filters on the vertical full page
map. This was done by removing the justify-content: space-between on
Answers-resultsHeaderTop for the full page map's css. This should not have
any negative repercussions.

This statement is based on a few ideas. First, we can divide full page maps
into two categories, has collapsible filters and does not have collapsible filters.
For pages with collapsible filters, the FilterLink component's container styling
has margin-left: auto, which will squish all of the other divs in -resultsHeaderTop
to the left, in the same way that justify-content: flex-start would (the browser default).
For pages without collapsible filters, we don't want justify-content: between, because
it causes any nlp filters that get displayed to fly all the way to the right of the page.

J=SLAP-1262
TEST=manual, auto

test that before and after of the page, after removing justify-content: space between,
is exactly the same. test for page with filters, and page without filters, using searches
that returned nlp filters and do not return nlp filters.