### PR TITLE
AnswersExperienceFrame Unit tests

### DIFF
--- a/static/js/__mocks__/iframe-common.js
+++ b/static/js/__mocks__/iframe-common.js
@@ -1,0 +1,6 @@
+// Note: This will need to be updated to 'createMockFromModule' if we upgrade to jest 26+
+const iframeCommon = jest.genMockFromModule('./iframe-common');
+
+iframeCommon.sendToIframe = jest.fn();
+
+module.exports = iframeCommon;

--- a/tests/static/js/answers-experience-frame.js
+++ b/tests/static/js/answers-experience-frame.js
@@ -1,0 +1,39 @@
+import AnswersExperienceFrame from '../../../static/js/answers-experience-frame';
+import RuntimeConfig from '../../../static/js/runtime-config';
+import { sendToIframe } from '../../../static/js/iframe-common';
+
+jest.mock('../../../static/js/iframe-common');
+
+describe('AnswersExperienceFrame works propertly', () => {
+  let answersExperienceFrame;
+
+  beforeEach(() => {
+    const runtimeConfig = new RuntimeConfig();
+    answersExperienceFrame = new AnswersExperienceFrame(runtimeConfig);
+    jest.clearAllMocks(); // ensure mock.calls are cleared before each test
+  });
+
+  it('The init function sends an init message to the iframe', () => {
+    answersExperienceFrame.init({});
+    const expectedMessage = {
+      initAnswersExperience: true,
+      runtimeConfig: {}
+    };
+    expect(sendToIframe).toHaveBeenCalledWith(expectedMessage);
+  });
+
+  it('Runtime config passed to the init function is sent to the child iframe', () => {
+    answersExperienceFrame.init({linkTarget: '_blank'});
+    const expectedMessage = {
+      initAnswersExperience: true,
+      runtimeConfig: {linkTarget: '_blank'}
+    };
+    expect(sendToIframe).toHaveBeenCalledWith(expectedMessage);
+  });
+
+  it('An init message will only be sent once', () => {
+    answersExperienceFrame.init({});
+    answersExperienceFrame.init({});
+    expect(sendToIframe).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Add tests for AnswersExperienceFrame

I created a jest mock for iframe-common so that we could check the interaction with the `sendToIframe` function

J=SLAP-1371
TEST=auto