### PR TITLE
Add RTF link click analytics for Direct Answer cards.

### DIFF
--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -67,6 +67,9 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
         });
       }
     }
+
+    const rtfElement = this._container.querySelector('.js-yxt-rtfValue');
+    rtfElement && rtfElement.addEventListener('click', e => this._handleRtfClickAnalytics(e));
   }
 
   /**
@@ -143,6 +146,32 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
         ...eventOptions
       },
     );
+  }
+
+  /**
+   * A click handler for links in a Rich Text Direct Answer. When such a link
+   * is clicked, an {@link AnalyticsEvent} needs to be fired.
+   *
+   * @param {MouseEvent} event The click event.
+   */
+  _handleRtfClickAnalytics (event) {
+    if (!event.target.dataset.ctaType) {
+      return;
+    }
+    const ctaType = event.target.dataset.ctaType;
+
+    const analyticsOptions = {
+      verticalKey: this.verticalConfigId,
+      directAnswer: true,
+      fieldName: this.answer.fieldApiName,
+      searcher: 'UNIVERSAL',
+      entityId: this.associatedEntityId,
+      url: event.target.href
+    };
+
+    const analyticsEvent = new ANSWERS.AnalyticsEvent(ctaType);
+    analyticsEvent.addOptions(analyticsOptions);
+    this.analyticsReporter.report(analyticsEvent);
   }
 
   /**


### PR DESCRIPTION
This PR ensures that all Direct Answer cards in the Theme support RTF link
click analytics. The code was taken largely from the SDK. The main difference
is the source of some of the event options.

J=SLAP-1405
TEST=manual

Built a local test site with the new base `card_component`. Saw the correct
`AnalyticsEvent`s getting fired when I clicked on a RTF DA's links. Verified
that clicking plain text in the RTF value did not cause an event to be
fired.