### PR TITLE
Add iframe JWT support

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -3,7 +3,7 @@
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
-  // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be ignored and the experience must be loaded through iframe-jwt.js or similar
+  // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be ignored and initAnswersJWT(token) or initAnswersFrameJWT(token) must be called.
   "logo": "", // The link to the logo for open graph meta tag - og:image.
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer

--- a/global_config.json
+++ b/global_config.json
@@ -3,6 +3,7 @@
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
+  // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be ignored and the experience must be loaded through iframe-jwt.js or similar
   "logo": "", // The link to the logo for open graph meta tag - og:image.
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -123,9 +123,8 @@
       window.iframeLoaded = new Promise(resolve => {
         iframeLoadedResolve = resolve;
       });
-      let iframeJWTResolve;
-      window.iframeJWT = new Promise(resolve => {
-        iframeJWTResolve = resolve;
+      window.answersJWT = new Promise(resolve => {
+        window.initAnswersJWT = resolve;
       });
       window.iFrameResizer = {
         onReady: function() {
@@ -138,7 +137,7 @@
         },
         onMessage: (message) => {
           if (message.token) {
-            iframeJWTResolve(message.token);
+            initAnswersJWT(message.token);
             return;
           }
           window.isOverlay && window.Overlay.onMessage(message);

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -126,7 +126,7 @@
       let iframeJWTResolve;
       window.iframeJWT = new Promise(resolve => {
         iframeJWTResolve = resolve;
-      })
+      });
       window.iFrameResizer = {
         onReady: function() {
           window.parentIFrame.sendMessage(JSON.stringify({

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -123,6 +123,10 @@
       window.iframeLoaded = new Promise(resolve => {
         iframeLoadedResolve = resolve;
       });
+      let iframeJWTResolve;
+      window.iframeJWT = new Promise(resolve => {
+        iframeJWTResolve = resolve;
+      })
       window.iFrameResizer = {
         onReady: function() {
           window.parentIFrame.sendMessage(JSON.stringify({
@@ -132,7 +136,13 @@
           }));
           iframeLoadedResolve();
         },
-        onMessage: window.isOverlay ? window.Overlay.onMessage : function() {},
+        onMessage: (message) => {
+          if (message.token) {
+            iframeJWTResolve(message.token);
+            return;
+          }
+          window.isOverlay && window.Overlay.onMessage(message);
+        }
       };
     {{/babel}}
     </script>

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -34,10 +34,10 @@
       const jwtNotProvidedTimeout = setTimeout(() => {
         console.error(
           'A JWT is required to initialize this Answers experience because "useJWT" is set to true.\n' +
-          'To specify a JWT, this page must be loaded through iframe-jwt.js or similar.'
+          'Load the experience by calling initAnswersJWT(token) or initAnswersFrameJWT(token).'
         );
       }, 2000);
-      window.iframeJWT.then(token => {
+      window.answersJWT.then(token => {
         clearTimeout(jwtNotProvidedTimeout);
         initAnswersInstance({
           ...injectedConfig,

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -32,11 +32,11 @@
     };
     {{#if global_config.useJWT}}
       const jwtNotProvidedTimeout = setTimeout(() => {
-        console.error(
+        console.warn(
           'A JWT is required to initialize this Answers experience because "useJWT" is set to true.\n' +
           'Load the experience by calling initAnswersJWT(token) or initAnswersFrameJWT(token).'
         );
-      }, 2000);
+      }, 5000);
       window.answersJWT.then(token => {
         clearTimeout(jwtNotProvidedTimeout);
         initAnswersInstance({

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -39,7 +39,7 @@
       } else { // to support cross-origin
         iframeSearchParams = new URLSearchParams(window.location.search);
       }
-      token = iframeSearchParams?.get('token');
+      token = iframeSearchParams.get('token');
     {{/if}}
     ANSWERS.init({
       templateBundle: TemplateBundle.default,

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -12,7 +12,9 @@
     const IS_STAGING = HitchhikerJS.isStaging(JAMBO_INJECTED_DATA?.pages?.stagingDomains || []);
     const injectedConfig = {
       experienceVersion: IS_STAGING ? 'STAGING' : 'PRODUCTION',
-      apiKey: HitchhikerJS.getInjectedProp('{{{global_config.experienceKey}}}', ['apiKey']),
+      {{#unless global_config.useJWT}} 
+        apiKey: HitchhikerJS.getInjectedProp('{{{global_config.experienceKey}}}', ['apiKey']),
+      {{/unless}}
       {{#with env.JAMBO_INJECTED_DATA}}
         {{#if businessId}}businessId: "{{businessId}}",{{/if}}
       {{/with}}
@@ -29,14 +31,16 @@
       {{/with}}
     };
     let token = null;
-    let iframeSearchParams = null;
-    if (window.frameElement) {
-      const iframeSrc = new URL(window.frameElement.src);
-      iframeSearchParams = new URLSearchParams(iframeSrc.search);
-    } else {
-      iframeSearchParams = new URLSearchParams(window.location.search);
-    }
-    token = iframeSearchParams?.get('token');
+    {{#if global_config.useJWT}}
+      let iframeSearchParams = null;
+      if (window.frameElement) { // to support same-origin
+        const iframeSrc = new URL(window.frameElement.src);
+        iframeSearchParams = new URLSearchParams(iframeSrc.search);
+      } else { // to support cross-origin
+        iframeSearchParams = new URLSearchParams(window.location.search);
+      }
+      token = iframeSearchParams?.get('token');
+    {{/if}}
     ANSWERS.init({
       templateBundle: TemplateBundle.default,
       ...injectedConfig,

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -31,7 +31,14 @@
       {{/with}}
     };
     {{#if global_config.useJWT}}
+      const jwtNotProvidedTimeout = setTimeout(() => {
+        console.error(
+          'Since useJWT is set, a JWT is required to initialize this Answers experience.\n' +
+          'To specify a JWT, this page must be loaded through iframe-jwt.js or similar.'
+        );
+      }, 2000);
       window.iframeJWT.then(token => {
+        clearTimeout(jwtNotProvidedTimeout);
         initAnswersInstance({
           ...injectedConfig,
           ...userConfig,

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -33,8 +33,8 @@
     {{#if global_config.useJWT}}
       const jwtNotProvidedTimeout = setTimeout(() => {
         console.warn(
-          'A JWT is required to initialize this Answers experience because "useJWT" is set to true.\n' +
-          'Load the experience by calling initAnswersJWT(token) or initAnswersFrameJWT(token).'
+          'A JWT has not been received within 5 seconds of page load, and "useJWT" is set to true.\n' + 
+          'Load the experience by calling initAnswersJWT(token).'
         );
       }, 5000);
       window.answersJWT.then(token => {

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -28,10 +28,20 @@
         {{/if}}
       {{/with}}
     };
+    let token = null;
+    let iframeSearchParams = null;
+    if (window.frameElement) {
+      const iframeSrc = new URL(window.frameElement.src);
+      iframeSearchParams = new URLSearchParams(iframeSrc.search);
+    } else {
+      iframeSearchParams = new URLSearchParams(window.location.search);
+    }
+    token = iframeSearchParams?.get('token');
     ANSWERS.init({
       templateBundle: TemplateBundle.default,
       ...injectedConfig,
       ...userConfig,
+      ...token && { apiKey: token },
       querySource: window.isOverlay ? 'OVERLAY' : 'STANDARD',
       onStateChange: (objParams, stringParams, replaceHistory) => {
         if ('parentIFrame' in window) {

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -30,22 +30,25 @@
         {{/if}}
       {{/with}}
     };
-    let token = null;
     {{#if global_config.useJWT}}
-      let iframeSearchParams = null;
-      if (window.frameElement) { // to support same-origin
-        const iframeSrc = new URL(window.frameElement.src);
-        iframeSearchParams = new URLSearchParams(iframeSrc.search);
-      } else { // to support cross-origin
-        iframeSearchParams = new URLSearchParams(window.location.search);
-      }
-      token = iframeSearchParams.get('token');
+      window.iframeJWT.then(token => {
+        initAnswersInstance({
+          ...injectedConfig,
+          ...userConfig,
+          apiKey: token
+        });
+      });
+    {{else}}
+      initAnswersInstance({
+        ...injectedConfig, 
+        ...userConfig
+      });
     {{/if}}
+  }
+  function initAnswersInstance (config) {
     ANSWERS.init({
       templateBundle: TemplateBundle.default,
-      ...injectedConfig,
-      ...userConfig,
-      ...token && { apiKey: token },
+      ...config,
       querySource: window.isOverlay ? 'OVERLAY' : 'STANDARD',
       onStateChange: (objParams, stringParams, replaceHistory) => {
         if ('parentIFrame' in window) {

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -33,7 +33,7 @@
     {{#if global_config.useJWT}}
       const jwtNotProvidedTimeout = setTimeout(() => {
         console.error(
-          'Since useJWT is set, a JWT is required to initialize this Answers experience.\n' +
+          'A JWT is required to initialize this Answers experience because "useJWT" is set to true.\n' +
           'To specify a JWT, this page must be loaded through iframe-jwt.js or similar.'
         );
       }, 2000);

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -83,7 +83,7 @@ export function generateIFrame(domain, queryParam, urlParam, token) {
   iFrameResize({
     checkOrigin: false,
     onInit: function(iframe) {
-      iframe.iFrameResizer.sendMessage({
+      token && iframe.iFrameResizer.sendMessage({
         token: token
       }); 
     },

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -86,6 +86,11 @@ export function generateIFrame(domain, queryParam, urlParam, token) {
   // For dynamic iFrame resizing
   iFrameResize({
     checkOrigin: false,
+    onInit: function(iframe) {
+      iframe.iFrameResizer.sendMessage({
+        token: token
+      }); 
+    },
     onMessage: function(messageData) {
       const message = JSON.parse(messageData.message);
       if (message.action === "paginate") {

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -1,6 +1,6 @@
 require('iframe-resizer');
 
-export function generateIFrame(domain, queryParam, urlParam) {
+export function generateIFrame(domain, queryParam, urlParam, token) {
   var isLocalHost = window.location.host.split(':')[0] === 'localhost';
   var containerEl = document.querySelector('#answers-container');
   var iframe = document.createElement('iframe');
@@ -47,6 +47,10 @@ export function generateIFrame(domain, queryParam, urlParam) {
     }
 
     new_params.push('referrerPageUrl=' + referrerPageUrl);
+
+    if(token) {
+      new_params.push('token=' + token);
+    }
 
     // Build the Iframe URL
     var iframeUrl = domain;

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -48,10 +48,6 @@ export function generateIFrame(domain, queryParam, urlParam, token) {
 
     new_params.push('referrerPageUrl=' + referrerPageUrl);
 
-    if(token) {
-      new_params.push('token=' + token);
-    }
-
     // Build the Iframe URL
     var iframeUrl = domain;
     if (verticalUrl) {

--- a/static/js/iframe-jwt-prod.js
+++ b/static/js/iframe-jwt-prod.js
@@ -3,6 +3,6 @@ import InjectedData from './models/InjectedData';
 
 const prodDomain = new InjectedData().getProdDomain();
 
-window.initAnswersFrame = function (token) {
+window.initAnswersFrameJWT = function (token) {
   generateIFrame(prodDomain, null, null, token);
 }

--- a/static/js/iframe-jwt-prod.js
+++ b/static/js/iframe-jwt-prod.js
@@ -1,8 +1,11 @@
 import { generateIFrame } from './iframe-common';
 import InjectedData from './models/InjectedData';
+import getJwtNotProvidedTimeout from './utils/getJwtNotProvidedTimeout';
 
 const prodDomain = new InjectedData().getProdDomain();
+const jwtNotProvidedTimeout = getJwtNotProvidedTimeout();
 
 window.initAnswersFrameJWT = function (token) {
+  clearTimeout(jwtNotProvidedTimeout);
   generateIFrame(prodDomain, null, null, token);
 }

--- a/static/js/iframe-jwt-prod.js
+++ b/static/js/iframe-jwt-prod.js
@@ -1,0 +1,8 @@
+import { generateIFrame } from './iframe-common';
+import InjectedData from './models/InjectedData';
+
+const prodDomain = new InjectedData().getProdDomain();
+
+window.initAnswersFrame = function (token) {
+  generateIFrame(prodDomain, null, null, token);
+}

--- a/static/js/iframe-jwt-staging.js
+++ b/static/js/iframe-jwt-staging.js
@@ -1,8 +1,11 @@
 import { generateIFrame } from './iframe-common';
 import InjectedData from './models/InjectedData';
+import getJwtNotProvidedTimeout from './utils/getJwtNotProvidedTimeout';
 
 const stagingDomain = new InjectedData().getStagingDomain();
+const jwtNotProvidedTimeout = getJwtNotProvidedTimeout();
 
 window.initAnswersFrameJWT = function (token) {
+  clearTimeout(jwtNotProvidedTimeout);
   generateIFrame(stagingDomain, null, null, token);
 }

--- a/static/js/iframe-jwt-staging.js
+++ b/static/js/iframe-jwt-staging.js
@@ -3,6 +3,6 @@ import InjectedData from './models/InjectedData';
 
 const stagingDomain = new InjectedData().getStagingDomain();
 
-window.initAnswersFrame = function (token) {
+window.initAnswersFrameJWT = function (token) {
   generateIFrame(stagingDomain, null, null, token);
 }

--- a/static/js/iframe-jwt-staging.js
+++ b/static/js/iframe-jwt-staging.js
@@ -1,0 +1,8 @@
+import { generateIFrame } from './iframe-common';
+import InjectedData from './models/InjectedData';
+
+const stagingDomain = new InjectedData().getStagingDomain();
+
+window.initAnswersFrame = function (token) {
+  generateIFrame(stagingDomain, null, null, token);
+}

--- a/static/js/iframe-jwt.js
+++ b/static/js/iframe-jwt.js
@@ -3,6 +3,6 @@ import InjectedData from './models/InjectedData';
 
 const domain = new InjectedData().getDomain();
 
-window.initAnswersFrame = function (token) {
+window.initAnswersFrameJWT = function (token) {
   generateIFrame(domain, null, null, token);
 }

--- a/static/js/iframe-jwt.js
+++ b/static/js/iframe-jwt.js
@@ -1,0 +1,8 @@
+import { generateIFrame } from './iframe-common';
+import InjectedData from './models/InjectedData';
+
+const domain = new InjectedData().getDomain();
+
+window.initAnswersFrame = function (token) {
+  generateIFrame(domain, null, null, token);
+}

--- a/static/js/iframe-jwt.js
+++ b/static/js/iframe-jwt.js
@@ -1,8 +1,11 @@
 import { generateIFrame } from './iframe-common';
 import InjectedData from './models/InjectedData';
+import getJwtNotProvidedTimeout from './utils/getJwtNotProvidedTimeout';
 
 const domain = new InjectedData().getDomain();
+const jwtNotProvidedTimeout = getJwtNotProvidedTimeout();
 
 window.initAnswersFrameJWT = function (token) {
+  clearTimeout(jwtNotProvidedTimeout);
   generateIFrame(domain, null, null, token);
 }

--- a/static/js/utils/getJwtNotProvidedTimeout.js
+++ b/static/js/utils/getJwtNotProvidedTimeout.js
@@ -1,0 +1,8 @@
+export default function getJwtNotProvidedTimeout () {
+  return setTimeout(() => {
+    console.warn(
+      'A JWT has not been received within 5 seconds of page load, and "useJWT" is set to true.\n' + 
+      'Load the experience by calling initAnswersFrameJWT(token).'
+    );
+  }, 5000);
+}

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -52,6 +52,7 @@ module.exports = function () {
       'HitchhikerJS': `./${jamboConfig.dirs.output}/static/entry.js`,
       'HitchhikerCSS': `./${jamboConfig.dirs.output}/static/css-entry.js`,
       'iframe': `./${jamboConfig.dirs.output}/static/js/iframe.js`,
+      'iframe-jwt': `./${jamboConfig.dirs.output}/static/js/iframe-jwt.js`,
       'answers': `./${jamboConfig.dirs.output}/static/js/iframe.js`,
       'overlay-button': `./${jamboConfig.dirs.output}/static/js/overlay/button-frame/entry.js`,
       'overlay': `./${jamboConfig.dirs.output}/static/js/overlay/parent-frame/yxtanswersoverlay.js`,

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -53,6 +53,8 @@ module.exports = function () {
       'HitchhikerCSS': `./${jamboConfig.dirs.output}/static/css-entry.js`,
       'iframe': `./${jamboConfig.dirs.output}/static/js/iframe.js`,
       'iframe-jwt': `./${jamboConfig.dirs.output}/static/js/iframe-jwt.js`,
+      'iframe-jwt-prod': `./${jamboConfig.dirs.output}/static/js/iframe-jwt-prod.js`,
+      'iframe-jwt-staging': `./${jamboConfig.dirs.output}/static/js/iframe-jwt-staging.js`,
       'answers': `./${jamboConfig.dirs.output}/static/js/iframe.js`,
       'overlay-button': `./${jamboConfig.dirs.output}/static/js/overlay/button-frame/entry.js`,
       'overlay': `./${jamboConfig.dirs.output}/static/js/overlay/parent-frame/yxtanswersoverlay.js`,

--- a/test-site/.gitignore
+++ b/test-site/.gitignore
@@ -3,6 +3,7 @@
 !config/index.json
 !pages/index.html.hbs
 !public/iframe_test.html
+!public/iframe_jwt_test.html
 public/
 config/
 pages/

--- a/test-site/jambo.json
+++ b/test-site/jambo.json
@@ -10,7 +10,8 @@
       "directanswercards"
     ],
     "preservedFiles": [
-      "public/iframe_test.html"
+      "public/iframe_test.html",
+      "public/iframe_jwt_test.html"
     ]
   },
   "defaultTheme": "answers-hitchhiker-theme"

--- a/test-site/public/iframe_jwt_test.html
+++ b/test-site/public/iframe_jwt_test.html
@@ -1,0 +1,1 @@
+<html><head><meta name="viewport" content="initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,width=device-width"></head><body><div id="answers-container"></div><script src="iframe-jwt.js"></script></body></html>


### PR DESCRIPTION
Add iframe JWT support which is enabled when useJWT is true in global config

For iframe experiences, add iframe-jwt.js (along with prod and staging versions) which provide an `initAnswersFrameJWT` function. The answers experience will load once `initAnswersFrameJWT` is called.

For non-iframe experiences, `initAnswersJWT` must be called rather than `initAnswersFrameJWT`

The next PR will ensure that the apiKey from the jambo injected data will not appear in the output of any builds.

This PR does not include JWT overlay support.

J=SLAP-1118
TEST=manual

Test iframe-jwt.js and see that the page doesn't load until initAnswersFrame is ran. Test supplying valid and invalid tokens. Test navigating between pages and refreshing the page. Test that if the answers experience with `useJWT=true` is loaded directly (not through the iframe), and error message appears in the console. Smoke test the non-iframe experience and the the overlay integration with `useJWT=false`.  Test JWT locally and on SGS. Test in a cross-domain manner with a local test site which points to an answers experience on SGS which is running this branch. On SGS, test iframe-jwt-prod.js and iframe-jwt-staging.js

Test JWT on non-iframe experiences.