### PR TITLE
Wrap 'Opens At' text in a call to `_localizer.getTranslation`.

### DIFF
--- a/static/js/hours/open-status/messagefactory.js
+++ b/static/js/hours/open-status/messagefactory.js
@@ -33,7 +33,7 @@ export default class OpenStatusMessageFactory {
               <span class="Hours-statusText Hours-opensToday">
                 <span class="Hours-statusText--current Hours-closed">
                   ${this._localizer.getTranslation(OpenStatusStrings.CLOSED)}
-                </span> · ${OpenStatusStrings.OPENS_AT} <span class="HoursInterval-time Hours-opensAtTime">
+                </span> · ${this._localizer.getTranslation(OpenStatusStrings.OPENS_AT)} <span class="HoursInterval-time Hours-opensAtTime">
                   ${time}
                 </span>
               </span>`;

--- a/tests/static/js/hours/open-status/messagefactory.js
+++ b/tests/static/js/hours/open-status/messagefactory.js
@@ -1,0 +1,50 @@
+import { OpenStatusStrings, OpenStatusTypes } from '../../../../../static/js/hours/open-status/constants';
+import OpenStatusMessageFactory from '../../../../../static/js/hours/open-status/messagefactory';
+
+const localizer = {
+  getLocalizedTime: jest.fn(yextTime => {
+    let time = new Date();
+    time.setHours(Math.floor(yextTime / 100));
+    time.setMinutes(yextTime % 100);
+
+    return time.toLocaleString('en', {
+      hour: 'numeric',
+      minute: 'numeric'
+    });
+  }),
+  getTranslation: jest.fn(str => {
+    const translations = {
+      [OpenStatusStrings.CLOSED]: 'Closed',
+      [OpenStatusStrings.OPEN_24_HOURS]: 'Open 24 Hours',
+      [OpenStatusStrings.OPENS_AT]: 'Opens at',
+      [OpenStatusStrings.OPEN_NOW]: 'Open Now',
+      [OpenStatusStrings.CLOSES_AT]: 'Closes at',
+    }
+    return translations[str];
+  })
+};
+const messageFactory = new OpenStatusMessageFactory(localizer);
+const sanitizeMessage = msg => msg.replace(/\s/g, '');
+
+describe('Open Status messages are generated correctly', () => {
+  it(`generates ${OpenStatusTypes.OPENS_TODAY} message correctly`, () => {
+    const hoursToday = {
+      status: OpenStatusTypes.OPENS_TODAY,
+      nextTime: 1700
+    };
+
+    const expectedMessage = `<span class="Hours-statusText Hours-opensToday">
+      <span class="Hours-statusText--current Hours-closed">
+        Closed
+      </span> · Opens at <span class="HoursInterval-time Hours-opensAtTime">
+        5:00 PM
+      </span>
+    </span>`;
+
+    expect(sanitizeMessage(messageFactory.create(hoursToday)))
+      .toEqual(sanitizeMessage(expectedMessage));
+    expect(localizer.getLocalizedTime.mock.calls[0][0]).toBe(1700);
+    expect(localizer.getTranslation.mock.calls[0][0]).toBe(OpenStatusStrings.CLOSED);
+    expect(localizer.getTranslation.mock.calls[1][0]).toBe(OpenStatusStrings.OPENS_AT);
+  });
+});


### PR DESCRIPTION
In the `open-status/message-factory` we forgot to wrap one of the static strings in a `_localizer.getTranslation` call. This caused the 'Opens At' string to always appear in English.

J=SLAP-1380
TEST=manual, auto

This fix was already verified manually by a HH. I am just adding it to the Theme. I did add a unit test suite for the `message-factory`. The test suite and test I added would have caught this issue and so will ensure there aren't future regressions on this front.