### PR TITLE
Add `postcss` back to `static/package.json`.

### DIFF
--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -4532,6 +4532,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "dev": true
+    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
@@ -4882,6 +4888,25 @@
       "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.0.11.tgz",
       "integrity": "sha512-Vy9eH1dRD9wHjYt/QqXcTz+RnX/zg53xK+KljFSX30PvdDMb2z+c6uDUeblUGqqJgz3QFsdlA0IJvHziPmWtQg==",
       "dev": true
+    },
+    "postcss": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.1.tgz",
+      "integrity": "sha512-9qH0MGjsSm+fjxOi3GnwViL1otfi7qkj+l/WX5gcRGmZNGsIcqc+A5fBkE6PUobEQK4APqYVaES+B3Uti98TCw==",
+      "dev": true,
+      "requires": {
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+          "dev": true
+        }
+      }
     },
     "postcss-modules-extract-imports": {
       "version": "2.0.0",
@@ -5744,6 +5769,12 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true
     },
     "source-map-resolve": {

--- a/static/package.json
+++ b/static/package.json
@@ -33,6 +33,7 @@
     "jambo": "^1.11.0",
     "jsdom": "^16.4.0",
     "mini-css-extract-plugin": "^1.6.0",
+    "postcss": "^8.3.1",
     "resolve-url-loader": "^3.1.1",
     "sass": "^1.34.0",
     "sass-loader": "^8.0.2",


### PR DESCRIPTION
The `InlineAssetHTMLPlugin` still requires `postcss`, so we need to add it back
to the `static/package.json`.

TEST=manual

Verified that I could now build a site after upgrading to `develop`.