### PR TITLE
Test site speedup

### DIFF
--- a/test-site/scripts/build.sh
+++ b/test-site/scripts/build.sh
@@ -7,14 +7,4 @@ set_working_dir_to_test_site () {
 
 set_working_dir_to_test_site
 
-rm -rf cards/event-custom
-rm -rf directanswercards/allfields-custom
-
-set -e
-
-npx jambo card --name event-custom --templateCardFolder cards/event-standard
-npx jambo directanswercard --name allfields-custom --templateCardFolder directanswercards/allfields-standard
-
-node scripts/create-verticals.js
-
 npx jambo build && npx grunt webpack

--- a/test-site/scripts/setup.sh
+++ b/test-site/scripts/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 set_working_dir_to_test_site () {
   path_to_this_script="$( dirname "${BASH_SOURCE[0]}" )"
   cd "$path_to_this_script/.."
@@ -12,6 +14,19 @@ copy_static_files_into_working_dir () {
   cp ../static/webpack-config.js webpack-config.js
 }
 
+cleanup_custom_cards () {
+  rm -rf cards/event-custom
+  rm -rf directanswercards/allfields-custom
+}
+
+create_custom_cards () {
+  npx jambo card --name event-custom --templateCardFolder cards/event-standard
+  npx jambo directanswercard --name allfields-custom --templateCardFolder directanswercards/allfields-standard
+}
+
 set_working_dir_to_test_site
 copy_static_files_into_working_dir
 npm i
+cleanup_custom_cards
+create_custom_cards
+node scripts/create-verticals.js


### PR DESCRIPTION
Speed up the test site build step by moving some work from the build step to the setup step

The setup-test-site command now does all the work to generate the jambo test site, and the build command does a regular `npx jambo build && grunt webpack`

By moving the card and the vertical generation work to the setup step, the build step improves from 21.9 seconds to 7.4 seconds on my laptop. The downside is that some changes will now require a full setup to be ran where before it was possible to apply the change with the build command:
- Updating page templates
- Updating patch files
- Updating the page config files

J=none
TEST=manual

Test the speed improvements and smoke test the test site
