### PR TITLE
revert renames to the locator bundle and script element id

### DIFF
--- a/templates/vertical-full-page-map/page-setup.js
+++ b/templates/vertical-full-page-map/page-setup.js
@@ -3,13 +3,13 @@ function addFullPageMap() {
   {{> theme-components/vertical-full-page-map/script}}
 }
 
-if (window.verticalFullPageMapBundleLoaded) {
+if (window.locatorBundleLoaded) {
   addFullPageMap();
 } else {
-  const verticalFullPageMapScript = document.querySelector('script#js-verticalFullPageMapScript');
-  verticalFullPageMapScript.onload = () => {
-    window.verticalFullPageMapBundleLoaded = true;
-    verticalFullPageMapScript.dispatchEvent(new Event('vertical-full-page-map-bundle-loaded'));
+  const locatorBundleScript = document.querySelector('script#js-answersLocatorBundleScript');
+  locatorBundleScript.onload = () => {
+    window.locatorBundleLoaded = true;
+    locatorBundleScript.dispatchEvent(new Event('vertical-full-page-map-bundle-loaded'));
     addFullPageMap();
   }
 }
@@ -20,7 +20,7 @@ if (window.verticalFullPageMapBundleLoaded) {
  * @param {ANSWERS.Component} card A location card
  */
 function registerVerticalFullPageMapCardListeners(card) {
-  if (window.verticalFullPageMapBundleLoaded) {
+  if (window.locatorBundleLoaded) {
     new VerticalFullPageMap.CardListenerAssigner({card: card}).addListenersToCard();
     return;
   }

--- a/templates/vertical-full-page-map/page.html.hbs
+++ b/templates/vertical-full-page-map/page.html.hbs
@@ -17,8 +17,8 @@
     {{> templates/vertical-full-page-map/script/locationbias modifier="main" }}
     {{> templates/vertical-full-page-map/script/locationbias modifier="mobileMap" }}
   {{/script/core }}
-  <script id="js-verticalFullPageMapScript" src="{{relativePath}}/locator-bundle.js"
-    onload="window.verticalFullPageMapBundleLoaded = true;" defer></script>
+  <script id="js-answersLocatorBundleScript" src="{{relativePath}}/locator-bundle.js"
+    onload="window.locatorBundleLoaded = true;" defer></script>
     <div class="Answers AnswersVerticalMap CollapsibleFilters VerticalFullPageMap VerticalFullPageMap--mobileListView js-answersVerticalFullPageMap">
       <div class="Answers-content">
         <div class="Answers-contentWrap js-locator-contentWrap" role="region" aria-label="{{ translate phrase="Main location search" }}">


### PR DESCRIPTION
We need to revert these renames, otherwise if somebody
upgrades their theme, and has a preexisting VerticalFullPageMap
page, the page will break.

TEST=manual

see that the locator loads locally