### PR TITLE
Fix layout bug with a header/footer on mobile list view

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -456,6 +456,14 @@
           display: none;
         }
       }
+
+      &-mapWrapper
+      {
+        // Hide the map above the screen. This has better performance than
+        // display: none since the map does not have to re-render
+        position: fixed;
+        top: calc(-2 * var(--yxt-maps-mobile-height));
+      }
     }
   }
 


### PR DESCRIPTION
Fixes a bug where the map would overlap with headers and footers

Fix the bug by positioning the map off the screen on mobile list view. I think this is a more robust solution than adjusting z-indexes because it prevents HHs from needing to carefully fill the entire header/footer so that the map is not visible behind it. Hiding the map off screen also performs better than `display: none`.

J=SLAP-1261
TEST=manual

Add a header and footer to a test site vertical full page map page and confirm that the overlapping map is no longer an issue. Test on desktop and mobile screen widths. Test on a physical Pixel 2xl, and on a Pixel 5 and one of the newer iPhones on Browserstack. Test with an iframe and without one.