### PR TITLE
remove + signs from percy snapshot query params

### DIFF
--- a/tests/percy/photographer.js
+++ b/tests/percy/photographer.js
@@ -34,7 +34,7 @@ class Photographer {
     await this._pageNavigator.gotoUniversalPage({ query: 'a' });
     await this._camera.snapshot('universal-search');
 
-    await this._pageNavigator.gotoUniversalPage({ query: 'office+sparce'});
+    await this._pageNavigator.gotoUniversalPage({ query: 'office sparce'});
     await this._camera.snapshot('universal-search--spellcheck');
   }
   
@@ -73,7 +73,7 @@ class Photographer {
     await this._camera.snapshotMobileOnly('vertical-full-page-map__mobile-detail-view');
 
     await this._pageNavigator
-      .gotoVerticalPage('locations_full_page_map', { query: 'office+sparce'});
+      .gotoVerticalPage('locations_full_page_map', { query: 'office sparce'});
     await this._camera.snapshotDesktopOnly('vertical-full-page-map--spellcheck__desktop-view');
     await this._camera.snapshotMobileOnly('vertical-full-page-map--spellcheck__mobile-list-view');
 


### PR DESCRIPTION
When the percy snapshot infra was updated to use an object
instead of directly specifying the query param string, plus
signs were kept as + signs instead of being translated into spaces.

J=SLAP-1313
TEST=auto

check that the "office sparce" snapshots show spell check again