### PR TITLE
Rich text featured snippets

### DIFF
--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -13,8 +13,8 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
    */
   dataForRender(type, answer, relatedItem, snippet) {
     const relatedItemData = relatedItem.data || {};
-    let snippetValue = "";
-    if (answer.fieldType == "rich_text" && snippet) {
+    let snippetValue = '';
+    if (answer.fieldType === "rich_text" && snippet) {
       snippetValue = ANSWERS.formatRichText(snippet.value, 'snippet');
     } else if (snippet) {
       snippetValue = Formatter.highlightField(snippet.value, snippet.matchedSubstrings);

--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -13,14 +13,21 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
    */
   dataForRender(type, answer, relatedItem, snippet) {
     const relatedItemData = relatedItem.data || {};
+    let snippetValue = "";
+    if (answer.fieldType == "rich_text" && snippet) {
+      snippetValue = ANSWERS.formatRichText(snippet.value, 'snippet');
+    } else if (snippet) {
+      snippetValue = Formatter.highlightField(snippet.value, snippet.matchedSubstrings);
+    }
 
     return {
       value: answer.value,
-      snippet: snippet && Formatter.highlightField(snippet.value, snippet.matchedSubstrings), // Text snippet to include alongside the answer
+      snippet: snippetValue, // Text snippet to include alongside the answer
       viewDetailsText: relatedItemData.fieldValues && relatedItemData.fieldValues.name, // Text below the direct answer and snippet
       viewDetailsLink: relatedItemData.website || (relatedItemData.fieldValues && relatedItemData.fieldValues.landingPageUrl), // Link for the "view details" text
       viewDetailsEventOptions: this.addDefaultEventOptions({
-        ctaLabel: 'VIEW_DETAILS'
+        ctaLabel: 'VIEW_DETAILS',
+        fieldName: 'snippet'
       }), // The event options for viewDetails click analytics
       linkTarget: '_top', // Target for all links in the direct answer
       // CTA: {
@@ -29,7 +36,7 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
       //   url: '', // The URL a user will be directed to when clicking
       //   target: '_top', // Where the new URL will be opened
       //   eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
-      //   eventOptions: this.addDefaultEventOptions() // The event options for CTA click analytics
+      //   eventOptions: this.addDefaultEventOptions({ fieldName: 'snippet' }) // The event options for CTA click analytics
       // },
       footerTextOnSubmission: 'Thank you for your feedback!', // Text to display in the footer when a thumbs up/down is clicked
       footerText: 'Was this the answer you were looking for?', // Text to display in the footer

--- a/global_config.json
+++ b/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "develop", // The version of the Answers SDK to use
+  "sdkVersion": "release/v1.9", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/global_config.json
+++ b/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "1.8", // The version of the Answers SDK to use
+  "sdkVersion": "develop", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/hbshelpers/sdkAssetUrl.js
+++ b/hbshelpers/sdkAssetUrl.js
@@ -19,8 +19,7 @@ module.exports = function sdkAssetUrl(branch, locale, assetName) {
     parsedBranch = `v${branch}`;
   } else if (branch === 'develop') {
     parsedBranch = 'canary/latest';
-  }
-  else {
+  } else {
     parsedBranch = `dev/${branch.replace(/\//g, '-')}`;
   }
 

--- a/hbshelpers/sdkAssetUrl.js
+++ b/hbshelpers/sdkAssetUrl.js
@@ -17,7 +17,10 @@ module.exports = function sdkAssetUrl(branch, locale, assetName) {
   let parsedBranch;
   if (isReleasedBranch) {
     parsedBranch = `v${branch}`;
-  } else {
+  } else if (branch === 'develop') {
+    parsedBranch = 'canary/latest';
+  }
+  else {
     parsedBranch = `dev/${branch.replace(/\//g, '-')}`;
   }
 

--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -92,7 +92,7 @@
 
   p
   {
-    margin-bottom: 0;
+    margin-bottom: var(--yxt-base-spacing);
   }
 
   s

--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -135,7 +135,7 @@
     margin-inline-end: var(--yxt-base-spacing);
   }
 
-  h1
+  h1 
   {
     @include header_styling;
     font-size: var(--yxt-font-size-xlg);

--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -95,6 +95,13 @@
     margin-bottom: var(--yxt-base-spacing);
   }
 
+  // If a 'p' is a child a 'li', set margin-bottom to 0 and instead rely on the
+  // margin-bottom of the 'li'
+  li > p
+  {
+    margin-bottom: 0;
+  }
+
   s
   {
     text-decoration: line-through;

--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -135,7 +135,7 @@
     margin-inline-end: var(--yxt-base-spacing);
   }
 
-  h1, .js-yxt-rtfValue > *:first-child // The first item should also get h1 styling
+  h1
   {
     @include header_styling;
     font-size: var(--yxt-font-size-xlg);

--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -95,7 +95,7 @@
     margin-bottom: var(--yxt-base-spacing);
   }
 
-  // If a 'p' is a child a 'li', set margin-bottom to 0 and instead rely on the
+  // If a 'p' is a child of a 'li', set margin-bottom to 0 and instead rely on the
   // margin-bottom of the 'li'
   li > p
   {

--- a/static/scss/answers/common/mixins.scss
+++ b/static/scss/answers/common/mixins.scss
@@ -11,12 +11,12 @@
 
 @mixin list_styling
 {
-  display: flex;
+  display: block;
   flex-direction: column;
   list-style-position: outside;
   margin-left: var(--yxt-base-spacing);
-  margin-top: var(--yxt-base-spacing);
-  margin-bottom: var(--yxt-base-spacing);
+  margin-top: calc(var(--yxt-base-spacing) / 2);
+  margin-bottom: calc(var(--yxt-base-spacing) / 2);
 }
 
 @mixin strong_styling
@@ -36,7 +36,7 @@
   margin-block-end: .33em;
   margin-inline-start: 0px;
   margin-inline-end: 0px;
-  font-weight: bold;
+  font-weight: var(--yxt-font-weight-semibold);
 }
 
 @mixin rich_text_formatting
@@ -55,7 +55,7 @@
 
   li
   {
-    margin-bottom: 0;
+    margin-bottom: calc(var(--yxt-base-spacing) / 2);
     margin-left: var(--yxt-base-spacing);
   }
 
@@ -92,7 +92,7 @@
 
   p
   {
-    margin-bottom: var(--yxt-base-spacing);
+    margin-bottom: 0;
   }
 
   s
@@ -135,7 +135,7 @@
     margin-inline-end: var(--yxt-base-spacing);
   }
 
-  h1 
+  h1, .js-yxt-rtfValue > *:first-child // The first item should also get h1 styling
   {
     @include header_styling;
     font-size: var(--yxt-font-size-xlg);
@@ -169,6 +169,10 @@
   {
     @include header_styling;
     font-size: var(--yxt-font-size-xs);
+  }
+
+  img {
+    margin-top: calc(var(--yxt-base-spacing) / 2);
   }
 }
 

--- a/static/scss/answers/directanswercards/documentsearch-standard.scss
+++ b/static/scss/answers/directanswercards/documentsearch-standard.scss
@@ -47,16 +47,21 @@
     justify-content: space-between;
 
     padding-top: calc(var(--yxt-base-spacing) * 0.7);
-    padding-bottom: var(--yxt-base-spacing);
+    padding-bottom: calc(var(--yxt-base-spacing) * 0.7);
     padding-left: var(--yxt-base-spacing);
     padding-right: var(--yxt-base-spacing);
 
     @include Text(
-      $size: var(--yxt-direct-answer-footer-font-size),
+      $size: var(--yxt-font-size-md-lg),
       $line-height: var(--yxt-direct-answer-footer-line-height),
-      $weight: var(--yxt-direct-answer-footer-font-weight),
-      $color: var(--yxt-direct-answer-footer-color)
+      $weight: var(--yxt-font-weight-light),
+      $color: var(--yxt-color-text-primary)
     );
+  } 
+
+  &-snippet
+  {
+    @include rich_text_formatting;
   }
 
   &-cta
@@ -153,6 +158,8 @@
 
   &-viewMoreWrapper
   {
+    font-size: var(--yxt-direct-answer-view-details-font-size);
+
     &:not(:first-child)
     {
       margin-top: calc(var(--yxt-base-spacing) / 2);

--- a/static/scss/answers/directanswercards/documentsearch-standard.scss
+++ b/static/scss/answers/directanswercards/documentsearch-standard.scss
@@ -62,6 +62,12 @@
   &-snippet
   {
     @include rich_text_formatting;
+
+    .js-yxt-rtfValue > *:first-child // The first RTF item should also get h1 styling
+    {
+      @include header_styling;
+      font-size: var(--yxt-font-size-xlg);
+    }
   }
 
   &-cta

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "1.8", // The version of the Answers SDK to use
+  "sdkVersion": "develop", // The version of the Answers SDK to use
   "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -1,5 +1,6 @@
 {
   "sdkVersion": "release/v1.9", // The version of the Answers SDK to use
+  "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
   "logo": "", // The link to the logo for open graph meta tag - og:image.

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -1,6 +1,5 @@
 {
-  "sdkVersion": "develop", // The version of the Answers SDK to use
-  "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
+  "sdkVersion": "release/v1.9", // The version of the Answers SDK to use
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
   "logo": "", // The link to the logo for open graph meta tag - og:image.

--- a/test-site/public/overlay.html
+++ b/test-site/public/overlay.html
@@ -22,4 +22,4 @@ prompts: [
   { text: "Do you have gift cards?", },
   { text: "I want a snack now", },
 ]
-};</script><script async src="./overlay.js"></script></head><body></body></html>
+};</script><script async="" src="./overlay.js"></script></head><body></body></html>

--- a/tests/percy/photographer.js
+++ b/tests/percy/photographer.js
@@ -121,6 +121,12 @@ class Photographer {
 
     await this._pageNavigator.gotoUniversalPage({ query: 'where was joe exotic born?' });
     await this._camera.snapshot('documentsearch-direct-answer')
+
+    await this._pageNavigator.gotoUniversalPage({ query: 'how to get rich text' });
+    await this._camera.snapshot('documentsearch-rich-text-direct-answer')
+
+    await this._pageNavigator.gotoUniversalPage({ query: 'who is howard?' });
+    await this._camera.snapshot('documentsearch-rich-text-picture-direct-answer')
   }
 }
 


### PR DESCRIPTION
Support rich text featured snippets

Note: This PR leverages the current develop version of the search ui. Before actual release, this should be updated to point to v1.9.

This PR
- Adds a fieldName: 'snippet' parameter to analytics events on the direct answer card
- Tweaks the RTF styling to match the updated mocks
- Updates the direct answer card styling in general

This PR also bumps the default font size of regular direct answers so that it matches this new font size of featured snippet direct answers. This was approved by product.

J=SLAP-1384
TEST=manual

Add data to the knowledge graph and test various featured snippet queries. Also test on the yext help site which has rtf featured snippets enabled.