### PR TITLE
Overlay button legacy bundle

### DIFF
--- a/static/js/overlay/button-frame/button.html
+++ b/static/js/overlay/button-frame/button.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head data-iframe-height="true">
-  <script src="overlay-button.js"></script>
+  <script src="overlay-button.js" type="module"></script>
+  <script src="overlay-button-legacy.js" nomodule></script>
   <link rel="stylesheet" type="text/css" href="overlay-button.css">
   <script>
-    window.iFrameResizer = {
-      onMessage: window.OverlayButtonJS.onMessage
-    }
+    document.addEventListener('DOMContentLoaded', function () {
+      window.iFrameResizer = {
+        onMessage: window.OverlayButtonJS.onMessage
+      };
+    });
   </script>
   <script
     src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js">

--- a/static/js/overlay/button-frame/entry-legacy.js
+++ b/static/js/overlay/button-frame/entry-legacy.js
@@ -1,0 +1,22 @@
+// Import global polyfills
+import 'core-js/stable';
+
+import cssVars from 'css-vars-ponyfill';
+
+cssVars({
+  onlyLegacy: true,
+  onBeforeSend: (xhr, node, url) => {
+    try {
+      const uriWithCacheBust = new URL(url);
+      const params = new SearchParams(uriWithCacheBust.search);
+      params.set('_', new Date().getTime());
+      uriWithCacheBust.search = params.toString();
+      xhr.open('GET', uriWithCacheBust.toString());
+    } catch (e) {
+      // Catch the error and continue if the URL provided in the asset is not a valid URL
+    }
+  }
+});
+
+// Include code and named-exports from the non-legacy bundle
+export * from './entry';

--- a/static/js/overlay/button-frame/entry.js
+++ b/static/js/overlay/button-frame/entry.js
@@ -1,22 +1,3 @@
-// Import global polyfills
-import 'core-js/stable';
-import cssVars from 'css-vars-ponyfill';
-
-cssVars({
-  onlyLegacy: true,
-  onBeforeSend: (xhr, node, url) => {
-    try {
-      const uriWithCacheBust = new URL(url);
-      const params = new SearchParams(uriWithCacheBust.search);
-      params.set('_', new Date().getTime());
-      uriWithCacheBust.search = params.toString();
-      xhr.open('GET', uriWithCacheBust.toString());
-    } catch (e) {
-      // Catch the error and continue if the URL provided in the asset is not a valid URL
-    }
-  }
-});
-
 // Import all SCSS
 import Scss from '../../../scss/answers/overlay/button/_default.scss';
 

--- a/static/webpack/webpack.prod.js
+++ b/static/webpack/webpack.prod.js
@@ -7,6 +7,7 @@ module.exports = (jamboConfig) => {
     devtool: 'source-map',
     entry: {
       'bundle-legacy': `./${jamboConfig.dirs.output}/static/entry-legacy.js`,
+      'overlay-button-legacy': `./${jamboConfig.dirs.output}/static/js/overlay/button-frame/entry-legacy.js`,
     },
     plugins: [
       new InlineAssetHtmlPlugin()


### PR DESCRIPTION
Improve development build time and web performance by adding a button legacy build

Create a legacy bundle build similar to #828 so that we can avoid the ponyfills and polyfills for modern web browsers. This yeids the following benefits:
- Improved webpack build time by about 13% from 4.5 seconds to 4 seconds when IS_DEVELOPMENT_PREVIEW=true
- Modern browsers are served a much smaller overlay-button bundle (32KB rather than the 211KB of the legacy bundle)

Since specifying type="module" on the  modern bundle makes it deferred, we must wait for DOMContentLoaded before trying to access `window.OverlayButtonJS`

J=SLAP-1417
TEST=manual

Smoke test the overlay on chrome and on IE11 on browserstack.