### PR TITLE
replace IconComponent with icon partials

### DIFF
--- a/cards/document-standard/template.hbs
+++ b/cards/document-standard/template.hbs
@@ -76,10 +76,10 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/document-standard/template.hbs
+++ b/cards/document-standard/template.hbs
@@ -77,8 +77,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -73,13 +73,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -74,13 +74,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -99,8 +99,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -97,10 +97,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -8,7 +8,7 @@
       {{{card.title}}}
     </h3>
     <div class="HitchhikerFaqAccordion-icon js-HitchhikerFaqAccordion-icon{{#if card.isExpanded}} HitchhikerFaqAccordion-icon--expanded{{/if}}">
-      {{> icons/bakedInIcon iconName='chevron' }}
+      {{> icons/builtInIcon iconName='chevron' }}
     </div>
   </button>
   <div class="HitchhikerFaqAccordion-content js-HitchhikerFaqAccordion-content"
@@ -60,13 +60,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -61,13 +61,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -83,10 +83,11 @@
    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
-    <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-      "iconName": "{{iconName}}"
-    }'>
+    <div class="HitchhikerCTA-icon">
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
   </div>
   {{/if}}

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -85,8 +85,8 @@
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
   </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -7,10 +7,8 @@
     <h3 class="HitchhikerFaqAccordion-title">
       {{{card.title}}}
     </h3>
-    <div class="HitchhikerFaqAccordion-icon js-HitchhikerFaqAccordion-icon{{#if card.isExpanded}} HitchhikerFaqAccordion-icon--expanded{{/if}}"
-      data-component="IconComponent"
-      data-opts='{"iconName": "chevron"}'
-      data-prop="icon">
+    <div class="HitchhikerFaqAccordion-icon js-HitchhikerFaqAccordion-icon{{#if card.isExpanded}} HitchhikerFaqAccordion-icon--expanded{{/if}}">
+      {{> icons/bakedInIcon iconName='chevron' }}
     </div>
   </button>
   <div class="HitchhikerFaqAccordion-content js-HitchhikerFaqAccordion-content"

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -176,8 +176,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -174,10 +174,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{iconUrl}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -103,13 +103,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -102,13 +102,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -66,13 +66,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -65,13 +65,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -99,8 +99,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -96,10 +96,10 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -62,13 +62,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -63,13 +63,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -90,10 +90,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -185,13 +185,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -92,8 +92,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -187,13 +187,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -118,10 +118,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -93,13 +93,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -92,13 +92,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -120,8 +120,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -73,13 +73,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -74,13 +74,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -99,8 +99,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -97,10 +97,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -8,7 +8,7 @@
       {{{card.title}}}
     </h3>
     <div class="HitchhikerFaqAccordion-icon js-HitchhikerFaqAccordion-icon{{#if card.isExpanded}} HitchhikerFaqAccordion-icon--expanded{{/if}}">
-      {{> icons/bakedInIcon iconName='chevron' }}
+      {{> icons/builtInIcon iconName='chevron' }}
     </div>
   </button>
   <div class="HitchhikerFaqAccordion-content js-HitchhikerFaqAccordion-content"
