### PR TITLE
Do not run the `babel` helper in Development Mode. (#782)

### DIFF
--- a/hbshelpers/babel.js
+++ b/hbshelpers/babel.js
@@ -1,24 +1,31 @@
 const { transformSync } = require('@babel/core');
 
 /**
- * Babel-ifies the enclosed code, using the config below.
+ * Babel-ifies the enclosed code, using the config below. Note that if the 
+ * IS_DEVELOPMENT_PREVIEW environment variable is set to 'true', the enclosed
+ * code is returned verbatim. This is an optimization for the build preview. 
  * 
  * @param {import('handlebars').HelperOptions} options 
  * @returns {string|null}
  */
 module.exports = function babel(options) {
   const srcCode = options.fn(this);
-  return transformSync(srcCode, {
-    compact: true,
-    minified: true,
-    comments: false,
-    sourceType: 'script',
-    presets: ['@babel/preset-env'],
-    plugins: [
-      '@babel/syntax-dynamic-import',
-      '@babel/plugin-transform-arrow-functions',
-      '@babel/plugin-proposal-object-rest-spread',
-      '@babel/plugin-transform-object-assign',
-    ]
-  }).code;
+
+  if (process.env.IS_DEVELOPMENT_PREVIEW === 'true' ) {
+    return srcCode;
+  } else {
+    return transformSync(srcCode, {
+      compact: true,
+      minified: true,
+      comments: false,
+      sourceType: 'script',
+      presets: ['@babel/preset-env'],
+      plugins: [
+        '@babel/syntax-dynamic-import',
+        '@babel/plugin-transform-arrow-functions',
+        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-transform-object-assign',
+      ]
+    }).code;
+  }
 };


### PR DESCRIPTION
This PR adds a check to the `babel` helper to see if we are currently in the Development Mode. If
so, the enclosed source code is not run through Babel, it is returned verbatim. This is a preview
optimization, since the Babel-ification is a relatively slow operation. It's not necessary for
preview either, assuming devs are not previewing their changes in IE11.

There will need to be a corresponding Jambo PR for this as well. Jambo still has a `babel` helper
of its own for legacy reasons.

J=SLAP-1312
TEST=manual

Ensured that when in Development mode, the helper was a simple pass-through. In Production mode,
the enclosed code was Babel-ified.