### PR TITLE
import runtime hbs helpers passed to the sdk from the hbshelpers folder

### DIFF
--- a/cards/event-standard/component.js
+++ b/cards/event-standard/component.js
@@ -33,7 +33,8 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
       CTA1: {
         label: 'RSVP', // The CTA's label
         iconName: 'calendar', // The icon to use for the CTA
-        url: profile.ticketUrl || profile.website, // The URL a user will be directed to when clicking
+        iconUrl: 'static/assets/slapshot.png',
+        url: '123', // The URL a user will be directed to when clicking
         target: linkTarget, // Where the new URL will be opened
         eventType: 'RSVP', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),

--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -37,9 +37,10 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
       // image: '', // The URL of the image to display on the card
       showOrdinal: true, // Show the map pin number on the card. Only supported for universal search
       CTA1: { // The primary call to action for the card
-        label: 'Call', // The label of the CTA
-        iconName: 'phone', // The icon to use for the CTA
-        url: Formatter.phoneLink(profile), // The URL a user will be directed to when clicking
+        label: 'RSVP', // The CTA's label
+        iconName: 'calendar', // The icon to use for the CTA
+        iconUrl: 'static/assets/slapshot.png',
+        url: '123',
         target: linkTarget, // If the URL will be opened in a new tab, etc.
         eventType: 'TAP_TO_CALL', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(), // The analytics event options for CTA clicks

--- a/cards/multilang-event-standard/component.js
+++ b/cards/multilang-event-standard/component.js
@@ -31,9 +31,9 @@ class multilang_event_standardCardComponent extends BaseCard['multilang-event-st
       // },
       // The primary CTA of the card
       CTA1: {
-        label: {{ translateJS phrase='RSVP' context='RSVP is a verb' }}, // The CTA's label
+        label: 'RSVP', // The CTA's label
         iconName: 'calendar', // The icon to use for the CTA
-        url: profile.ticketUrl || profile.website, // The URL a user will be directed to when clicking
+        iconUrl: 'static/assets/slapshot.png',
         target: linkTarget, // Where the new URL will be opened
         eventType: 'RSVP', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),

--- a/cards/multilang-location-standard/component.js
+++ b/cards/multilang-location-standard/component.js
@@ -37,9 +37,11 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
       // image: '', // The URL of the image to display on the card
       showOrdinal: true, // Show the map pin number on the card. Only supported for universal search
       CTA1: { // The primary call to action for the card
-        label: {{ translateJS phrase='Call' context='Call is a verb' }}, // The label of the CTA
-        iconName: 'phone', // The icon to use for the CTA
-        url: Formatter.phoneLink(profile), // The URL a user will be directed to when clicking
+
+        label: 'RSVP', // The CTA's label
+        iconName: 'calendar', // The icon to use for the CTA
+        iconUrl: 'static/assets/slapshot.png',
+        url: '123',
         target: linkTarget, // If the URL will be opened in a new tab, etc.
         eventType: 'TAP_TO_CALL', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(), // The analytics event options for CTA clicks

--- a/hbshelpers/all.js
+++ b/hbshelpers/all.js
@@ -1,0 +1,9 @@
+/**
+ * Returns true if every parameter is truthy.
+ * 
+ * @param  {...any} args 
+ * @returns {boolean}
+ */
+module.exports = function all(...args) {
+  return args.filter(item => item).length === args.length;
+}

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -47,6 +47,11 @@
       },
       onReady: () => {
         window.AnswersExperience.AnswersInitializedPromise.resolve();
+        
+        HitchhikerJS.registerHbsHelpers();
+        ANSWERS.registerHelper('close-card-svg', () => {
+          return ANSWERS.renderer.SafeString({{{stringifyPartial (read 'static/assets/images/close-card') }}});
+        });
 
         {{> @partial-block }}
 
@@ -55,32 +60,6 @@
         {{#if global_config.conversionTrackingEnabled}}
           ANSWERS.setConversionsOptIn(true);
         {{/if}}
-
-        ANSWERS.registerHelper('all', function (...args) {
-          return args.filter(item => item).length === args.length;
-        });
-
-        ANSWERS.registerHelper('any', function (...args) {
-          return args.filter(item => item).length > 1;
-        });
-
-        ANSWERS.registerHelper('matches', function(str, regexPattern) {
-          const regex = new RegExp(regexPattern)
-          return str && str.match(regex);
-        });
-
-        /**
-         * Determine whether a URL is absolute or not.
-         * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com"
-         */
-        ANSWERS.registerHelper('isNonRelativeUrl', function(str) {
-          const absoluteURLRegex = /^(\/|[a-zA-Z]+:)/;
-          return str && str.match(absoluteURLRegex);
-        });
-
-        ANSWERS.registerHelper('close-card-svg', () => {
-          return ANSWERS.renderer.SafeString({{{stringifyPartial (read 'static/assets/images/close-card') }}});
-        });
       }
     }).catch(err => {
       window.AnswersExperience.AnswersInitializedPromise.reject('Answers failed to initialized.');

--- a/static/js/HitchhikerJS.js
+++ b/static/js/HitchhikerJS.js
@@ -40,3 +40,6 @@ const runtimeConfig = new RuntimeConfig();
 window.AnswersExperience = new AnswersExperience(runtimeConfig);
 
 export * from './video-apis';
+
+import registerHbsHelpers from './registerHbsHelpers';
+export { registerHbsHelpers };

--- a/static/js/registerHbsHelpers.js
+++ b/static/js/registerHbsHelpers.js
@@ -1,0 +1,19 @@
+import all from 'HbsHelpers/all';
+import any from 'HbsHelpers/any';
+import isNonRelativeUrl from 'HbsHelpers/isNonRelativeUrl';
+import relativePathHandler from 'HbsHelpers/relativePathHandler';
+
+export default function registerHbsHelpers() {
+  ANSWERS.registerHelper('all', all);
+  ANSWERS.registerHelper('any', any);
+  ANSWERS.registerHelper('isNonRelativeUrl', isNonRelativeUrl);
+  ANSWERS.registerHelper('relativePathHandler', relativePathHandler);
+
+  /**
+   * @deprecated in favor of isNonRelativeUrl
+   */
+  ANSWERS.registerHelper('matches', function(str, regexPattern) {
+    const regex = new RegExp(regexPattern)
+    return str && str.match(regex);
+  });
+}

--- a/static/js/registerHbsHelpers.js
+++ b/static/js/registerHbsHelpers.js
@@ -1,7 +1,7 @@
-import all from 'HbsHelpers/all';
-import any from 'HbsHelpers/any';
-import isNonRelativeUrl from 'HbsHelpers/isNonRelativeUrl';
-import relativePathHandler from 'HbsHelpers/relativePathHandler';
+const all = require('HbsHelpers/all') ;
+const any = require('HbsHelpers/any');
+const isNonRelativeUrl = require('HbsHelpers/isNonRelativeUrl');
+const relativePathHandler = require('HbsHelpers/relativePathHandler');
 
 export default function registerHbsHelpers() {
   ANSWERS.registerHelper('all', all);

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1959,6 +1959,85 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "copy-webpack-plugin": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
+      "integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.5",
+        "glob-parent": "^6.0.0",
+        "globby": "^11.0.3",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^3.1.0",
+        "schema-utils": "^3.0.0",
+        "serialize-javascript": "^6.0.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+          "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
+          "integrity": "sha512-Hdd4287VEJcZXUwv1l8a+vXC1GjOQqXe+VS30w/ypihpcnu9M1n3xeYeJu5CBpeEQj2nAab2xxz28GuA3vp4Ww==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        }
+      }
+    },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",

--- a/static/package.json
+++ b/static/package.json
@@ -20,6 +20,7 @@
     "@yext/cta-formatter": "^1.0.0",
     "babel-loader": "^8.1.0",
     "comment-json": "^3.0.2",
+    "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^3.4.2",
     "esbuild-loader": "^2.13.1",
     "file-loader": "^5.1.0",

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -43,8 +43,19 @@ module.exports = function () {
     jamboInjectedData = getCleanedJamboInjectedData(jamboInjectedData)
     jamboInjectedData = JSON.stringify(jamboInjectedData)
   }
+  const baseHbsHelpersPath = path.resolve(
+    __dirname, jamboConfig.dirs.themes, jamboConfig.defaultTheme, 'hbshelpers');
+  fs.copySync(baseHbsHelpersPath, path.join(jamboConfig.dirs.output, 'hbshelpers'));
 
   const plugins = [
+    // new CopyWebpackPlugin({
+    //   patterns: [
+    //     {
+    //       from: path.resolve(__dirname, jamboConfig.dirs.themes, jamboConfig.defaultTheme, 'hbshelpers'),
+    //       to: path.join(jamboConfig.dirs.output, 'hbshelpers')
+    //     },
+    //   ],
+    // }),
     new MiniCssExtractPlugin({
       filename: pathData => {
         const chunkName = pathData.chunk.name;
@@ -86,7 +97,7 @@ module.exports = function () {
     resolve: {
       alias: {
         static: path.resolve(__dirname, jamboConfig.dirs.output, 'static'),
-        HbsHelpers: path.resolve(__dirname, jamboConfig.dirs.themes, jamboConfig.defaultTheme, 'hbshelpers'),
+        HbsHelpers: path.resolve(__dirname, jamboConfig.dirs.output, 'hbshelpers'),
       }
     },
     output: {

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -86,6 +86,7 @@ module.exports = function () {
     resolve: {
       alias: {
         static: path.resolve(__dirname, jamboConfig.dirs.output, 'static'),
+        HbsHelpers: path.resolve(__dirname, jamboConfig.dirs.themes, jamboConfig.defaultTheme, 'hbshelpers'),
       }
     },
     output: {


### PR DESCRIPTION
This commit lets us share hbshelpers between jambo and the SDK, instead
of copying them (which is what we were doing before). This is done using
a webpack resolve alias.
Helpers that have handlebars in them cannot be easily shared, though
there is only one case of that.

The helpers were moved above the partial-block, to avoid issues with adding
components before registering helpers. We don't have any components in the theme
 that have this problem, but I have run into this before when messing around with things.

J=SLAP-1297
TEST=manual

smoke test that the page still loads
cards would break instantly if the any and all helpers weren't registered
to the SDK

test custom icons in card components, on both es and en locales (to test relative path
handling)