### PR TITLE
RuntimeConfig Setters for analyticsEventsEnabled

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -46,6 +46,8 @@
         }
       },
       onReady: () => {
+        window.AnswersInitialized.resolve();
+
         {{> @partial-block }}
 
         {{> script/on-ready}}

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -82,6 +82,8 @@
           return ANSWERS.renderer.SafeString({{{stringifyPartial (read 'static/assets/images/close-card') }}});
         });
       }
+    }).catch(err => {
+      window.AnswersExperience.AnswersInitializedPromise.reject('Answers failed to initialized.');
     });
     {{> script/after-init}}
   }

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -46,7 +46,7 @@
         }
       },
       onReady: () => {
-        window.AnswersInitialized.resolve();
+        window.AnswersExperience.AnswersInitializedPromise.resolve();
 
         {{> @partial-block }}
 

--- a/static/js/HitchhikerJS.js
+++ b/static/js/HitchhikerJS.js
@@ -34,12 +34,6 @@ export { ManualInitializer };
 import RuntimeConfigReceiver from './runtime-config-receiver';
 export { RuntimeConfigReceiver };
 
-import DeferredPromise from './deferred-promise';
-window.AnswersInitialized = new DeferredPromise((resolve, reject) => {
-  setTimeout(reject, 5000, 
-    'Timed out waiting on Answers initialization. Unable to update Answer\'s configuration(s).');
-});
-
 import RuntimeConfig from './runtime-config';
 import AnswersExperience from './answers-experience';
 const runtimeConfig = new RuntimeConfig();

--- a/static/js/HitchhikerJS.js
+++ b/static/js/HitchhikerJS.js
@@ -34,9 +34,7 @@ export { ManualInitializer };
 import RuntimeConfigReceiver from './runtime-config-receiver';
 export { RuntimeConfigReceiver };
 
-import RuntimeConfig from './runtime-config';
-window.AnswersExperience = {
-  runtimeConfig: new RuntimeConfig()
-};
+import AnswersExperience from './answers-experience';
+window.AnswersExperience = AnswersExperience;
 
 export * from './video-apis';

--- a/static/js/HitchhikerJS.js
+++ b/static/js/HitchhikerJS.js
@@ -37,7 +37,6 @@ export { RuntimeConfigReceiver };
 import RuntimeConfig from './runtime-config';
 import AnswersExperience from './answers-experience';
 const runtimeConfig = new RuntimeConfig();
-const answersExperience = new AnswersExperience(runtimeConfig);
-window.AnswersExperience = answersExperience;
+window.AnswersExperience = new AnswersExperience(runtimeConfig);
 
 export * from './video-apis';

--- a/static/js/HitchhikerJS.js
+++ b/static/js/HitchhikerJS.js
@@ -34,7 +34,16 @@ export { ManualInitializer };
 import RuntimeConfigReceiver from './runtime-config-receiver';
 export { RuntimeConfigReceiver };
 
+import DeferredPromise from './deferred-promise';
+window.AnswersInitialized = new DeferredPromise((resolve, reject) => {
+  setTimeout(reject, 5000, 
+    'Timed out waiting on Answers initialization. Unable to update Answer\'s configuration(s).');
+});
+
+import RuntimeConfig from './runtime-config';
 import AnswersExperience from './answers-experience';
-window.AnswersExperience = AnswersExperience;
+const runtimeConfig = new RuntimeConfig();
+const answersExperience = new AnswersExperience(runtimeConfig);
+window.AnswersExperience = answersExperience;
 
 export * from './video-apis';

--- a/static/js/answers-experience-frame.js
+++ b/static/js/answers-experience-frame.js
@@ -4,9 +4,11 @@ export default class AnswersExperienceFrame {
   constructor (runtimeConfig) {
     this.runtimeConfig = runtimeConfig;
     this._hasManuallyInitialized = false;
-
-    runtimeConfig._onUpdate(updatedConfig => {
-      sendToIframe({ runtimeConfig: updatedConfig });
+    
+    Object.entries(runtimeConfig.getAll()).forEach(([key, value]) => {
+      runtimeConfig._onUpdate(key, configOption => {
+        sendToIframe({ runtimeConfig: {key: configOption} });
+      });
     });
   }
 

--- a/static/js/answers-experience-frame.js
+++ b/static/js/answers-experience-frame.js
@@ -6,7 +6,6 @@ export default class AnswersExperienceFrame {
     this._hasManuallyInitialized = false;
 
     runtimeConfig.registerListener({
-      eventType: 'update',
       callback: updatedConfig => {
         sendToIframe({ runtimeConfig: updatedConfig });
       }

--- a/static/js/answers-experience-frame.js
+++ b/static/js/answers-experience-frame.js
@@ -4,11 +4,12 @@ export default class AnswersExperienceFrame {
   constructor (runtimeConfig) {
     this.runtimeConfig = runtimeConfig;
     this._hasManuallyInitialized = false;
-    
-    Object.entries(runtimeConfig.getAll()).forEach(([key, value]) => {
-      runtimeConfig._onUpdate(key, configOption => {
-        sendToIframe({ runtimeConfig: {key: configOption} });
-      });
+
+    runtimeConfig.registerListener({
+      eventType: 'update',
+      callback: updatedConfig => {
+        sendToIframe({ runtimeConfig: updatedConfig });
+      }
     });
   }
 

--- a/static/js/answers-experience.js
+++ b/static/js/answers-experience.js
@@ -6,7 +6,6 @@ export default class AnswersExperience {
     this.AnswersInitializedPromise = new DeferredPromise();
 
     runtimeConfig.registerListener({
-      eventType: 'update',
       key: 'analyticsEventsEnabled',
       callback: updatedConfigOption => {
         this.AnswersInitializedPromise

--- a/static/js/answers-experience.js
+++ b/static/js/answers-experience.js
@@ -1,0 +1,51 @@
+import RuntimeConfig from './runtime-config';
+
+/**
+ * Check if Answers is initialized in window in a timed loop
+ * 
+ * @returns {Promise} When resolved, Answers exists in window
+ */
+function waitForAnswerInit() {
+  return new Promise((resolve, reject) => {
+    let timeElapsed = 0;
+    const duration = 5000;
+    const intervalLength = 10;
+
+    const interval = setInterval(() => {
+      timeElapsed += intervalLength;
+      if (window.hasOwnProperty('ANSWERS')) {
+        clearInterval(interval);
+        resolve();
+      }
+      if (timeElapsed > duration) {
+        clearInterval(interval);
+        reject('Timed out waiting on Answers initialization. Unable to update Answer\'s configuration(s).');
+      }
+    }, intervalLength);
+  });
+}
+
+/**
+ * Update Answer's runtime configurations
+ * 
+ * @param {Object} updatedConfig An object representation of the runtime config
+ */
+function updateAnswersConfig(updatedConfig) {
+  if (updatedConfig['analyticsEventsEnabled']) {
+    ANSWERS.setAnalyticsOptIn(updatedConfig['analyticsEventsEnabled'] === 'true');
+  }
+}
+
+const runtimeConfig = new RuntimeConfig();
+
+runtimeConfig._onUpdate(updatedConfig => {
+  waitForAnswerInit()
+    .then(() => updateAnswersConfig(updatedConfig))
+    .catch(err => console.warn(err));
+});
+
+const AnswersExperience = { 
+  runtimeConfig: runtimeConfig
+};
+
+export default AnswersExperience;

--- a/static/js/answers-experience.js
+++ b/static/js/answers-experience.js
@@ -5,7 +5,7 @@ import RuntimeConfig from './runtime-config';
  * 
  * @returns {Promise} When resolved, Answers exists in window
  */
-function waitForAnswerInit() {
+function waitForAnswersInit() {
   return new Promise((resolve, reject) => {
     let timeElapsed = 0;
     const duration = 5000;
@@ -39,7 +39,7 @@ function updateAnswersConfig(updatedConfig) {
 const runtimeConfig = new RuntimeConfig();
 
 runtimeConfig._onUpdate(updatedConfig => {
-  waitForAnswerInit()
+  waitForAnswersInit()
     .then(() => updateAnswersConfig(updatedConfig))
     .catch(err => console.warn(err));
 });

--- a/static/js/answers-experience.js
+++ b/static/js/answers-experience.js
@@ -1,51 +1,22 @@
-import RuntimeConfig from './runtime-config';
+export default class AnswersExperience {
+  constructor (runtimeConfig) {
+    this.runtimeConfig = runtimeConfig;
 
-/**
- * Check if Answers is initialized in window in a timed loop
- * 
- * @returns {Promise} When resolved, Answers exists in window
- */
-function waitForAnswersInit() {
-  return new Promise((resolve, reject) => {
-    let timeElapsed = 0;
-    const duration = 5000;
-    const intervalLength = 10;
+    runtimeConfig._onUpdate(updatedConfig => {
+      window.AnswersInitialized
+        .then(() => updateAnswersConfig(updatedConfig))
+        .catch(err => console.warn(err));
+    });
 
-    const interval = setInterval(() => {
-      timeElapsed += intervalLength;
-      if (window.hasOwnProperty('ANSWERS')) {
-        clearInterval(interval);
-        resolve();
+		/**
+     * Update Answer's runtime configurations
+     * 
+     * @param {Object} updatedConfig An object representation of the runtime config
+     */
+    function updateAnswersConfig(updatedConfig) {
+      if (updatedConfig['analyticsEventsEnabled']) {
+        ANSWERS.setAnalyticsOptIn(updatedConfig['analyticsEventsEnabled'] === 'true');
       }
-      if (timeElapsed > duration) {
-        clearInterval(interval);
-        reject('Timed out waiting on Answers initialization. Unable to update Answer\'s configuration(s).');
-      }
-    }, intervalLength);
-  });
-}
-
-/**
- * Update Answer's runtime configurations
- * 
- * @param {Object} updatedConfig An object representation of the runtime config
- */
-function updateAnswersConfig(updatedConfig) {
-  if (updatedConfig['analyticsEventsEnabled']) {
-    ANSWERS.setAnalyticsOptIn(updatedConfig['analyticsEventsEnabled'] === 'true');
+    }
   }
 }
-
-const runtimeConfig = new RuntimeConfig();
-
-runtimeConfig._onUpdate(updatedConfig => {
-  waitForAnswersInit()
-    .then(() => updateAnswersConfig(updatedConfig))
-    .catch(err => console.warn(err));
-});
-
-const AnswersExperience = { 
-  runtimeConfig: runtimeConfig
-};
-
-export default AnswersExperience;

--- a/static/js/answers-experience.js
+++ b/static/js/answers-experience.js
@@ -3,16 +3,16 @@ import DeferredPromise from './deferred-promise';
 export default class AnswersExperience {
   constructor (runtimeConfig) {
     this.runtimeConfig = runtimeConfig;
+    this.AnswersInitializedPromise = new DeferredPromise();
 
-    this.AnswersInitializedPromise = new DeferredPromise((resolve, reject) => {
-      setTimeout(reject, 5000, 
-        'Timed out waiting on Answers initialization. Unable to update Answer\'s configuration(s).');
-    });
-
-    runtimeConfig._onUpdate('analyticsEventsEnabled', updatedConfigOption => {
-      this.AnswersInitializedPromise
-        .then(() => this.updateAnswersAnalyticsEventsConfig(updatedConfigOption))
-        .catch(err => console.warn(err));
+    runtimeConfig.registerListener({
+      eventType: 'update',
+      key: 'analyticsEventsEnabled',
+      callback: updatedConfigOption => {
+        this.AnswersInitializedPromise
+          .then(() => this.updateAnswersAnalyticsEventsConfig(updatedConfigOption))
+          .catch(err => console.warn(err));
+      }
     });
   }
 

--- a/static/js/deferred-promise.js
+++ b/static/js/deferred-promise.js
@@ -10,7 +10,7 @@ export default class DeferredPromise {
       this.resolve = resolve;
       this.reject = reject;
       
-      if(stateHandler) {
+      if (stateHandler) {
         stateHandler(resolve, reject);
       }
     });

--- a/static/js/deferred-promise.js
+++ b/static/js/deferred-promise.js
@@ -1,0 +1,15 @@
+export default class DeferredPromise {
+  constructor(handler = null) {
+    this._promise = new Promise((resolve, reject)=> {
+      this.resolve = resolve
+      this.reject = reject
+      
+      if(handler) {
+        handler(resolve, reject);
+      }
+    });
+    
+    this.then = this._promise.then.bind(this._promise);
+    this.catch = this._promise.catch.bind(this._promise);
+  }
+}

--- a/static/js/deferred-promise.js
+++ b/static/js/deferred-promise.js
@@ -1,15 +1,22 @@
+/**
+ * a Promise wrapper class that exposes resolve() and reject() so its state can
+ * be defer and settle outside of a promise constructor. It carries over some
+ * main methods of Promise, which invoke the corresponding methods bound to the
+ * inner promise created in this class.
+ */
 export default class DeferredPromise {
-  constructor(handler = null) {
-    this._promise = new Promise((resolve, reject)=> {
-      this.resolve = resolve
-      this.reject = reject
+  constructor(stateHandler = null) {
+    this._promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
       
-      if(handler) {
-        handler(resolve, reject);
+      if(stateHandler) {
+        stateHandler(resolve, reject);
       }
     });
     
-    this.then = this._promise.then.bind(this._promise);
-    this.catch = this._promise.catch.bind(this._promise);
+    this.then = Promise.prototype.then.bind(this._promise);
+    this.catch = Promise.prototype.catch.bind(this._promise);
+    this.finally = Promise.prototype.finally.bind(this._promise);
   }
 }

--- a/static/js/runtime-config-receiver.js
+++ b/static/js/runtime-config-receiver.js
@@ -4,7 +4,7 @@
  export default class RuntimeConfigReceiver {
   /**
    * Updates the experience's runtime config to include the data provided by the received config
-   * @param {Object} config An object representation of the runtime config.
+   * @param {Object} config An object representation (partial or entirety) of the runtime config.
    *                        (Not the data model with getters and setters)
    */
   static handle (config) {

--- a/static/js/runtime-config.js
+++ b/static/js/runtime-config.js
@@ -4,7 +4,7 @@
 export default class RuntimeConfig {
   constructor (initialConfig = {}) {
     this._data = { ...initialConfig };
-    this._onUpdateListener = () => {};
+    this._onUpdateListeners = {};
   }
 
   /**
@@ -32,15 +32,19 @@ export default class RuntimeConfig {
   set (key, value) {
     this._validateSet(key, value);
     this._data[key] = value;
-    this._onUpdateListener(this.getAll());
+    if(!this._onUpdateListeners[key]) {
+      this._onUpdate(key, () => {});
+    }
+    this._onUpdateListeners[key](value);
   }
 
   /**
-   * A function which is called any time the RuntimeConfig is updated
+   * A function which is called any time a specific key in RuntimeConfig is updated
+   * @param {string} key
    * @param {Function} cb 
    */
-  _onUpdate (cb) {
-    this._onUpdateListener = cb;
+  _onUpdate (key, cb) {
+    this._onUpdateListeners[key] = cb;
   }
 
   _validateSet (key, value) {

--- a/static/js/runtime-config.js
+++ b/static/js/runtime-config.js
@@ -32,7 +32,7 @@ export default class RuntimeConfig {
   set (key, value) {
     this._validateSet(key, value);
     this._data[key] = value;
-    if(!this._onUpdateListeners[key]) {
+    if (!this._onUpdateListeners[key]) {
       this._onUpdate(key, () => {});
     }
     this._onUpdateListeners[key](value);

--- a/static/js/runtime-config.js
+++ b/static/js/runtime-config.js
@@ -6,13 +6,13 @@ export default class RuntimeConfig {
     this._data = { ...initialConfig };
     
     /**
-     * Hold listeners that applies to all keys
+     * Listeners that apply to all keys
      * @type {Object[]}
      */
     this._generalListeners = [];
     
     /**
-     * Hold listeners that applies to specific keys
+     * Listeners that apply to specific keys
      * @type {Map<string:Object[]>}
      */
     this._keySpecificListeners = {};

--- a/tests/static/js/runtime-config.js
+++ b/tests/static/js/runtime-config.js
@@ -20,10 +20,25 @@ describe('Runtime config data model functionality', () => {
     expect(actualData).toEqual(expectedData);
   });
 
-  it('The _onUpdate callback is called when data is set', () => {
+  it('generic listener callback is called when data is set', () => {
     const runtimeConfig = new RuntimeConfig();
     const mockCallback = jest.fn();
-    runtimeConfig._onUpdate(mockCallback);
+    runtimeConfig.registerListener({
+      eventType: 'update',
+      callback: mockCallback});
+    runtimeConfig.set('linkTarget', '_blank');
+    expect(mockCallback).toHaveBeenCalled();
+  });
+
+  it('key-specific listener callback is called only when the corresponding key\'s data is set', () => {
+    const runtimeConfig = new RuntimeConfig();
+    const mockCallback = jest.fn();
+    runtimeConfig.registerListener({
+      eventType: 'update',
+      key: 'linkTarget',
+      callback: mockCallback});
+    runtimeConfig.set('someConfig', 'someValue');
+    expect(mockCallback).not.toHaveBeenCalled();
     runtimeConfig.set('linkTarget', '_blank');
     expect(mockCallback).toHaveBeenCalled();
   });


### PR DESCRIPTION
Theme's runtime config setters for analyticsEventsEnabled update SDK's config accordingly after Answers is initialized

- update runtimeConfig to support general and key-specific listener with event type
- changed AnswersExperience to a class
- provide runtimeConfig a key-specific listener to handle updates on 'analyticsEventsEnabled' from AnswersExperience - a deferred promise is placed in the window (from html.hbs), resolve after Answers is initialized (wait duration of 5 secs) and call SDK's analytics setter, reject if Answers failed to initialize.
- config updates from AnswersExperienceFrame send message to iframe and handle by RuntimeConfigReceiver. Since this invokes runtimeConfig.set from AnswersExperience, the same key-specific listener will be used.

J=SLAP-1393
TEST=manual & auto

Launched hitchhiker theme test site, called runtimeConfig.set for analyticsEventsEnabled in iframe and non-iframe page. Set analyticsEventsEnabled to false/true, and see that console.log from SDK's analytics setter printed the correct result. Click thumbs up on direct answer card, and confirm a network call is made to realtimeanalytics when set to true and no feedback got send when set to false.
Update and test general/key-specific listener in jest