### PR TITLE
add Coveralls github workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,30 @@
+# This workflow will run our tests, generate an lcov code coverage file,
+# and send that coverage to Coveralls 
+
+name: Code Coverage
+
+on:
+  push:
+    branches-ignore: dev/*
+  pull_request:
+
+jobs:
+  Coveralls:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npx jest --coverage
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Answers Hitchhiker Theme
 
+<div>
+  <a href='https://coveralls.io/github/yext/answers-hitchhiker-theme?branch=master'>
+    <img src='https://coveralls.io/repos/github/yext/answers-hitchhiker-theme/badge.svg?branch=master' alt='Coverage Status' />
+  </a>
+</div>
+
 A [Jambo](https://github.com/yext/jambo) theme for building Answers experiences.
 
 Additonal resources for integrating Answers can be found at https://hitchhikers.yext.com/.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "yargs": "^17.0"
   },
   "jest": {
+    "collectCoverageFrom": [
+      "static/**/*.js"
+    ],
     "verbose": true,
     "moduleFileExtensions": [
       "js"


### PR DESCRIPTION
Adds a code coverage workflow using Coveralls
Only static .js files have their coverage collected.
Trying to collect code coverage from hbs files masquerading
as js files causes the coverage reporter to crash, since it
can't parse the hbs portions of the file correctly.

Also adds a code coverage badge to the readme.

J=SLAP-873
TEST=auto