### PR TITLE
Locator time debouncing

### DIFF
--- a/static/js/theme-map/SearchPreventer.js
+++ b/static/js/theme-map/SearchPreventer.js
@@ -4,7 +4,7 @@ import { Coordinate } from './Geo/Coordinate.js';
  * Responsible for determining whether or not a new search should be ran based on the
  * location of the most recent search, the current center of the map, and the zoom level.
  */
-class SearchDebouncer {
+class SearchPreventer {
   constructor () {
     /**
      * The threshold for allowing a new search based on the distance to the previous search.
@@ -28,7 +28,7 @@ class SearchDebouncer {
   }
 
   /**
-   * Determines if a search should be debounced based on the relative distance of the current map
+   * Determines if a search should be prevented based on the relative distance of the current map
    * center to the previous map center.
    * 
    * @param {Coordinate} mostRecentSearchMapCenter
@@ -40,12 +40,11 @@ class SearchDebouncer {
     const distanceToLastSearch = currentMapCenter.distanceTo(mostRecentSearchMapCenter);
     const relativeDistance = this._calculateRelativeDistance(distanceToLastSearch, currentZoom);
 
-
     return relativeDistance <= this.relativeDistanceThreshold;
   }
 
   /**
-   * Determines if a search should be debounced based on the difference between the map zoom during
+   * Determines if a search should be prevented based on the difference between the map zoom during
    * the most recent search and the current map zoom.
    * 
    * @param {number} mostRecentSearchZoom
@@ -78,4 +77,4 @@ class SearchDebouncer {
   }
 }
 
-export { SearchDebouncer };
+export { SearchPreventer };

--- a/tests/acceptance/blocks/thememap.js
+++ b/tests/acceptance/blocks/thememap.js
@@ -29,6 +29,7 @@ class ThemeMap {
 
   async dragLeft () {
     await t.drag(this._canvas, 750, 0);
+    await t.wait(1000); // Wait longer than the debouncer to allow a new search to be triggered
   }
 
   async toggleSearchThisArea () {

--- a/tests/acceptance/suites/vertical-full-page-map.js
+++ b/tests/acceptance/suites/vertical-full-page-map.js
@@ -27,6 +27,7 @@ test('Search when map moves works', async t => {
   const resultsCountBeforeDrag = await VerticalResults.getNumResults();
   await ThemeMap.dragLeft();
   await ThemeMap.dragLeft();
+  await t.wait(500); // Wait longer than the debouncer to allow a new search to be triggered
   const resultsCountAfterDrag = await VerticalResults.getNumResults();
   await t.expect(resultsCountBeforeDrag !== resultsCountAfterDrag).ok();
 });

--- a/tests/acceptance/suites/vertical-full-page-map.js
+++ b/tests/acceptance/suites/vertical-full-page-map.js
@@ -27,7 +27,6 @@ test('Search when map moves works', async t => {
   const resultsCountBeforeDrag = await VerticalResults.getNumResults();
   await ThemeMap.dragLeft();
   await ThemeMap.dragLeft();
-  await t.wait(500); // Wait longer than the debouncer to allow a new search to be triggered
   const resultsCountAfterDrag = await VerticalResults.getNumResults();
   await t.expect(resultsCountBeforeDrag !== resultsCountAfterDrag).ok();
 });


### PR DESCRIPTION
Debounce the locator based on time

This PR adds a time-based debouncer so that `searchThisArea` will not execute until 250ms have passed since the last time the debounce function was called. This prevents unnecessary searches from being ran when someone quickly zooms in or out of the map.

For this change, I renamed the `SearchDebouncer` to the `SearchPreventer`since it is a more accurate name. The distinction is that if a search doesn't pass the criteria of the `SearchPreventer`, it will never be ran. Debouncing is different because when a debounced function is called, it will eventually execute after sufficient time has passed without another function call.

I was hoping that this change would also reduce the number of searches made when dragging the map, however the debounce time necessary to make that work is too large and would lead to a sluggish user experience. It is possible that we would be able to accomplish it in a non-sluggish manner by reseting the debouncer whenever the user clicks on the map canvas, however further experimentation would be necessary.

I opted not to debounce `searchThisArea()` calls after a user clicks on the 'Search This Area` button or on a cluster since there is little need for a debouncer there.

J=SLAP-1301
TEST=manual

Test that zooming in the map quickly doesn't trigger a new search until the zooming is done