### PR TITLE
product-prominentimage: fix CTAs to the bottom

### DIFF
--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -97,7 +97,7 @@
   &-ctasWrapper
   {
     text-transform: uppercase;
-    margin-top: calc(var(--yxt-base-spacing) / 2);
+    margin-top: auto;
   }
 
   &-primaryCTA,

--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -98,6 +98,7 @@
   {
     text-transform: uppercase;
     margin-top: auto;
+    padding-top: calc(var(--yxt-base-spacing) / 2);
   }
 
   &-primaryCTA,


### PR DESCRIPTION
This commit updates the product-prominentimage card
to always fix CTAs to the bottom of the card for the
vertical-grid layout. Previously, when cards on the same
row had different amounts of content above the CTA, for
example using different sized images, or shorter vs
longer card title text that may wrap, the CTAs would not
be aligned to the bottom of the card.

This was reported as a regression for 1.19, however I made a
site using theme 1.18, and this was still in issue there.
It's possible the Hitchhikers had some sort of internal
patch to get the desired behavior, and changing from 1.18 to 1.19
broke their patch.

J=SLAP-1192
TEST=manual

test that the CTAs are fixed to the bottom of the screen
didn't add percy snapshots because we have an item to figure
out how to add card snapshots to the theme. 