### PR TITLE
fix acceptance tests false positives

### DIFF
--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -6,4 +6,4 @@ export BROWSERSTACK_BUILD_ID="${GITHUB_BRANCH} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npm run acceptance -- --browsers browserstack:ie@11.0 browserstack:safari
+npm run acceptance -- --browsers browserstack:ie@11.0 browserstack:safari browserstack:firefox

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -31,4 +31,4 @@ jobs:
       - run: npm run setup-test-site
       - run: npm run build-test-site
       - name: Run Acceptance Tests
-        run: npm run acceptance -- --browsers chrome:headless firefox:headless
+        run: npm run acceptance -- --browsers chrome:headless

--- a/package-lock.json
+++ b/package-lock.json
@@ -13950,9 +13950,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.0.tgz",
-      "integrity": "sha512-gbtedDPfBgG40iLbaRXhqYJycUYqFVZQLIxl1cG5Ez/xZL/47TetSYzPSIixkWa36GKHr9D/o/oSG1vHXF4zTw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "testcafe-browser-provider-browserstack": "^1.13.1",
     "underscore.string": "^3.3.5",
     "urijs": "1.18.12",
-    "yargs": "^17.0"
+    "yargs": "^17.0.1"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -27,10 +27,7 @@ async function runTests (browsers) {
       .src('tests/acceptance/suites/*.js')
       .browsers(browsers)
       .startApp(`npx serve -p ${PORT} test-site/public`, 4000)
-      .run({
-        quarantineMode: true,
-        pageLoadTimeout: 25000
-      });
+      .run({ quarantineMode: true });
     if (result > 0) {
       process.exit(1);
     }

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -23,12 +23,12 @@ runTests(argv.browsers);
 async function runTests (browsers) {
   const testcafe = await createTestCafe();
   try {
-    const result = await testcafe.createRunner()
+    const numberTestsFailed = await testcafe.createRunner()
       .src('tests/acceptance/suites/*.js')
       .browsers(browsers)
       .startApp(`npx serve -p ${PORT} test-site/public`, 4000)
       .run({ quarantineMode: true });
-    if (result > 0) {
+    if (numberTestsFailed > 0) {
       process.exit(1);
     }
   }

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -23,11 +23,17 @@ runTests(argv.browsers);
 async function runTests (browsers) {
   const testcafe = await createTestCafe();
   try {
-    await testcafe.createRunner()
+    const result = await testcafe.createRunner()
       .src('tests/acceptance/suites/*.js')
       .browsers(browsers)
       .startApp(`npx serve -p ${PORT} test-site/public`, 4000)
-      .run({ quarantineMode: true });
+      .run({
+        quarantineMode: true,
+        pageLoadTimeout: 25000
+      });
+    if (result > 0) {
+      process.exit(1);
+    }
   }
   finally {
     await testcafe.close();


### PR DESCRIPTION
Previously, the acceptance test github check would always pass, even
if tests failed. There currently is some issue with how we load mapbox-gl
and firefox:headless, which would cause a "Failed to initialize WebGL."
error, which only occurs for firefox:headless, and not chrome:headless
or regular firefox.

As a short term fix we now run firefox in browserstack.

J=SLAP-1319
TEST=auto

see that the process will exit with 1 (by checking `$?` in terminal) if
I throw an error inside of acceptance/index.js's `try` block, and also
that the github acceptance test check will report a failure

see that the acceptance test check will report a failure if any tests fail, and 
exit with status code 1