### PR TITLE
Add analytics to RTF link clicks in result cards.

### DIFF
--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -26,6 +26,12 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
         })
       );
     }
+
+    const rtfElement = DOM.query(this._container, '.js-yxt-rtfValue');
+    if (rtfElement) {
+      const fieldName = rtfElement.dataset.fieldName;
+      DOM.on(rtfElement, 'click', e => this._handleRtfClickAnalytics(e, fieldName));
+    }
   }
 
   setState(data) {
@@ -82,6 +88,38 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
       },
       eventOptions
     );
+  }
+
+  /**
+   * A click handler for links in a Rich Text attriubte. When such a link is
+   * clicked, an {@link AnalyticsEvent} needs to be fired.
+   *
+   * @param {MouseEvent} event The click event.
+   * @param {string} fieldName The name of the Rich Text field used in the
+   *                           attriubte.
+   */
+   _handleRtfClickAnalytics (event, fieldName) {
+    const ctaType = event.target.dataset.ctaType;
+    if (!ctaType) {
+      return;
+    }
+
+    const analyticsOptions = {
+      directAnswer: false,
+      verticalKey: this.verticalKey,
+      searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
+      entityId: this.result.id,
+      url: event.target.href
+    };
+    if (!fieldName) {
+      console.warn('Field name not provided for RTF click analytics');
+    } else {
+      analyticsOptions.fieldName = fieldName;
+    }
+
+    const analyticsEvent = new ANSWERS.AnalyticsEvent(ctaType);
+    analyticsEvent.addOptions(analyticsOptions);
+    this.analyticsReporter.report(analyticsEvent);
   }
 
   static get type() {

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -26,11 +26,11 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
         })
       );
     }
-
-    const rtfElement = DOM.query(this._container, '.js-yxt-rtfValue');
+    
+    const rtfElement = this._container.querySelector('.js-yxt-rtfValue');
     if (rtfElement) {
       const fieldName = rtfElement.dataset.fieldName;
-      DOM.on(rtfElement, 'click', e => this._handleRtfClickAnalytics(e, fieldName));
+      rtfElement.addEventListener('click', e => this._handleRtfClickAnalytics(e, fieldName));
     }
   }
 


### PR DESCRIPTION
This PR ensures that for all result cards, when an RTF link is clicked, the correct `AnalyticsEvent` is fired. This code is largely taken from the SDK's `CardComponent` class. The only difference is in how some of the event options are computed.

J=SLAP-1403
TEST=manual

Tested the following:
- Event was properly fired for a link click on vertical.
- Event was properly fired for a link click on universal.
- Clicking elsewhere on an RTF value (not a link) did not cause an event to fire.