### PR TITLE
correct orderUrl in menuitem

### DIFF
--- a/cards/menuitem-standard/component.js
+++ b/cards/menuitem-standard/component.js
@@ -37,7 +37,7 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
       CTA1: {
         label: 'Order Now', // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
-        url: profile.orderUrl, // The URL a user will be directed to when clicking
+        url: profile.orderUrl && profile.orderUrl.url, // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),

--- a/cards/multilang-menuitem-standard/component.js
+++ b/cards/multilang-menuitem-standard/component.js
@@ -37,7 +37,7 @@ class multilang_menuitem_standardCardComponent extends BaseCard['multilang-menui
       CTA1: {
         label: {{ translateJS phrase='Order Now' }}, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
-        url: profile.orderUrl, // The URL a user will be directed to when clicking
+        url: profile.orderUrl && profile.orderUrl.url, // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),


### PR DESCRIPTION
updated profile.orderUrl to profile.orderUrl.url, and added the related null check, in menuitem-standard and multilang-menuitem-standard component.

J=SLAP-1329
TEST=manual

launched test site and rendered a menu item where its profile object contains a dummy url, which redirected accordingly.