### PR TITLE
fix google streetview man being invisible

### DIFF
--- a/static/scss/answers/templates/vertical-map.scss
+++ b/static/scss/answers/templates/vertical-map.scss
@@ -92,6 +92,10 @@
     min-height: 950px;
     border-left: var(--yxt-border-default);
 
+    img {
+      max-height: none;
+    }
+
     @include bplte(xs)
     {
       display: none;

--- a/test-site/config-overrides/locations_google.json
+++ b/test-site/config-overrides/locations_google.json
@@ -1,0 +1,9 @@
+{
+  "verticalsToConfig": {
+    "KM": {
+      "mapConfig": {
+        "mapProvider": "Google"
+      }
+    }
+  }
+}

--- a/test-site/scripts/create-verticals.js
+++ b/test-site/scripts/create-verticals.js
@@ -20,6 +20,11 @@ const verticalConfiguration = {
     template: 'vertical-map',
     cardName: 'location-standard'
   },
+  locations_google: {
+    verticalKey: 'KM',
+    template: 'vertical-map',
+    cardName: 'location-standard'
+  },
   locations_full_page_map: {
     verticalKey: 'KM',
     template: 'vertical-full-page-map',

--- a/tests/percy/photographer.js
+++ b/tests/percy/photographer.js
@@ -61,6 +61,7 @@ class Photographer {
     await this._pageNavigator.gotoVerticalPage('locations_google', { query: 'virginia' });
     await this._camera.snapshot('vertical-map-search--google');
   }
+
   async _captureVerticalFullPageMapSearch () {
     await this._pageNavigator
       .gotoVerticalPage('locations_full_page_map', { query: '' });

--- a/tests/percy/photographer.js
+++ b/tests/percy/photographer.js
@@ -57,8 +57,10 @@ class Photographer {
   async _captureVerticalMapSearch () {
     await this._pageNavigator.gotoVerticalPage('locations', { query: 'a' });
     await this._camera.snapshot('vertical-map-search');
+
+    await this._pageNavigator.gotoVerticalPage('locations_google', { query: 'virginia' });
+    await this._camera.snapshot('vertical-map-search--google');
   }
-  
   async _captureVerticalFullPageMapSearch () {
     await this._pageNavigator
       .gotoVerticalPage('locations_full_page_map', { query: '' });


### PR DESCRIPTION
Mr. Pegman was being covered up due to our css
reset setting his max-height to 100%, which happened
to be 0 due to how the google maps js works.

This commit adds a css override on top of that.
I wanted to remove the actual line of the css reset
causing this behavior, however it's likely that removing
that line would cause ripples throughout the html-css continuum.

T=409037
TEST=manual, auto

see mr. pegman again
add a percy snapshot for him