### PR TITLE
use express instead of serve-handler for snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6794,10 +6794,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.67.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7215,12 +7212,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-jest": "^25.5.1",
     "comment-json": "^4.1.0",
     "cross-env": "^7.0.2",
+    "express": "^4.17.1",
     "file-system": "^2.2.2",
     "full-icu": "^1.3.1",
     "handlebars": "^4.7.6",

--- a/tests/percy/iframepagenavigator.js
+++ b/tests/percy/iframepagenavigator.js
@@ -19,14 +19,14 @@ class IframePageNavigator extends PageNavigator {
 
   async gotoUniversalPage(queryParams = {}) {
     const queryParamsString = getQueryParamsString(queryParams);
-    const url = `${this._siteUrl}/${this._iframePage}?${queryParamsString}`;
+    const url = `${this._siteUrl}/${this._iframePage}.html?${queryParamsString}`;
     await this._page.goto(url);
     await waitTillHTMLRendered(this._page);
   }
 
   async gotoVerticalPage(vertical, queryParams = {}) {
     const queryParamsString = getQueryParamsString(queryParams);
-    const url = `${this._siteUrl}/${this._iframePage}?verticalUrl=${vertical}&${queryParamsString}`;
+    const url = `${this._siteUrl}/${this._iframePage}.html?verticalUrl=${vertical}.html&${queryParamsString}`;
     await this._page.goto(url);
     await waitTillHTMLRendered(this._page);
   }

--- a/tests/percy/standardpagenavigator.js
+++ b/tests/percy/standardpagenavigator.js
@@ -24,7 +24,7 @@ class StandardPageNavigator extends PageNavigator {
 
   async gotoVerticalPage(vertical, queryParams = {}) {
     const queryParamsString = getQueryParamsString(queryParams);
-    const url = `${this._siteUrl}/${vertical}?${queryParamsString}`;
+    const url = `${this._siteUrl}/${vertical}.html?${queryParamsString}`;
     await this._page.goto(url);
     await waitTillHTMLRendered(this._page);
   }

--- a/tests/test-utils/server.js
+++ b/tests/test-utils/server.js
@@ -1,5 +1,4 @@
-const http = require('http');
-const handler = require('serve-handler');
+const express = require('express');
 
 /**
  * A simple http server
@@ -13,12 +12,8 @@ class HttpServer {
    * @param {number} config.port - The port to serve at
    */
   constructor ({dir, port}) {
-    this._server = http.createServer((request, response) => {
-      return handler(request, response, {
-        "public": dir
-      });
-    });
-
+    this._app = express();
+    this._app.use(express.static(dir));
     this._port = port;
   }
 
@@ -26,7 +21,9 @@ class HttpServer {
    * Starts the server
    */
   start () {
-    this._server.listen(this._port);
+    this._server = this._app.listen(this._port, () => {
+      console.log(`listening at http://localhost:${this._port}`);
+    });
   }
 
   /**


### PR DESCRIPTION
This pr updates our tests to use express instead of serve-handler.
serve (likely due to using serve-handler) currently has a bug where,
if any redirects occur, it will lose any query params you had in the url.
See: vercel/serve#643

On top of that, serve will automatically redirect urls like
/index.html to just /, which breaks our iframe integration for universal.

J=SLAP-1313
TEST=auto

percy snapshots for universal on iframe are now corrected and
show the correct query