### PR TITLE
Reduce Webpack's logging output

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -35,7 +35,7 @@ module.exports = function () {
       after: {
         root: `${jamboConfig.dirs.output}`,
         include: ['static'],
-        log: true
+        log: false
       }
     })
   ];

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -42,6 +42,7 @@ module.exports = function () {
 
   const commonConfig = {
     devtool: 'source-map',
+    stats: 'errors-warnings',
     performance: {
       maxAssetSize: 1536000,
       maxEntrypointSize: 1024000


### PR DESCRIPTION
This PR reduces the amount of logging done by Webpack. In the common Webpack config, `stats` was set to `errors-warnings`. This will significantly decrease the amount of information logged by Webpack. Specifically, we will no longer write out the statistics of each generated asset. If there is an issue with the bundling of an asset, that will still appear in the console. The `remove-files-webpack-plugin` was configured to no longer log it's output to the console. This information was not especially useful to a user of the Theme. 

This is part of an ongoing effort to clean up the console for those doing local development and development in CBD.

TEST=manual

On a local test site, verified that Webpack still worked as expected but there was much less info in stdout.