### PR TITLE
fix test-site's mock date

### DIFF
--- a/test-site/static/js/formatters-custom.js
+++ b/test-site/static/js/formatters-custom.js
@@ -1,6 +1,5 @@
-const mockedDate = new Date('December 25, 2020 12:42:00');
 global.Date = class extends Date {
-  constructor(date) {
-    return date ? super(date) : mockedDate;
+  constructor(date = 'December 25, 2020 12:42:00 GMT-0500') {
+    super(date);
   }
 };


### PR DESCRIPTION
This commit fixes an issue with the mocked date we use
for our formatters in the test-site. Currently, we create
an instance of Date, and decorate the original Date class
to return this instance if new Date() is called with no params
(which should return the current date). However, the issue is that,
if new Date() is called, and then out of its setters is called,
like setHours() or setMinutes(), which we call in our HoursStringsLocalizer,
this fixed instance will be mutated. This causes inconsistent date time
behavior when using the test-site for local testing.

This is fixed by returning a new instance of Date every time the Date()
constructor is called. It also now specifies GMT-0500, instead of depending
on the host machine's timezone.

J=SLAP-1313
TEST=manual

open dev tools and see that the output of new Date() is the expected date,
and that without this change it is not