### PR TITLE
Fix iframe page navigation when initializeManually=true

### DIFF
--- a/static/js/answers-experience-frame.js
+++ b/static/js/answers-experience-frame.js
@@ -3,6 +3,7 @@ import { sendToIframe } from './iframe-common';
 export default class AnswersExperienceFrame {
   constructor (runtimeConfig) {
     this.runtimeConfig = runtimeConfig;
+    this._hasManuallyInitialized = false;
 
     runtimeConfig._onUpdate(updatedConfig => {
       sendToIframe({ runtimeConfig: updatedConfig });
@@ -16,6 +17,9 @@ export default class AnswersExperienceFrame {
    * @param {Object} config 
    */
   init (config) {
+    if (this.hasManuallyInitialized()) {
+      return;
+    }
     Object.entries(config).forEach(([key, value]) => {
       this.runtimeConfig.set(key, value);
     });
@@ -23,5 +27,15 @@ export default class AnswersExperienceFrame {
       initAnswersExperience: true,
       runtimeConfig: this.runtimeConfig.getAll()
     });
+    this._hasManuallyInitialized = true;
+  }
+
+  /**
+   * Returns whether or not the init function has been called
+   *
+   * @returns {boolean}
+   */
+  hasManuallyInitialized () {
+    return this._hasManuallyInitialized;
   }
 }

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -11,9 +11,9 @@ const iframeMessageQueue = [];
  * Puts an iframe on the page of an Answers experience and sets up resizing and cross-domain communication
  * 
  * @param {string} domain The location of the answers experience
- * @param {RuntimeConfig} runtimeConfig used for passing runtime config to the iframe
+ * @param {AnswersExperienceFrame} answersExperienceFrame
  */
-export function generateIFrame(domain, runtimeConfig) {
+export function generateIFrame(domain, answersExperienceFrame) {
   var isLocalHost = window.location.host.split(':')[0] === 'localhost';
   var containerEl = document.querySelector('#answers-container');
   var iframe = document.createElement('iframe');
@@ -95,12 +95,13 @@ export function generateIFrame(domain, runtimeConfig) {
     checkOrigin: false,
     onInit: function() {
       iframeInitialized = true;
-      runtimeConfig && iframeMessageQueue.push({
-        runtimeConfig: runtimeConfig.getAll()
+      iframeMessageQueue.push({
+        initAnswersExperience: answersExperienceFrame.hasManuallyInitialized(),
+        runtimeConfig: answersExperienceFrame.runtimeConfig.getAll()
       });
-      iframeMessageQueue.forEach(message => {
-        sendToIframe(message);
-      });
+      while (iframeMessageQueue.length !== 0) {
+        sendToIframe(iframeMessageQueue.shift());
+      }
     },
     onMessage: function(messageData) {
       const message = JSON.parse(messageData.message);

--- a/static/js/iframe-prod.js
+++ b/static/js/iframe-prod.js
@@ -4,7 +4,8 @@ import RuntimeConfig from './runtime-config';
 import AnswersExperienceFrame from './answers-experience-frame';
 
 const runtimeConfig = new RuntimeConfig();
-window.AnswersExperienceFrame = new AnswersExperienceFrame(runtimeConfig);
+const answersExperienceFrame = new AnswersExperienceFrame(runtimeConfig);
+window.AnswersExperienceFrame = answersExperienceFrame;
 
 const prodDomain = new InjectedData().getProdDomain();
-generateIFrame(prodDomain, runtimeConfig);
+generateIFrame(prodDomain, answersExperienceFrame);

--- a/static/js/iframe-staging.js
+++ b/static/js/iframe-staging.js
@@ -4,7 +4,8 @@ import RuntimeConfig from './runtime-config';
 import AnswersExperienceFrame from './answers-experience-frame';
 
 const runtimeConfig = new RuntimeConfig();
-window.AnswersExperienceFrame = new AnswersExperienceFrame(runtimeConfig);
+const answersExperienceFrame = new AnswersExperienceFrame(runtimeConfig);
+window.AnswersExperienceFrame = answersExperienceFrame;
 
 const stagingDomain = new InjectedData().getStagingDomain();
-generateIFrame(stagingDomain, runtimeConfig);
+generateIFrame(stagingDomain, answersExperienceFrame);

--- a/static/js/iframe.js
+++ b/static/js/iframe.js
@@ -4,7 +4,8 @@ import RuntimeConfig from './runtime-config';
 import AnswersExperienceFrame from './answers-experience-frame';
 
 const runtimeConfig = new RuntimeConfig();
-window.AnswersExperienceFrame = new AnswersExperienceFrame(runtimeConfig);
+const answersExperienceFrame = new AnswersExperienceFrame(runtimeConfig);
+window.AnswersExperienceFrame = answersExperienceFrame;
 
 const domain = new InjectedData().getDomain();
-generateIFrame(domain, runtimeConfig);
+generateIFrame(domain, answersExperienceFrame);


### PR DESCRIPTION
Ensure that the page initializes upon page navigation when initializeManually=true

This functionality broke during a recent re-factor when I moved the initAnswersExperience boolean out of the runtimeConfig and into the top-level of the message. Since this data was previously inside the runtimeConfig, it would persist and the experience would receive the message to re-initialize during page navigation. After moving that data outside of the runtimeConfig, the page would no longer receive that message and would fail to re-initialize. To fix this, I ensure that the parent indicates to the iframe that it needs to re-initialize.

J=none
TEST=manual

Load an iframe test site with manuallyInitialize=true, and call the init function. See that the experience now initializes when navigating verticals within the iframe.