### PR TITLE
Clear the builtin location filter after 'search this area' searches

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -597,6 +597,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       useFacets: true
     });
     this.updateMostRecentSearchState();
+    this.core.clearStaticFilterNode('SearchThisArea');
   }
 
   /**


### PR DESCRIPTION
Clear the builtin location filter after 'search this area' searches so that the filter isn't applied on subsequent requests

This behavior caused an issue in a techops because builtin location filters override NLP location filters from queries. This would sometimes lead to no results or incorrect results if a user searched for a specific location after dragging the map or clicking the 'search this area' button.

J=TECHOPS-650
TEST=manual

View the network tab and confirm that the builtin filter is only applied during 'search this area' searches. Test that using the search bar to find results near a specific location works. Product also tested this change.