### PR TITLE
Resolved deprecation warnings from inlineAssetHtmlPlugin and webpack

### DIFF
--- a/static/package.json
+++ b/static/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-webpack": "^4.0.0",
     "html-loader": "^1.1.0",
-    "html-webpack-plugin": "^4.3.0",
+    "html-webpack-plugin": "^5.3.1",
     "jambo": "^1.11.0",
     "jsdom": "^16.4.0",
     "mini-css-extract-plugin": "^1.6.0",
@@ -39,7 +39,7 @@
     "resolve-url-loader": "^3.1.1",
     "sass-loader": "^8.0.2",
     "simple-git": "^2.15.0",
-    "webpack": "^5.4.0",
+    "webpack": "^5.37.1",
     "webpack-cli": "^4.2.0",
     "webpack-merge": "^5.7.3"
   },


### PR DESCRIPTION
update packages

- Updated html-webpack-plugin, used by inlineAssetHtlmPlugin, to be more integrated with webpack v5, which got rid of the deprecated warnings from older v4 with asset and public path.
- Since inlineAssetHTMLPlugin only access compilation.assets without modification, no changes are needed in the js file. Instead, updated webpack version to remove compilation asset warning.

J=SLAP-1307
TEST=manual

Compiled successfully without deprecation warnings. Launched test site and performed searches and navigations without error.