### PR TITLE
change webpack devtool to 'eval' from 'source-map'

### DIFF
--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -48,7 +48,6 @@ module.exports = function () {
   ];
 
   const commonConfig = {
-    devtool: 'source-map',
     stats: 'errors-warnings',
     performance: {
       maxAssetSize: 1536000,

--- a/static/webpack/webpack.dev.js
+++ b/static/webpack/webpack.dev.js
@@ -1,6 +1,7 @@
 module.exports = () => {
   return {
     mode: 'development',
+    devtool: 'eval',
     optimization: {
       minimize: false
     }

--- a/static/webpack/webpack.prod.js
+++ b/static/webpack/webpack.prod.js
@@ -4,6 +4,7 @@ module.exports = () => {
   const InlineAssetHtmlPlugin = require('./InlineAssetHtmlPlugin');
   return {
     mode: 'production',
+    devtool: 'source-map',
     plugins: [
       new InlineAssetHtmlPlugin()
     ],

--- a/test-site/public/overlay.html
+++ b/test-site/public/overlay.html
@@ -22,4 +22,4 @@ prompts: [
   { text: "Do you have gift cards?", },
   { text: "I want a snack now", },
 ]
-};</script><script async src="./overlay.js"></script></head><body></body></html>
+};</script><script async="" src="./overlay.js"></script></head><body></body></html>

--- a/test-site/public/overlay.html
+++ b/test-site/public/overlay.html
@@ -22,4 +22,4 @@ prompts: [
   { text: "Do you have gift cards?", },
   { text: "I want a snack now", },
 ]
-};</script><script async="" src="./overlay.js"></script></head><body></body></html>
+};</script><script async src="./overlay.js"></script></head><body></body></html>


### PR DESCRIPTION
See here for a comparison of webpack devtool options
https://webpack.js.org/configuration/devtool/

'source-map' is listed as one of the slowest options
for build, and is recommended for production builds
that want high quality source maps.
Changing this to 'eval' shaves off 0.5s from the build time,
while still providing a source map in dev mode.

J=SLAP-1373
TEST=manual

see ~0.5s shaved off the webpack build time
see that I get source maps in dev mode, and can
add a console log to a formatter and clicking on
the console.log's line number will take me to the
correct source line in dev tools