### PR TITLE
Fix locator bundle race condition

### DIFF
--- a/cards/financial-professional-location/component.js
+++ b/cards/financial-professional-location/component.js
@@ -7,7 +7,7 @@ class financial_professional_locationCardComponent extends BaseCard['financial-p
 
   onMount() {
     const onVerticalFullPageMap = !!document.querySelector('.js-answersVerticalFullPageMap');
-    onVerticalFullPageMap && new VerticalFullPageMap.CardListenerAssigner({card: this}).addListenersToCard();
+    onVerticalFullPageMap && registerVerticalFullPageMapCardListeners(this);
     super.onMount();
   }
 

--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -7,7 +7,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
 
   onMount() {
     const onVerticalFullPageMap = !!document.querySelector('.js-answersVerticalFullPageMap');
-    onVerticalFullPageMap && new VerticalFullPageMap.CardListenerAssigner({card: this}).addListenersToCard();
+    onVerticalFullPageMap && registerVerticalFullPageMapCardListeners(this);
     super.onMount();
   }
 

--- a/cards/multilang-financial-professional-location/component.js
+++ b/cards/multilang-financial-professional-location/component.js
@@ -7,7 +7,7 @@ class multilang_financial_professional_locationCardComponent extends BaseCard['m
 
   onMount() {
     const onVerticalFullPageMap = !!document.querySelector('.js-answersVerticalFullPageMap');
-    onVerticalFullPageMap && new VerticalFullPageMap.CardListenerAssigner({card: this}).addListenersToCard();
+    onVerticalFullPageMap && registerVerticalFullPageMapCardListeners(this);
     super.onMount();
   }
 

--- a/cards/multilang-location-standard/component.js
+++ b/cards/multilang-location-standard/component.js
@@ -7,7 +7,7 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
 
   onMount() {
     const onVerticalFullPageMap = !!document.querySelector('.js-answersVerticalFullPageMap');
-    onVerticalFullPageMap && new VerticalFullPageMap.CardListenerAssigner({card: this}).addListenersToCard();
+    onVerticalFullPageMap && registerVerticalFullPageMapCardListeners(this);
     super.onMount();
   }
 

--- a/cards/multilang-professional-location/component.js
+++ b/cards/multilang-professional-location/component.js
@@ -7,7 +7,7 @@ class multilang_professional_locationCardComponent extends BaseCard['multilang-p
 
   onMount() {
     const onVerticalFullPageMap = !!document.querySelector('.js-answersVerticalFullPageMap');
-    onVerticalFullPageMap && new VerticalFullPageMap.CardListenerAssigner({card: this}).addListenersToCard();
+    onVerticalFullPageMap && registerVerticalFullPageMapCardListeners(this);
     super.onMount();
   }
   

--- a/cards/professional-location/component.js
+++ b/cards/professional-location/component.js
@@ -7,7 +7,7 @@ class professional_locationCardComponent extends BaseCard['professional-location
 
   onMount() {
     const onVerticalFullPageMap = !!document.querySelector('.js-answersVerticalFullPageMap');
-    onVerticalFullPageMap && new VerticalFullPageMap.CardListenerAssigner({card: this}).addListenersToCard();
+    onVerticalFullPageMap && registerVerticalFullPageMapCardListeners(this);
     super.onMount();
   }
 

--- a/templates/vertical-full-page-map/page-setup.js
+++ b/templates/vertical-full-page-map/page-setup.js
@@ -7,5 +7,25 @@ if (window.locatorBundleLoaded) {
   loadFullPageMap();
 } else {
   const locatorBundleScript = document.querySelector('script#js-answersLocatorBundleScript');
-  locatorBundleScript.onload = loadFullPageMap;
+  locatorBundleScript.onload = () => {
+    window.locatorBundleLoaded = true;
+    locatorBundleScript.dispatchEvent(new Event('locator-bundle-loaded'));
+    loadFullPageMap();
+  }
+}
+
+/**
+ * Registers listeners on the card once the locator bundle is loaded
+ *
+ * @param {ANSWERS.Component} card A location card
+ */
+function registerVerticalFullPageMapCardListeners(card) {
+  if (window.locatorBundleLoaded) {
+    new VerticalFullPageMap.CardListenerAssigner({card: card}).addListenersToCard();
+    return;
+  }
+  const locatorBundleScript = document.querySelector('script#js-answersLocatorBundleScript');
+  locatorBundleScript.addEventListener('locator-bundle-loaded', () => {
+    new VerticalFullPageMap.CardListenerAssigner({card: card}).addListenersToCard();
+  });
 }


### PR DESCRIPTION
Fix a race condition where the vertical-full-page-map cards would break if the search loads before the locator bundle

J=SLAP-1276
TEST=manual

Use Fiddler to delay the loading of the locator bundle and observe the cards rendering properly. The cards aren't clickable while the bundle is loading, but as soon as it does, the cards become clickable. Also test that when the bundle loads before the search, the listeners register properly.