### PR TITLE
update acceptance test workflow name

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,4 +1,4 @@
-name: BrowserStack Acceptance Tests
+name: Acceptance Tests
 
 on: push
 


### PR DESCRIPTION
I think initially the workflow only ran tests in browserstack,
but the headless tests don't use browserstack.