### PR TITLE
Dynamic link targets

### DIFF
--- a/cards/event-standard/component.js
+++ b/cards/event-standard/component.js
@@ -12,10 +12,12 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+    
     return {
       title: profile.name, // The header text of the card
       url: profile.website, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       date: Formatter.bigDate(profile),
       subtitle: Formatter.dateRange(profile),
@@ -32,7 +34,7 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
         label: 'RSVP', // The CTA's label
         iconName: 'calendar', // The icon to use for the CTA
         url: profile.ticketUrl || profile.website, // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'RSVP', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -42,7 +44,7 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
         label: 'Directions',
         iconName: 'directions',
         url: Formatter.getDirectionsUrl(profile),
-        target: '_top',
+        target: linkTarget,
         eventType: 'DRIVING_DIRECTIONS',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -12,10 +12,12 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
    * @param {Object} profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.question || profile.name, // The header text of the card
       // subtitle: '', // The sub-header text of the card
-      details: profile.answer ? ANSWERS.formatRichText(profile.answer, "answer", "_top") : null, // The text in the body of the card
+      details: profile.answer ? ANSWERS.formatRichText(profile.answer, "answer", linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // showMoreDetails: {
@@ -29,7 +31,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         // iconName: '', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened. To open in a new tab use '_blank'
+        target: linkTarget, // Where the new URL will be opened. To open in a new tab use '_blank'
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         // Event options for the analytics event fired when this CTA is clicked.
         eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ }),
@@ -40,7 +42,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         // iconName: '',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ }),
         // ariaLabel: '',

