### PR TITLE
use spawnSync in grunt watch

### DIFF
--- a/static/Gruntfile.js
+++ b/static/Gruntfile.js
@@ -1,10 +1,10 @@
-const webpackConfig = require('./webpack-config');
-const { exec } = require("child_process");
-const jamboConfig = require('./jambo.json');
-
-const outputDir = jamboConfig.dirs.output;
+const { spawnSync } = require('child_process');
 
 module.exports = function (grunt) {
+  const webpackConfig = require('./webpack-config');
+  const jamboConfig = require('./jambo.json');
+  
+  const outputDir = jamboConfig.dirs.output;
   grunt.initConfig({
     webpack: {
       myConfig: webpackConfig
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
     watch: {
       all: {
         files: ['**', '!**/node_modules/**', `!${outputDir}/**`],
-        tasks: ['jambobuild', 'webpack',],
+        tasks: ['build',],
         options: {
           spawn: false,
         },
@@ -23,23 +23,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-webpack');
   grunt.loadNpmTasks('grunt-contrib-watch');
 
-  grunt.registerTask('jambobuild', 'Jambo build.',
-  function() {
-    // Force task into async mode and grab a handle to the "done" function.
-    var done = this.async();
-    // Run some sync stuff.
-    grunt.log.writeln('Processing task...');
-    // And some async stuff.
-    exec('npx jambo build', (error, stdout, stderr) => {
-      if (error) {
-        console.log(error.message);
-        done(false);
-        return;
-      }
-
-      stderr && console.error(stderr);
-      stdout && console.log(stdout);
-      done();
-    });
+  grunt.registerTask('build', 'jambo build -> grunt webpack', () => {
+    spawnSync('npm', ['run',  'build', '--silent'], { stdio: 'inherit' });
   });
 }

--- a/static/package.json
+++ b/static/package.json
@@ -4,7 +4,8 @@
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "jambo build && grunt webpack"
   },
   "author": "tmeyer@yext.com",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This lets us simplify our grunt watch a little bit.
We also get some other benefits, like the stdout
and stderr being logged in the original order jambo output them,
as opposed to all of stderr and then all of stdout.
This change also adds support for colorful jambo, at least when
grunt watch is used via CLI. Previously, if you tried to run
grunt watch, and hooked it up to a jambo with colored
output, the colors wouldn't print.

While working on this were some issues with getting the webpack build
to not run if the jambo build failed. I tried switching
to grunt-shell, but after some testing noticed that
grunt-shell does not support colorful output, at least
not with jambo nor with npm. So I just made an npm build
script that would jambo build and then webpack.

When testing this in live preview, I noticed that I needed
to run `npm run build` with the --silent flag in order to
suppress extra error messaging from npm, with the error messaging
in question really messing up the sitesgitstorm console.
These error messages occur when using node 12, but not on
node 14 (what I used locally).

I also moved the imports for the jambo config and webpack config
into the Gruntfile's exported function. I think this will let
people upgrade their themes without having to restart preview,
at the very least it let me change the webpack config and gruntfile
without needing to restart.

J=SLAP-964
TEST=manual

tested this change in sitesgitstorm on our slapshot
test account.
tried both changing a config file to trigger a build,
and deleting a comma in a config file to trigger a build error

tested that the webpack build will not try to run if the jambo build fails

tested that colorful output works locally by hooking up my local jambo

in SGS, tested manually editing the webpack config (not via upgrade)
and saw my new console.log changes reflected in the console
also updated the Gruntfile to not run npm run build with the --silent
flag, intentionally broke a config json's syntax, and saw the oddly
formatted npm error messages come back