### PR TITLE
VerticalFullPageMap IE11 compatibility improvements

### DIFF
--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -106,10 +106,28 @@ const debounce = (func, wait) => {
   };
 };
 
+/**
+ * Removes an element from the DOM, with support for IE11
+ * 
+ * @param {Element} element
+ */
+const removeElement = (element) => {
+  if (!element) {
+    return;
+  }
+  if (element.remove) {
+    element.remove();
+  } else {
+    element.parentNode && element.parentNode.removeChild(element); // For IE11
+  }
+}
+
 export {
   getLanguageForProvider,
   getEncodedSvg,
   getNormalizedLongitude,
   isViewableWithinContainer,
-  debounce
+  debounce,
+  removeElement
 }
+

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -1,6 +1,6 @@
 import { Coordinate } from './Geo/Coordinate.js';
 import { smoothScroll } from './Util/SmoothScroll.js';
-import { getLanguageForProvider, isViewableWithinContainer } from './Util/helpers.js';
+import { getLanguageForProvider, isViewableWithinContainer, removeElement } from './Util/helpers.js';
 import { SearchDebouncer } from './SearchDebouncer';
 import { defaultCenterCoordinate } from './constants.js';
 
@@ -449,25 +449,9 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       el.classList.remove('yxt-Card--pinFocused');
     });
 
-    this._removeElement(this._detailCard);
+    removeElement(this._detailCard);
 
     this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, null);
-  }
-
-  /**
-   * Removes an element from the DOM, with support for IE11
-   * 
-   * @param {Element} element
-   */
-  _removeElement(element) {
-    if (!element) {
-      return;
-    }
-    if (element.remove) {
-      element.remove();
-    } else {
-      element.parentNode && element.parentNode.removeChild(element); // For IE11
-    }
   }
 
   /**
@@ -487,7 +471,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     card.classList.add('yxt-Card--pinFocused');
 
     if (this.isMobile()) {
-      document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').forEach((el) => this._removeElement(el));
+      document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').forEach((el) => removeElement(el));
       const isDetailCardOpened = document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').length;
 
       this._detailCard = card.cloneNode(true);

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -113,7 +113,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
     /**
      * Provides information about whether or not the window is within the mobile breakpoint
-     * @ytype {MediaQueryList}
+     * @type {MediaQueryList}
      */
     this.mobileBreakpointMediaQuery = window.matchMedia(`(max-width: ${this.mobileBreakpointMax}px)`);
 
@@ -189,13 +189,19 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       this.updateCssForDesktop();
     }
 
-    this.mobileBreakpointMediaQuery.addEventListener('change', () => {
+    const breakpointChangeHandler = () => {
       if (this.isMobile()) {
         this.updateCssForMobile();
       } else {
         this.updateCssForDesktop();
       }
-    }, { passive: true });
+    };
+    if (this.mobileBreakpointMediaQuery.addEventListener) {
+      this.mobileBreakpointMediaQuery
+        .addEventListener('change', breakpointChangeHandler, { passive: true });
+    } else {
+      this.mobileBreakpointMediaQuery.addListener(breakpointChangeHandler); // For IE11
+    }
   }
 
   /**
@@ -443,9 +449,25 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       el.classList.remove('yxt-Card--pinFocused');
     });
 
-    this._detailCard && this._detailCard.remove();
+    this._removeElement(this._detailCard);
 
     this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, null);
+  }
+
+  /**
+   * Removes an element from the DOM, with support for IE11
+   * 
+   * @param {Element} element
+   */
+  _removeElement(element) {
+    if (!element) {
+      return;
+    }
+    if (element.remove) {
+      element.remove();
+    } else {
+      element.parentNode && element.parentNode.removeChild(element); // For IE11
+    }
   }
 
   /**
@@ -465,7 +487,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     card.classList.add('yxt-Card--pinFocused');
 
     if (this.isMobile()) {
-      document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').forEach((el) => el.remove());
+      document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').forEach((el) => this._removeElement(el));
       const isDetailCardOpened = document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').length;
 
       this._detailCard = card.cloneNode(true);
@@ -474,9 +496,9 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
       if (!isDetailCardOpened) {
         window.requestAnimationFrame(() => {
-          this._detailCard.style = 'height: 0;';
+          this._detailCard.setAttribute('style', 'height: 0;');
           window.requestAnimationFrame(() => {
-            this._detailCard.style = '';
+            this._detailCard.removeAttribute('style');
           });
         });
       }

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -218,7 +218,6 @@
 
     &-mobileToggle
     {
-      flex: 1;
       padding: 16px;
     }
 


### PR DESCRIPTION
Update the VerticalFullPageMap to be fully IE11 compliant

We were using some syntax which wasn't supported by IE11. Update the locator to account for that. Also remove the flex on the mobile view toggle button because that was not being formatted properly on IE11. Removing the flex didn't change anything that I could see, and Percy didn't pick up any changes either.

Fixes for IE11 compatibility:
- For MediaQueryLists, use addListener rather than addEventListener
- Add a `removeElement()` helper function with IE11 support (essentially a ponyfill)
- Use setAttribute and removeAttribute for updating the detail card styling

J=none
TEST=manual

Test on IE11 and chrome and make sure that erros are no longer produced in the console on IE11, and test various functionality including pin clustering, opening and closing details cards, and toggling between mobile views.