### PR TITLE
Reorganize the snapshots

### DIFF
--- a/test-site/config/index.json
+++ b/test-site/config/index.json
@@ -36,7 +36,7 @@
     },
     "KM": {
       "universalSectionTemplate": "grid-two-columns",
-      "cardType": "multilang-financial-professional-location",
+      "cardType": "financial-professional-location",
       "mapConfig": {
         "mapProvider": "Google"
       }

--- a/tests/percy/photographer.js
+++ b/tests/percy/photographer.js
@@ -17,30 +17,30 @@ class Photographer {
   }
 
   async captureSnapshots() {
-    await this._captureHomepage();
     await this._captureUniversalSearch();
     await this._captureVerticalSearch();
     await this._captureVerticalGridSearch();
     await this._captureVerticalMapSearch();
     await this._captureVerticalFullPageMapSearch();
   }
-
-  async _captureHomepage () {
-    await this._pageNavigator.gotoUniversalPage();
-    await this._camera.snapshot('homepage');
-  }
   
   async _captureUniversalSearch () {
-    await this._pageNavigator.gotoUniversalPage({ query: 'a' });
+    await this._pageNavigator.gotoUniversalPage();
     await this._camera.snapshot('universal-search');
+
+    await this._pageNavigator.gotoUniversalPage({ query: 'a' });
+    await this._camera.snapshot('universal-search--no-results');
 
     await this._pageNavigator.gotoUniversalPage({ query: 'office sparce'});
     await this._camera.snapshot('universal-search--spellcheck');
   }
   
   async _captureVerticalSearch () {
-    await this._pageNavigator.gotoVerticalPage('events', { query: 'a' });
+    await this._pageNavigator.gotoVerticalPage('events');
     await this._camera.snapshot('vertical-search');
+
+    await this._pageNavigator.gotoVerticalPage('events', { query: 'a' });
+    await this._camera.snapshot('vertical-search--no-results');
 
     await this._pageNavigator.gotoVerticalPage('events',{ query: 'vrginia' });
     await this._camera.snapshot('vertical-search--spellcheck');


### PR DESCRIPTION
Reorganize snapshots to make them simpler

Rather than a homepage snaphshot, we can just use univeral search instead and take separate snapshots for no results. Also switch to the non-multilang financial-professional-location because we want full test coverage on the non-multilang cards.

J=SLAP-1361
TEST=visual

Check the updated percy snapshots