--- a/cards/financial-professional-location/component.js
+++ b/cards/financial-professional-location/component.js
@@ -18,12 +18,14 @@ class financial_professional_locationCardComponent extends BaseCard['financial-p
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       showOrdinal: true, // Show the map pin number on the card. Only supported for universal search
       title: profile.name, // The header text of the card
       // subtitle: '', // The sub-header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       address: Formatter.address(profile), // The address for the card
       details: profile.description, // The text in the body of the card
@@ -48,7 +50,7 @@ class financial_professional_locationCardComponent extends BaseCard['financial-p
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -58,7 +60,7 @@ class financial_professional_locationCardComponent extends BaseCard['financial-p
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: ''

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -145,7 +145,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -145,7 +145,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/job-standard/component.js
+++ b/cards/job-standard/component.js
@@ -12,10 +12,12 @@ class job_standardCardComponent extends BaseCard['job-standard'] {
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       // image: '', // The URL of the image to display on the card
       // tagLabel: '', // The label of the displayed image
       titleEventOptions: this.addDefaultEventOptions(),
@@ -33,7 +35,7 @@ class job_standardCardComponent extends BaseCard['job-standard'] {
         label: 'Apply Now', // The CTA's label
         iconName: 'briefcase', // The icon to use for the CTA
         url: profile.applicationUrl || profile.landingPageUrl, // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA

--- a/cards/link-standard/component.js
+++ b/cards/link-standard/component.js
@@ -12,10 +12,12 @@ class link_standardCardComponent extends BaseCard['link-standard'] {
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.htmlTitle, // The header text of the card
       url: profile.link, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       // subtitle: '', // The sub-header text of the card
       // If the card's details are longer than a certain character count, you can truncate the

--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -18,10 +18,12 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
    * @param {Object} profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(), // The event options for title click analytics
       // subtitle: '', // The sub-header text of the card
       hours: Formatter.openStatus(profile),
@@ -38,7 +40,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
         label: 'Call', // The label of the CTA
         iconName: 'phone', // The icon to use for the CTA
         url: Formatter.phoneLink(profile), // The URL a user will be directed to when clicking
-        target: '_top', // If the URL will be opened in a new tab, etc.
+        target: linkTarget, // If the URL will be opened in a new tab, etc.
         eventType: 'TAP_TO_CALL', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(), // The analytics event options for CTA clicks
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -47,7 +49,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
         label: 'Get Directions',
         iconName: 'directions',
         url: Formatter.getDirectionsUrl(profile),
-        target: '_top',
+        target: linkTarget,
         eventType: 'DRIVING_DIRECTIONS',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -47,7 +47,7 @@
   <a class="HitchhikerLocationStandard-phone--mobile js-Hitchhiker-phone" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -47,7 +47,7 @@
   <a class="HitchhikerLocationStandard-phone--mobile js-Hitchhiker-phone" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/menuitem-standard/component.js
+++ b/cards/menuitem-standard/component.js
@@ -12,10 +12,12 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       image: Formatter.image(profile.c_photo).url, // The URL of the image to display on the card
       altText: Formatter.image(profile.c_photo).alternateText,  // The alternate text for the image
       // tagLabel: '', // The label of the displayed image
@@ -38,7 +40,7 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
         label: 'Order Now', // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: profile.orderUrl, // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -48,7 +50,7 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
         label: 'View Menu',
         iconName: 'magnifying_glass',
         url: profile.landingPageUrl,
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/multilang-event-standard/component.js
+++ b/cards/multilang-event-standard/component.js
@@ -12,10 +12,12 @@ class multilang_event_standardCardComponent extends BaseCard['multilang-event-st
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.website, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       date: Formatter.bigDate(profile),
       subtitle: Formatter.dateRange(profile),
@@ -32,7 +34,7 @@ class multilang_event_standardCardComponent extends BaseCard['multilang-event-st
         label: {{ translateJS phrase='RSVP' context='RSVP is a verb' }}, // The CTA's label
         iconName: 'calendar', // The icon to use for the CTA
         url: profile.ticketUrl || profile.website, // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'RSVP', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -42,7 +44,7 @@ class multilang_event_standardCardComponent extends BaseCard['multilang-event-st
         label: {{ translateJS phrase='Directions' }},
         iconName: 'directions',
         url: Formatter.getDirectionsUrl(profile),
-        target: '_top',
+        target: linkTarget,
         eventType: 'DRIVING_DIRECTIONS',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/multilang-faq-accordion/component.js
+++ b/cards/multilang-faq-accordion/component.js
@@ -12,10 +12,12 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
    * @param {Object} profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.question || profile.name, // The header text of the card
       // subtitle: '', // The sub-header text of the card
-      details: profile.answer ? ANSWERS.formatRichText(profile.answer, "answer", "_top") : null, // The text in the body of the card
+      details: profile.answer ? ANSWERS.formatRichText(profile.answer, "answer", linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // showMoreDetails: {
@@ -29,7 +31,7 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         // iconName: '', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened. To open in a new tab use '_blank'
+        target: linkTarget, // Where the new URL will be opened. To open in a new tab use '_blank'
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         // Event options for the analytics event fired when this CTA is clicked.
         eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ }),
@@ -40,7 +42,7 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         // iconName: '',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions({ /* Add additional options here */ }),
         // ariaLabel: '',

--- a/cards/multilang-financial-professional-location/component.js
+++ b/cards/multilang-financial-professional-location/component.js
@@ -18,12 +18,14 @@ class multilang_financial_professional_locationCardComponent extends BaseCard['m
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       showOrdinal: true, // Show the map pin number on the card. Only supported for universal search
       title: profile.name, // The header text of the card
       // subtitle: '', // The sub-header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       address: Formatter.address(profile), // The address for the card
       details: profile.description, // The text in the body of the card
@@ -48,7 +50,7 @@ class multilang_financial_professional_locationCardComponent extends BaseCard['m
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -58,7 +60,7 @@ class multilang_financial_professional_locationCardComponent extends BaseCard['m
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: ''

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -145,7 +145,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -145,7 +145,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-job-standard/component.js
+++ b/cards/multilang-job-standard/component.js
@@ -12,10 +12,12 @@ class multilang_job_standardCardComponent extends BaseCard['multilang-job-standa
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       // image: '', // The URL of the image to display on the card
       // tagLabel: '', // The label of the displayed image
       titleEventOptions: this.addDefaultEventOptions(),
@@ -33,7 +35,7 @@ class multilang_job_standardCardComponent extends BaseCard['multilang-job-standa
         label: {{ translateJS phrase='Apply Now' }}, // The CTA's label
         iconName: 'briefcase', // The icon to use for the CTA
         url: profile.applicationUrl || profile.landingPageUrl, // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA

--- a/cards/multilang-link-standard/component.js
+++ b/cards/multilang-link-standard/component.js
@@ -12,10 +12,12 @@ class multilang_link_standardCardComponent extends BaseCard['multilang-link-stan
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.htmlTitle, // The header text of the card
       url: profile.link, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       // subtitle: '', // The sub-header text of the card
       // If the card's details are longer than a certain character count, you can truncate the

--- a/cards/multilang-location-standard/component.js
+++ b/cards/multilang-location-standard/component.js
@@ -18,10 +18,12 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
    * @param {Object} profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(), // The event options for title click analytics
       // subtitle: '', // The sub-header text of the card
       hours: Formatter.openStatus(profile),
@@ -38,7 +40,7 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
         label: {{ translateJS phrase='Call' context='Call is a verb' }}, // The label of the CTA
         iconName: 'phone', // The icon to use for the CTA
         url: Formatter.phoneLink(profile), // The URL a user will be directed to when clicking
-        target: '_top', // If the URL will be opened in a new tab, etc.
+        target: linkTarget, // If the URL will be opened in a new tab, etc.
         eventType: 'TAP_TO_CALL', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(), // The analytics event options for CTA clicks
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -47,7 +49,7 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
         label: {{ translateJS phrase='Get Directions' }},
         iconName: 'directions',
         url: Formatter.getDirectionsUrl(profile),
-        target: '_top',
+        target: linkTarget,
         eventType: 'DRIVING_DIRECTIONS',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -47,7 +47,7 @@
   <a class="HitchhikerLocationStandard-phone--mobile js-Hitchhiker-phone" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -47,7 +47,7 @@
   <a class="HitchhikerLocationStandard-phone--mobile js-Hitchhiker-phone" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-menuitem-standard/component.js
+++ b/cards/multilang-menuitem-standard/component.js
@@ -12,10 +12,12 @@ class multilang_menuitem_standardCardComponent extends BaseCard['multilang-menui
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       image: Formatter.image(profile.c_photo).url, // The URL of the image to display on the card
       altText: Formatter.image(profile.c_photo).alternateText,  // The alternate text for the image
       // tagLabel: '', // The label of the displayed image
@@ -38,7 +40,7 @@ class multilang_menuitem_standardCardComponent extends BaseCard['multilang-menui
         label: {{ translateJS phrase='Order Now' }}, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: profile.orderUrl, // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -48,7 +50,7 @@ class multilang_menuitem_standardCardComponent extends BaseCard['multilang-menui
         label: {{ translateJS phrase='View Menu' }},
         iconName: 'magnifying_glass',
         url: profile.landingPageUrl,
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/multilang-product-prominentimage-clickable/component.js
+++ b/cards/multilang-product-prominentimage-clickable/component.js
@@ -27,16 +27,18 @@ class multilang_product_prominentimage_clickableCardComponent
       imageUrl = Formatter.image(profile.photoGallery[0]).url;
       alternateText = Formatter.image(profile.photoGallery[0]).alternateText;
     }
+     
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     return {
       title: profile.name, // The header text of the card
       url: cardUrl, // If the card is a clickable link, set URL here
-      target: '_top', // If the card URL should open in a new tab, etc.
+      target: linkTarget, // If the card URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
-      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card, Warning: cannot contain links
+      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card, Warning: cannot contain links
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
     };
   }

--- a/cards/multilang-product-prominentimage/component.js
+++ b/cards/multilang-product-prominentimage/component.js
@@ -18,16 +18,17 @@ class multilang_product_prominentimageCardComponent extends BaseCard['multilang-
       imageUrl = Formatter.image(profile.photoGallery[0]).url;
       alternateText = Formatter.image(profile.photoGallery[0]).alternateText;
     }
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
-      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card
+      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
@@ -42,7 +43,7 @@ class multilang_product_prominentimageCardComponent extends BaseCard['multilang-
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -52,7 +53,7 @@ class multilang_product_prominentimageCardComponent extends BaseCard['multilang-
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/multilang-product-standard/component.js
+++ b/cards/multilang-product-standard/component.js
@@ -18,16 +18,17 @@ class multilang_product_standardCardComponent extends BaseCard['multilang-produc
       imageUrl = Formatter.image(profile.photoGallery[0]).url;
       alternateText = Formatter.image(profile.photoGallery[0]).alternateText;
     }
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       titleEventOptions: this.addDefaultEventOptions(),
       subtitle: Formatter.price(profile.price), // The sub-header text of the card
-      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card
+      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
@@ -41,7 +42,7 @@ class multilang_product_standardCardComponent extends BaseCard['multilang-produc
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -51,7 +52,7 @@ class multilang_product_standardCardComponent extends BaseCard['multilang-produc
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/multilang-professional-location/component.js
+++ b/cards/multilang-professional-location/component.js
@@ -18,12 +18,14 @@ class multilang_professional_locationCardComponent extends BaseCard['multilang-p
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       showOrdinal: true, // Show the map pin number on the card. Only supported for universal search
       title: `${profile.firstName} ${profile.lastName}`, // The header text of the card
       // subtitle: '', // The sub-header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       address: Formatter.address(profile), // The address for the card
       details: profile.description, // The text in the body of the card
@@ -48,7 +50,7 @@ class multilang_professional_locationCardComponent extends BaseCard['multilang-p
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -58,7 +60,7 @@ class multilang_professional_locationCardComponent extends BaseCard['multilang-p
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: ''

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -142,7 +142,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -142,7 +142,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-professional-standard/component.js
+++ b/cards/multilang-professional-standard/component.js
@@ -12,11 +12,13 @@ class multilang_professional_standardCardComponent extends BaseCard['multilang-p
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: `${profile.firstName} ${profile.lastName}`, // The header text of the card
       // subtitle: '', // The sub-header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       details: profile.description, // The text in the body of the card
       // listTitle: '', // Heading of the bulleted list
@@ -38,7 +40,7 @@ class multilang_professional_standardCardComponent extends BaseCard['multilang-p
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -48,7 +50,7 @@ class multilang_professional_standardCardComponent extends BaseCard['multilang-p
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: ''

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -106,7 +106,7 @@
   <a class="HitchhikerProfessionalStandard-phone--mobile" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions="{{json card.phoneEventOptions}}"
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -106,7 +106,7 @@
   <a class="HitchhikerProfessionalStandard-phone--mobile" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions="{{json card.phoneEventOptions}}"
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/multilang-standard/component.js
+++ b/cards/multilang-standard/component.js
@@ -12,10 +12,12 @@ class multilang_standardCardComponent extends BaseCard['multilang-standard'] {
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       // image: '', // The URL of the image to display on the card
       // altText: '', // The alternate text for the image
       titleEventOptions: this.addDefaultEventOptions(),
@@ -33,7 +35,7 @@ class multilang_standardCardComponent extends BaseCard['multilang-standard'] {
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -43,7 +45,7 @@ class multilang_standardCardComponent extends BaseCard['multilang-standard'] {
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/product-prominentimage-clickable/component.js
+++ b/cards/product-prominentimage-clickable/component.js
@@ -27,15 +27,17 @@ class product_prominentimage_clickableCardComponent extends BaseCard['product-pr
       alternateText = Formatter.image(profile.photoGallery[0]).alternateText;
     }
 
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: profile.name, // The header text of the card
       url: cardUrl, // If the card is a clickable link, set URL here
-      target: '_top', // If the card URL should open in a new tab, etc.
+      target: linkTarget, // If the card URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
-      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card, Warning: cannot contain links
+      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card, Warning: cannot contain links
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
     };
   }

--- a/cards/product-prominentimage/component.js
+++ b/cards/product-prominentimage/component.js
@@ -18,16 +18,17 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
       imageUrl = Formatter.image(profile.photoGallery[0]).url;
       alternateText = Formatter.image(profile.photoGallery[0]).alternateText;
     }
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       subtitle: Formatter.price(profile.price), // The sub-header text of the card
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
-      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card
+      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
@@ -42,7 +43,7 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -52,7 +53,7 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -18,16 +18,17 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
       imageUrl = Formatter.image(profile.photoGallery[0]).url;
       alternateText = Formatter.image(profile.photoGallery[0]).alternateText;
     }
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     return {
       title: profile.name, // The header text of the card
       url: profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       image: imageUrl, // The URL of the image to display on the card
       altText: alternateText,  // The alternate text for the image
       titleEventOptions: this.addDefaultEventOptions(),
       subtitle: Formatter.price(profile.price), // The sub-header text of the card
-      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', '_top') : null, // The text in the body of the card
+      details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
@@ -41,7 +42,7 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -51,7 +52,7 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/cards/professional-location/component.js
+++ b/cards/professional-location/component.js
@@ -18,12 +18,14 @@ class professional_locationCardComponent extends BaseCard['professional-location
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       showOrdinal: true, // Show the map pin number on the card. Only supported for universal search
       title: `${profile.firstName} ${profile.lastName}`, // The header text of the card
       // subtitle: '', // The sub-header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       address: Formatter.address(profile), // The address for the card
       details: profile.description, // The text in the body of the card
@@ -48,7 +50,7 @@ class professional_locationCardComponent extends BaseCard['professional-location
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -58,7 +60,7 @@ class professional_locationCardComponent extends BaseCard['professional-location
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: ''

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -142,7 +142,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -142,7 +142,7 @@
     href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions='{{json card.phoneEventOptions}}'
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/professional-standard/component.js
+++ b/cards/professional-standard/component.js
@@ -12,11 +12,13 @@ class professional_standardCardComponent extends BaseCard['professional-standard
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+
     return {
       title: `${profile.firstName} ${profile.lastName}`, // The header text of the card
       // subtitle: '', // The sub-header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
       details: profile.description, // The text in the body of the card
       // listTitle: '', // Heading of the bulleted list
@@ -38,7 +40,7 @@ class professional_standardCardComponent extends BaseCard['professional-standard
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -48,7 +50,7 @@ class professional_standardCardComponent extends BaseCard['professional-standard
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: ''

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -106,7 +106,7 @@
   <a class="HitchhikerProfessionalStandard-phone--mobile" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions="{{json card.phoneEventOptions}}"
-    target="_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
     {{card.phone}}
   </a>
 </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -106,7 +106,7 @@
   <a class="HitchhikerProfessionalStandard-phone--mobile" href="tel:{{card.phone}}"
     data-eventtype="TAP_TO_CALL"
     data-eventoptions="{{json card.phoneEventOptions}}"
-    target={{#if card.target}}"{{card.target}}"{{else}}"_top">
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.phone}}
   </a>
 </div>

--- a/cards/standard/component.js
+++ b/cards/standard/component.js
@@ -12,10 +12,12 @@ class standardCardComponent extends BaseCard['standard'] {
    * @param profile profile of the entity in the card
    */
   dataForRender(profile) {
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+    
     return {
       title: profile.name, // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
-      target: '_top', // If the title's URL should open in a new tab, etc.
+      target: linkTarget, // If the title's URL should open in a new tab, etc.
       // image: '', // The URL of the image to display on the card
       // altText: '', // The alternate text for the image
       titleEventOptions: this.addDefaultEventOptions(),
@@ -33,7 +35,7 @@ class standardCardComponent extends BaseCard['standard'] {
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
-        target: '_top', // Where the new URL will be opened
+        target: linkTarget, // Where the new URL will be opened
         eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
@@ -43,7 +45,7 @@ class standardCardComponent extends BaseCard['standard'] {
         label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
-        target: '_top',
+        target: linkTarget,
         eventType: 'CTA_CLICK',
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '',

--- a/directanswercards/allfields-standard/component.js
+++ b/directanswercards/allfields-standard/component.js
@@ -13,6 +13,7 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
   dataForRender(type, answer, relatedItem) {
     let isArray = Array.isArray(answer.value);
     let value, arrayValue, regularValue, isRichText;
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     switch (answer.fieldType) {
       case 'url':
@@ -121,9 +122,9 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
       case 'rich_text':
         isRichText = true;
         if (isArray) {
-          arrayValue = answer.value.map((value) => ANSWERS.formatRichText(value));
+          arrayValue = answer.value.map((value) => ANSWERS.formatRichText(value, null, linkTarget));
         } else {
-          regularValue = ANSWERS.formatRichText(answer.value);
+          regularValue = ANSWERS.formatRichText(answer.value, null, linkTarget);
         }
         value = isArray ? arrayValue : regularValue;
         break;
@@ -153,7 +154,6 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
     //     break;
     // }
 
-
     return {
       // iconName: '', // Icon that appears on the top left of the direct answer card
       // iconUrl: '', // URL for Icon that appears on the top left of the direct answer card
@@ -167,12 +167,12 @@ class allfields_standardComponent extends BaseDirectAnswerCard['allfields-standa
       viewDetailsEventOptions: this.addDefaultEventOptions({
         ctaLabel: 'VIEW_DETAILS'
       }), // The event options for viewDetails click analytics
-      linkTarget: '_top', // Target for all links in the direct answer
+      linkTarget: linkTarget, // Target for all links in the direct answer
       // CTA: {
       //   label: '', // The CTA's label
       //   iconName: 'chevron', // The icon to use for the CTA
       //   url: '', // The URL a user will be directed to when clicking
-      //   target: '_top', // Where the new URL will be opened
+      //   target: linkTarget, // Where the new URL will be opened
       //   eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
       //   eventOptions: this.addDefaultEventOptions() // The event options for CTA click analytics
       // },

--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -13,6 +13,7 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
    */
   dataForRender(type, answer, relatedItem, snippet) {
     const relatedItemData = relatedItem.data || {};
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     return {
       value: answer.value,
@@ -22,12 +23,12 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
       viewDetailsEventOptions: this.addDefaultEventOptions({
         ctaLabel: 'VIEW_DETAILS'
       }), // The event options for viewDetails click analytics
-      linkTarget: '_top', // Target for all links in the direct answer
+      linkTarget: linkTarget, // Target for all links in the direct answer
       // CTA: {
       //   label: '', // The CTA's label
       //   iconName: 'chevron', // The icon to use for the CTA
       //   url: '', // The URL a user will be directed to when clicking
-      //   target: '_top', // Where the new URL will be opened
+      //   target: linkTarget, // Where the new URL will be opened
       //   eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
       //   eventOptions: this.addDefaultEventOptions() // The event options for CTA click analytics
       // },

--- a/directanswercards/multilang-allfields-standard/component.js
+++ b/directanswercards/multilang-allfields-standard/component.js
@@ -13,6 +13,7 @@ class multilang_allfields_standardComponent extends BaseDirectAnswerCard['multil
   dataForRender(type, answer, relatedItem) {
     let isArray = Array.isArray(answer.value);
     let value, arrayValue, regularValue;
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
 
     switch (answer.fieldType) {
       case 'url':
@@ -120,9 +121,9 @@ class multilang_allfields_standardComponent extends BaseDirectAnswerCard['multil
         break;
       case 'rich_text':
         if (isArray) {
-          arrayValue = answer.value.map((value) => ANSWERS.formatRichText(value));
+          arrayValue = answer.value.map((value) => ANSWERS.formatRichText(value, null, linkTarget));
         } else {
-          regularValue = ANSWERS.formatRichText(answer.value);
+          regularValue = ANSWERS.formatRichText(answer.value, null, linkTarget);
         }
         value = isArray ? arrayValue : regularValue;
       case 'single_line_text':
@@ -151,7 +152,6 @@ class multilang_allfields_standardComponent extends BaseDirectAnswerCard['multil
     //     break;
     // }
 
-
     return {
       // iconName: '', // Icon that appears on the top left of the direct answer card
       // iconUrl: '', // URL for Icon that appears on the top left of the direct answer card
@@ -165,12 +165,12 @@ class multilang_allfields_standardComponent extends BaseDirectAnswerCard['multil
       viewDetailsEventOptions: this.addDefaultEventOptions({
         ctaLabel: 'VIEW_DETAILS'
       }), // The event options for viewDetails click analytics
-      linkTarget: '_top', // Target for all links in the direct answer
+      linkTarget: linkTarget, // Target for all links in the direct answer
       // CTA: {
       //   label: '', // The CTA's label
       //   iconName: 'chevron', // The icon to use for the CTA
       //   url: '', // The URL a user will be directed to when clicking
-      //   target: '_top', // Where the new URL will be opened
+      //   target: linkTarget, // Where the new URL will be opened
       //   eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
       //   eventOptions: this.addDefaultEventOptions() // The event options for CTA click analytics
       // },


### PR DESCRIPTION
Use link targets from runtime config, and default to "_top" if it is not specified

Update all targets which include card title links, CTAS, phone links, RTF links, and direct answer links

J=SLAP-1349
TEST=manual

Load the test site, change the runtime config link target and see different link target behavior. Test title links, CTAs, phone links, RTF links, and direct answer links

