### PR TITLE
Refresh error due to double encoding in verticalUrl

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -115,11 +115,11 @@
     <script>
       {{#babel}}
       function iframeGetSearchParams() {
-        let params = new URLSearchParams(window.location.search);
+        let params = window.location.search.substr(1);
         let verticalUrl = window.location.pathname.substr(1);
         return verticalUrl 
-          ? params.toString() + '&verticalUrl=' + verticalUrl
-          : params.toString();
+          ? params + '&verticalUrl=' + verticalUrl
+          : params;
       }
       let iframeLoadedResolve;
       window.iframeLoaded = new Promise(resolve => {

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -116,11 +116,10 @@
       {{#babel}}
       function iframeGetSearchParams() {
         let params = new URLSearchParams(window.location.search);
-        let verticalUrl = window.location.pathname.substr(1)
-        if (verticalUrl) {
-          params.set('verticalUrl', verticalUrl);
-        }
-        return params.toString();
+        let verticalUrl = window.location.pathname.substr(1);
+        return verticalUrl 
+          ? params.toString() + '&verticalUrl=' + verticalUrl
+          : params.toString();
       }
       let iframeLoadedResolve;
       window.iframeLoaded = new Promise(resolve => {

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -115,8 +115,8 @@
     <script>
       {{#babel}}
       function iframeGetSearchParams() {
-        let params = window.location.search.substr(1);
-        let verticalUrl = window.location.pathname.substr(1);
+        const params = window.location.search.substr(1);
+        const verticalUrl = window.location.pathname.substr(1);
         return verticalUrl 
           ? params + '&verticalUrl=' + verticalUrl
           : params;

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -15,9 +15,6 @@ export function generateIFrame(domain, queryParam, urlParam) {
     var paramString = window.location.search;
     paramString = paramString.substr(1, paramString.length);
 
-    // Decode ASCII forward slash to avod repeat encodings on page refreshes
-    paramString = paramString.replaceAll("%2F", "/");
-
     // Parse the params out of the URL
     var params = paramString.split('&'),
                  verticalUrl;

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -16,7 +16,7 @@ export function generateIFrame(domain, queryParam, urlParam) {
     paramString = paramString.substr(1, paramString.length);
 
     // Decode ASCII forward slash to avod repeat encodings on page refreshes
-    paramString = paramString.replace("%2F", "/");
+    paramString = paramString.replaceAll("%2F", "/");
 
     // Parse the params out of the URL
     var params = paramString.split('&'),


### PR DESCRIPTION
- URLSearchParams set() encoded verticalUrl even though it's already encoded, extracted from window's URL pathname. Changed to appending to the param string

J=SLAP-1376
TEST=manual

Launched multilang site with iframe data-path directed to a page with spaces in its names. Confirmed refresh and back/forward nav works accordingly.