### PR TITLE
Styling fix for fieldset

### DIFF
--- a/static/scss/answers/directanswercards/documentsearch-standard.scss
+++ b/static/scss/answers/directanswercards/documentsearch-standard.scss
@@ -140,6 +140,15 @@
     }
   }
 
+  &-fieldset
+  {
+    display: inline;
+    margin-inline-start: 2px;
+    margin-inline-end: 2px;
+    line-height: 0;
+    min-inline-size: min-content;
+  }
+
   &-feedback
   {
     @include Text(


### PR DESCRIPTION
Update the fieldset styling to properly align the text with the thumbs on the document search standard card on Firefox

This stying was likely missing from the cards initially because they seem to be releveant to only the allfields-standard card. However these CSS classes are present for both cards so we should use this styling to properly align the thumbs with the text. 

This styling is the same as the styling currently in use for allfields-standard.

J=none
TEST=manual

View a document search direct answer on both chrome and firefox