### PR TITLE
run on-document-load js partial through babel helper

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -78,9 +78,11 @@
         href="{{#unless (isNonRelativeUrl global_config.favicon)}}{{relativePath}}/{{/unless}}{{global_config.favicon}}" />
     {{/if}}
     <script>
+      {{#babel}}
       document.addEventListener('DOMContentLoaded', function () {
         {{> script/on-document-load}}
       });
+      {{/babel}}
     </script>
     <script src="{{relativePath}}/bundle.js" data-webpack-inline></script>
     {{#if global_config.googleAnalyticsId}}


### PR DESCRIPTION
The exit disclaimer code instructions tell people to put
their code in the on-document-load partial. We want this
partial to work in ie11 even if people use newer features.

J=SLAP-1131
TEST=manual

see that I can specify an arrow func in on-doc-load and it
gets transpiled