### PR TITLE
Remove _fireOnDomLoad

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -6,15 +6,6 @@
       if (window.name == 'overlay') {
         window.isOverlay = true;
       }
-      function onDocumentReady(cb) {
-        if (document.readyState === 'complete' 
-          || document.readyState === 'loaded'
-          || document.readyState === 'interactive') {
-          cb.bind(this)();
-        } else {
-          document.addEventListener('DOMContentLoaded', cb.bind(this));
-        }
-      }
       {{/babel}}
     </script>
     {{> layouts/headincludes }}
@@ -88,7 +79,7 @@
     {{/if}}
     <script>
       {{#babel}}
-        onDocumentReady(() => {
+        document.addEventListener('DOMContentLoaded', () => {
           {{> script/on-document-load}}
           {{#if global_config.initializeManually}}
             new HitchhikerJS.ManualInitializer(initAnswers).setup();
@@ -138,18 +129,18 @@
       window.iframeLoaded = new Promise(resolve => {
         iframeLoadedResolve = resolve;
       });
-     
-      window.iFrameResizer =  {
-        onReady: function() {
-          window.parentIFrame.sendMessage(JSON.stringify({
-            params: iframeGetSearchParams(),
-            replaceHistory: true,
-            pageTitle: document.title
-          }));
-          iframeLoadedResolve();
-        },
-        onMessage: (message) => {
-          onDocumentReady(() => {
+
+      document.addEventListener('DOMContentLoaded', () => {
+        window.iFrameResizer =  {
+          onReady: function() {
+            window.parentIFrame.sendMessage(JSON.stringify({
+              params: iframeGetSearchParams(),
+              replaceHistory: true,
+              pageTitle: document.title
+            }));
+            iframeLoadedResolve();
+          },
+          onMessage: (message) => {
             if (message.initAnswersExperience) {
               window.AnswersExperience.init(message.runtimeConfig);
             } else if (message.runtimeConfig) {
@@ -157,9 +148,9 @@
             } else if (window.isOverlay) {
               window.Overlay.onMessage(message);
             }
-          });
-        }
-      };
+          }
+        };
+      });
     {{/babel}}
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -6,6 +6,14 @@
       if (window.name == 'overlay') {
         window.isOverlay = true;
       }
+      function onDocumentReady(cb) {
+        if (document.readyState === "complete"
+          || document.readyState === "loaded") {
+          cb.bind(this)();
+        } else {
+          document.addEventListener('DOMContentLoaded', cb.bind(this));
+        }
+      }
       {{/babel}}
     </script>
     {{> layouts/headincludes }}
@@ -79,7 +87,7 @@
     {{/if}}
     <script>
       {{#babel}}
-        document.addEventListener('DOMContentLoaded', () => {
+        onDocumentReady(() => {
           {{> script/on-document-load}}
           {{#if global_config.initializeManually}}
             new HitchhikerJS.ManualInitializer(initAnswers).setup();
@@ -140,13 +148,15 @@
           iframeLoadedResolve();
         },
         onMessage: (message) => {
-          if (message.initAnswersExperience) {
-            window.AnswersExperience.init(message.runtimeConfig);
-          } else if (message.runtimeConfig) {
-            HitchhikerJS.RuntimeConfigReceiver.handle(message.runtimeConfig);
-          } else if (window.isOverlay) {
-            window.Overlay.onMessage(message);
-          }
+          onDocumentReady(() => {
+            if (message.initAnswersExperience) {
+              window.AnswersExperience.init(message.runtimeConfig);
+            } else if (message.runtimeConfig) {
+              HitchhikerJS.RuntimeConfigReceiver.handle(message.runtimeConfig);
+            } else if (window.isOverlay) {
+              window.Overlay.onMessage(message);
+            }
+          });
         }
       };
     {{/babel}}

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -129,7 +129,7 @@
       window.iframeLoaded = new Promise(resolve => {
         iframeLoadedResolve = resolve;
       });
-    
+     
       window.iFrameResizer =  {
         onReady: function() {
           window.parentIFrame.sendMessage(JSON.stringify({

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -130,27 +130,25 @@
         iframeLoadedResolve = resolve;
       });
 
-      document.addEventListener('DOMContentLoaded', () => {
-        window.iFrameResizer =  {
-          onReady: function() {
-            window.parentIFrame.sendMessage(JSON.stringify({
-              params: iframeGetSearchParams(),
-              replaceHistory: true,
-              pageTitle: document.title
-            }));
-            iframeLoadedResolve();
-          },
-          onMessage: (message) => {
-            if (message.initAnswersExperience) {
-              window.AnswersExperience.init(message.runtimeConfig);
-            } else if (message.runtimeConfig) {
-              HitchhikerJS.RuntimeConfigReceiver.handle(message.runtimeConfig);
-            } else if (window.isOverlay) {
-              window.Overlay.onMessage(message);
-            }
+      window.iFrameResizer =  {
+        onReady: function() {
+          window.parentIFrame.sendMessage(JSON.stringify({
+            params: iframeGetSearchParams(),
+            replaceHistory: true,
+            pageTitle: document.title
+          }));
+          iframeLoadedResolve();
+        },
+        onMessage: (message) => {
+          if (message.initAnswersExperience) {
+            window.AnswersExperience.init(message.runtimeConfig);
+          } else if (message.runtimeConfig) {
+            HitchhikerJS.RuntimeConfigReceiver.handle(message.runtimeConfig);
+          } else if (window.isOverlay) {
+            window.Overlay.onMessage(message);
           }
-        };
-      });
+        }
+      }
     {{/babel}}
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -129,7 +129,7 @@
       window.iframeLoaded = new Promise(resolve => {
         iframeLoadedResolve = resolve;
       });
-
+    
       window.iFrameResizer =  {
         onReady: function() {
           window.parentIFrame.sendMessage(JSON.stringify({
@@ -148,7 +148,7 @@
             window.Overlay.onMessage(message);
           }
         }
-      }
+      };
     {{/babel}}
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -7,8 +7,7 @@
         window.isOverlay = true;
       }
       function onDocumentReady(cb) {
-        if (document.readyState === "complete"
-          || document.readyState === "loaded") {
+        if (document.readyState === 'complete' || document.readyState === 'loaded') {
           cb.bind(this)();
         } else {
           document.addEventListener('DOMContentLoaded', cb.bind(this));

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -7,7 +7,9 @@
         window.isOverlay = true;
       }
       function onDocumentReady(cb) {
-        if (document.readyState === 'complete' || document.readyState === 'loaded') {
+        if (document.readyState === 'complete' 
+          || document.readyState === 'loaded'
+          || document.readyState === 'interactive') {
           cb.bind(this)();
         } else {
           document.addEventListener('DOMContentLoaded', cb.bind(this));

--- a/static/js/manual-initializer.js
+++ b/static/js/manual-initializer.js
@@ -22,28 +22,14 @@ export default class ManualInitializer {
       );
     }, 5000);
     window.AnswersExperience.init = (config = {}) => {
-      this._fireOnDomLoad(() => {
-        Object.entries(config).forEach(([key, value]) => {
-          window.AnswersExperience.runtimeConfig.set(key, value);
-        });
-        clearTimeout(runtimeConfigNotProvidedTimeout);
-        if (!this._hasAnswersInitialized) {
-          this._initAnswers();
-        }
-        this._hasAnswersInitialized = true;
+      Object.entries(config).forEach(([key, value]) => {
+        window.AnswersExperience.runtimeConfig.set(key, value);
       });
-    }
-  }
-
-  /**
-   * Executes the provided function on DOM load
-   * @param {Function} cb 
-   */
-   _fireOnDomLoad (cb) {
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', cb);
-    } else {
-      cb();
+      clearTimeout(runtimeConfigNotProvidedTimeout);
+      if (!this._hasAnswersInitialized) {
+        this._initAnswers();
+      }
+      this._hasAnswersInitialized = true;
     }
   }
 }


### PR DESCRIPTION
We can remove the `_fireOnDomLoad` from the manual initializer because the setup function itself is called during `DOMContentLoaded`

J=none
TEST=manual

Smoke test runtime config and manual initialization