@@ -60,13 +60,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -61,13 +61,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -83,10 +83,11 @@
    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
   {{#if (any iconName iconUrl)}}
   <div class="HitchhikerCTA-iconWrapper">
-    <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-      "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-      "iconName": "{{iconName}}"
-    }'>
+    <div class="HitchhikerCTA-icon">
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
   </div>
   {{/if}}

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -85,8 +85,8 @@
   <div class="HitchhikerCTA-iconWrapper">
     <div class="HitchhikerCTA-icon">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
   </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -7,10 +7,8 @@
     <h3 class="HitchhikerFaqAccordion-title">
       {{{card.title}}}
     </h3>
-    <div class="HitchhikerFaqAccordion-icon js-HitchhikerFaqAccordion-icon{{#if card.isExpanded}} HitchhikerFaqAccordion-icon--expanded{{/if}}"
-      data-component="IconComponent"
-      data-opts='{"iconName": "chevron"}'
-      data-prop="icon">
+    <div class="HitchhikerFaqAccordion-icon js-HitchhikerFaqAccordion-icon{{#if card.isExpanded}} HitchhikerFaqAccordion-icon--expanded{{/if}}">
+      {{> icons/bakedInIcon iconName='chevron' }}
     </div>
   </button>
   <div class="HitchhikerFaqAccordion-content js-HitchhikerFaqAccordion-content"

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -176,8 +176,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -174,10 +174,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{iconUrl}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -103,13 +103,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -102,13 +102,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -66,13 +66,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -65,13 +65,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -99,8 +99,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -96,10 +96,10 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -62,13 +62,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -63,13 +63,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -90,10 +90,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -185,13 +185,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -92,8 +92,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -187,13 +187,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -118,10 +118,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -93,13 +93,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -92,13 +92,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -120,8 +120,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -109,9 +109,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon"
-        data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -111,8 +111,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -74,13 +74,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -75,13 +75,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -113,8 +113,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -77,13 +77,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -76,13 +76,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -111,9 +111,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon"
-        data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -94,8 +94,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -98,8 +98,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -71,13 +71,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -70,13 +70,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -100,13 +100,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -173,8 +173,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -99,13 +99,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -171,10 +171,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -66,13 +66,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -133,10 +133,10 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -65,13 +65,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -136,8 +136,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -66,13 +66,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -65,13 +65,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -101,8 +101,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -98,10 +98,10 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -109,9 +109,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon"
-        data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -111,8 +111,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -74,13 +74,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -75,13 +75,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -113,8 +113,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -77,13 +77,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -76,13 +76,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -111,9 +111,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon"
-        data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}","iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -94,8 +94,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent"
-        data-opts='{"iconName": "{{iconName}}", "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"}'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -98,8 +98,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -71,13 +71,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -70,13 +70,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -100,13 +100,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -173,8 +173,8 @@
     <div class="HitchhikerCTA-iconWrapper">
       <div class="HitchhikerCTA-icon">
         {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
         }}
       </div>
     </div>

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -99,13 +99,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -171,10 +171,11 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'>
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
       </div>
     </div>
     {{/if}}

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -66,13 +66,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -133,10 +133,10 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -65,13 +65,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -136,8 +136,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -66,13 +66,13 @@
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
-      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
     </span>
   </button>
   {{/if}}

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -65,13 +65,15 @@
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
   </button>
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
-    <span data-component="IconComponent"
-      data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
+    <span>
+      {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
   </button>
   {{/if}}
 </div>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -101,8 +101,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -98,10 +98,10 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -130,11 +130,9 @@
         {{footerText}}
       </legend>
       <label class="HitchhikerAllFieldsStandard-thumb">
-        <span class="HitchhikerAllFieldsStandard-thumbUpIcon"
-              data-component="IconComponent"
-              data-opts='{"iconName": "thumb"}'
-              data-prop="icon"
-        ></span>
+        <span class="HitchhikerAllFieldsStandard-thumbUpIcon">
+          {{> icons/bakedInIcon iconName='thumb' }}
+        </span>
         <input type="radio"
                 name="feedback"
                 value="true"

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -176,10 +176,10 @@
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -131,7 +131,7 @@
       </legend>
       <label class="HitchhikerAllFieldsStandard-thumb">
         <span class="HitchhikerAllFieldsStandard-thumbUpIcon">
-          {{> icons/bakedInIcon iconName='thumb' }}
+          {{> icons/builtInIcon iconName='thumb' }}
         </span>
         <input type="radio"
                 name="feedback"
@@ -143,7 +143,7 @@
       </label>
       <label class="HitchhikerAllFieldsStandard-thumb">
         <span class="HitchhikerAllFieldsStandard-thumbDownIcon">
-          {{> icons/bakedInIcon iconName='thumb' }}
+          {{> icons/builtInIcon iconName='thumb' }}
         </span>
         <input type="radio"
                 name="feedback"

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -19,14 +19,12 @@
 
 {{#*inline 'icon'}}
 {{#if (any iconName iconUrl)}}
-<div class="HitchhikerAllFieldsStandard-titleIconWrapper"
-  data-component="IconComponent"
-  data-opts='{
-    "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
-  }'
-  data-prop="icon"
-></div>
+<div class="HitchhikerAllFieldsStandard-titleIconWrapper"></div>
+  {{> icons/iconPartial
+    iconName=iconName
+    iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+  }}
+</div>
 {{/if}}
 {{/inline}}
 

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -21,8 +21,8 @@
 {{#if (any iconName iconUrl)}}
 <div class="HitchhikerAllFieldsStandard-titleIconWrapper"></div>
   {{> icons/iconPartial
-    iconName=iconName
-    iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      iconName=iconName
+      iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
   }}
 </div>
 {{/if}}
@@ -171,8 +171,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -142,11 +142,9 @@
         </span>
       </label>
       <label class="HitchhikerAllFieldsStandard-thumb">
-        <span class="HitchhikerAllFieldsStandard-thumbDownIcon"
-              data-component="IconComponent"
-              data-opts='{"iconName": "thumb"}'
-              data-prop="icon"
-        ></span>
+        <span class="HitchhikerAllFieldsStandard-thumbDownIcon">
+          {{> icons/bakedInIcon iconName='thumb' }}
+        </span>
         <input type="radio"
                 name="feedback"
                 value="false"

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -103,8 +103,8 @@
       <div class="HitchhikerCTA-iconWrapper">
         <div class="HitchhikerCTA-icon" data-component="IconComponent">
           {{> icons/iconPartial
-            iconName=iconName
-            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+              iconName=iconName
+              iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
           }}
         </div>
       </div>

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -101,10 +101,12 @@
       target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
       {{#if (any iconName iconUrl)}}
       <div class="HitchhikerCTA-iconWrapper">
-        <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-          "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-          "iconName": "{{iconName}}"
-        }'></div>
+        <div class="HitchhikerCTA-icon" data-component="IconComponent">
+          {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          }}
+        </div>
       </div>
       {{/if}}
       <div class='HitchhikerCTA-iconLabel'>

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -61,11 +61,9 @@
           {{footerText}}
         </legend>
         <label class="HitchhikerDocumentSearchStandard-thumb">
-          <span class="HitchhikerDocumentSearchStandard-thumbUpIcon"
-                data-component="IconComponent"
-                data-opts='{"iconName": "thumb"}'
-                data-prop="icon"
-          ></span>
+          <span class="HitchhikerDocumentSearchStandard-thumbUpIcon">
+            {{> icons/bakedInIcon iconName='thumb' }}
+          </span>
           <input type="radio"
                   name="feedback"
                   value="true"
@@ -75,11 +73,9 @@
           </span>
         </label>
         <label class="HitchhikerDocumentSearchStandard-thumb">
-          <span class="HitchhikerDocumentSearchStandard-thumbDownIcon"
-                data-component="IconComponent"
-                data-opts='{"iconName": "thumb"}'
-                data-prop="icon"
-          ></span>
+          <span class="HitchhikerDocumentSearchStandard-thumbDownIcon">
+            {{> icons/bakedInIcon iconName='thumb' }}
+          </span>
           <input type="radio"
                   name="feedback"
                   value="false"

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -62,7 +62,7 @@
         </legend>
         <label class="HitchhikerDocumentSearchStandard-thumb">
           <span class="HitchhikerDocumentSearchStandard-thumbUpIcon">
-            {{> icons/bakedInIcon iconName='thumb' }}
+            {{> icons/builtInIcon iconName='thumb' }}
           </span>
           <input type="radio"
                   name="feedback"
@@ -74,7 +74,7 @@
         </label>
         <label class="HitchhikerDocumentSearchStandard-thumb">
           <span class="HitchhikerDocumentSearchStandard-thumbDownIcon">
-            {{> icons/bakedInIcon iconName='thumb' }}
+            {{> icons/builtInIcon iconName='thumb' }}
           </span>
           <input type="radio"
                   name="feedback"

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -130,11 +130,9 @@
         {{footerText}}
       </legend>
       <label class="HitchhikerAllFieldsStandard-thumb">
-        <span class="HitchhikerAllFieldsStandard-thumbUpIcon"
-              data-component="IconComponent"
-              data-opts='{"iconName": "thumb"}'
-              data-prop="icon"
-        ></span>
+        <span class="HitchhikerAllFieldsStandard-thumbUpIcon">
+          {{> icons/bakedInIcon iconName='thumb' }}
+        </span>
         <input type="radio"
                 name="feedback"
                 value="true"

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -176,10 +176,10 @@
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      <div class="HitchhikerCTA-icon" data-component="IconComponent" data-opts='{
-        "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}",
-        "iconName": "{{iconName}}"
-      }'></div>
+      {{> icons/iconPartial
+        iconName=iconName
+        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      }}
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -131,7 +131,7 @@
       </legend>
       <label class="HitchhikerAllFieldsStandard-thumb">
         <span class="HitchhikerAllFieldsStandard-thumbUpIcon">
-          {{> icons/bakedInIcon iconName='thumb' }}
+          {{> icons/builtInIcon iconName='thumb' }}
         </span>
         <input type="radio"
                 name="feedback"
@@ -143,7 +143,7 @@
       </label>
       <label class="HitchhikerAllFieldsStandard-thumb">
         <span class="HitchhikerAllFieldsStandard-thumbDownIcon">
-          {{> icons/bakedInIcon iconName='thumb' }}
+          {{> icons/builtInIcon iconName='thumb' }}
         </span>
         <input type="radio"
                 name="feedback"

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -21,8 +21,8 @@
 {{#if (any iconName iconUrl)}}
 <div class="HitchhikerAllFieldsStandard-titleIconWrapper">
   {{> icons/iconPartial
-    iconName=iconName
-    iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+      iconName=iconName
+      iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
   }}
 </div>
 {{/if}}
@@ -171,8 +171,8 @@
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
       {{> icons/iconPartial
-        iconName=iconName
-        iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          iconName=iconName
+          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
       }}
     </div>
     {{/if}}

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -19,14 +19,12 @@
 
 {{#*inline 'icon'}}
 {{#if (any iconName iconUrl)}}
-<div class="HitchhikerAllFieldsStandard-titleIconWrapper"
-  data-component="IconComponent"
-  data-opts='{
-    "iconName": "{{iconName}}",
-    "iconUrl": "{{#if iconUrl}}{{#unless (isNonRelativeUrl iconUrl)}}{{@root.relativePath}}/{{/unless}}{{iconUrl}}{{/if}}"
-  }'
-  data-prop="icon"
-></div>
+<div class="HitchhikerAllFieldsStandard-titleIconWrapper">
+  {{> icons/iconPartial
+    iconName=iconName
+    iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+  }}
+</div>
 {{/if}}
 {{/inline}}
 

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -142,11 +142,9 @@
         </span>
       </label>
       <label class="HitchhikerAllFieldsStandard-thumb">
-        <span class="HitchhikerAllFieldsStandard-thumbDownIcon"
-              data-component="IconComponent"
-              data-opts='{"iconName": "thumb"}'
-              data-prop="icon"
-        ></span>
+        <span class="HitchhikerAllFieldsStandard-thumbDownIcon">
+          {{> icons/bakedInIcon iconName='thumb' }}
+        </span>
         <input type="radio"
                 name="feedback"
                 value="false"

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "feature/icon-partial-i18n", // The version of the Answers SDK to use
+  "sdkVersion": "feature/develop-i18n", // The version of the Answers SDK to use
   "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
+++ b/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
@@ -16,12 +16,11 @@
             <a class="yxt-AlternativeVerticals-suggestionLink"
                 href="{{url}}">
               {{#if hasIcon}}
-                <div class="yxt-AlternativeVerticals-verticalIconWrapper"
-                      data-component="IconComponent"
-                      data-opts='{
-                        "iconName": "{{iconName}}",
-                        "iconUrl": "{{iconUrl}}"
-                      }'>
+                <div class="yxt-AlternativeVerticals-verticalIconWrapper">
+                  {{> icons/iconPartial
+                    iconName=iconName
+                    iconUrl=iconUrl
+                  }}
                 </div>
               {{/if}}
               <div class="yxt-AlternativeVerticals-suggestionLink--copy">
@@ -32,11 +31,8 @@
                   {{translate phrase='([[resultsCount]] result)' pluralForm='([[resultsCount]] results)' count=resultsCount resultsCount=resultsCount escapeHTML=false }}
                 </span>
               </div>
-              <div class="yxt-AlternativeVerticals-arrowIconWrapper"
-                    data-component="IconComponent"
-                    data-opts='{
-                      "iconName": "chevron"
-                    }'>
+              <div class="yxt-AlternativeVerticals-arrowIconWrapper">
+                {{> icons/bakedInIcon iconName='chevron' }}
               </div>
             </a>
           </li>

--- a/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
+++ b/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
@@ -32,7 +32,7 @@
                 </span>
               </div>
               <div class="yxt-AlternativeVerticals-arrowIconWrapper">
-                {{> icons/bakedInIcon iconName='chevron' }}
+                {{> icons/builtInIcon iconName='chevron' }}
               </div>
             </a>
           </li>

--- a/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
+++ b/theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs
@@ -18,8 +18,8 @@
               {{#if hasIcon}}
                 <div class="yxt-AlternativeVerticals-verticalIconWrapper">
                   {{> icons/iconPartial
-                    iconName=iconName
-                    iconUrl=iconUrl
+                      iconName=iconName
+                      iconUrl=iconUrl
                   }}
                 </div>
               {{/if}}

--- a/universalsectiontemplates/grid-four-columns.hbs
+++ b/universalsectiontemplates/grid-four-columns.hbs
@@ -61,7 +61,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsGridFourColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/grid-four-columns.hbs
+++ b/universalsectiontemplates/grid-four-columns.hbs
@@ -22,7 +22,7 @@
   <div class="HitchhikerResultsGridFourColumns-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
+        <div>{{> icons/builtInIcon iconName=_config.icon }}</div>
       {{else}}
         <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
@@ -61,7 +61,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsGridFourColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
+        <div>{{> icons/builtInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/grid-four-columns.hbs
+++ b/universalsectiontemplates/grid-four-columns.hbs
@@ -22,9 +22,9 @@
   <div class="HitchhikerResultsGridFourColumns-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
       {{else}}
-        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
     {{/if}}
     <div class="HitchhikerResultsGridFourColumns-titleLabel">{{_config.title}}</div>

--- a/universalsectiontemplates/grid-three-columns.hbs
+++ b/universalsectiontemplates/grid-three-columns.hbs
@@ -23,7 +23,7 @@
   <div class="HitchhikerResultsGridThreeColumns-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
+        <div>{{> icons/builtInIcon iconName=_config.icon }}</div>
       {{else}}
         <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
@@ -62,7 +62,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsGridThreeColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
+        <div>{{> icons/builtInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/grid-three-columns.hbs
+++ b/universalsectiontemplates/grid-three-columns.hbs
@@ -62,7 +62,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsGridThreeColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/grid-three-columns.hbs
+++ b/universalsectiontemplates/grid-three-columns.hbs
@@ -23,9 +23,9 @@
   <div class="HitchhikerResultsGridThreeColumns-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
       {{else}}
-        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
     {{/if}}
     <div class="HitchhikerResultsGridThreeColumns-titleLabel">{{_config.title}}</div>

--- a/universalsectiontemplates/grid-two-columns.hbs
+++ b/universalsectiontemplates/grid-two-columns.hbs
@@ -62,7 +62,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsGridTwoColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/grid-two-columns.hbs
+++ b/universalsectiontemplates/grid-two-columns.hbs
@@ -23,7 +23,7 @@
   <div class="HitchhikerResultsGridTwoColumns-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
+        <div>{{> icons/builtInIcon iconName=_config.icon }}</div>
       {{else}}
         <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
@@ -62,7 +62,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsGridTwoColumns-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
+        <div>{{> icons/builtInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/grid-two-columns.hbs
+++ b/universalsectiontemplates/grid-two-columns.hbs
@@ -23,9 +23,9 @@
   <div class="HitchhikerResultsGridTwoColumns-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
       {{else}}
-        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
     {{/if}}
     <div class="HitchhikerResultsGridTwoColumns-titleLabel">{{_config.title}}</div>

--- a/universalsectiontemplates/standard.hbs
+++ b/universalsectiontemplates/standard.hbs
@@ -23,7 +23,7 @@
   <div class="HitchhikerResultsStandard-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
+        <div>{{> icons/builtInIcon iconName=_config.icon }}</div>
       {{else}}
         <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
@@ -62,7 +62,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsStandard-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
+        <div>{{> icons/builtInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/standard.hbs
+++ b/universalsectiontemplates/standard.hbs
@@ -62,7 +62,7 @@
          data-eventoptions='{{eventOptions}}'
       >
         <div class="HitchhikerResultsStandard-viewMoreLabel">{{_config.viewMoreLabel}}</div>
-        <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+        <div>{{> icons/bakedInIcon iconName='chevron' }}</div>
       </a>
     </div>
   {{/if}}

--- a/universalsectiontemplates/standard.hbs
+++ b/universalsectiontemplates/standard.hbs
@@ -23,9 +23,9 @@
   <div class="HitchhikerResultsStandard-title">
     {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
-        <div data-component="IconComponent" data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/bakedInIcon iconName=_config.icon }}</div>
       {{else}}
-        <div data-component="IconComponent" data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+        <div>{{> icons/iconPartial iconUrl=_config.icon }}</div>
       {{/if}}
     {{/if}}
     <div class="HitchhikerResultsStandard-titleLabel">{{_config.title}}</div>


### PR DESCRIPTION
This PR updates all IconComponent usages to use the icon partials in the SDK
It also points the test-site to the feature/develop-i18n branch of the SDK,
which is the same commit that develop is currently at, but includes i18n assets
so our spanish snapshots work

The first group of commits do a find and replace for identical (including whitespace like indentation)
usages of IconComponent.

J=SLAP-1297
TEST=manual

test that custom icons can still be set for card CTAs, section titles, and the searchbar
see that built in icons still show up