### PR TITLE
Loading indicator in theme

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -55,6 +55,7 @@ $container-width: 1000px;
   --yxt-text-snippet-highlight-color: #eef3fb;
   --yxt-text-snippet-font-color: var(--yxt-color-text-primary);
   --yxt-direct-answer-view-details-font-weight: var(--yxt-font-weight-normal);
+  --yxt-search-loading-opacity: 0.5;
 
   // interactive map variables
   --yxt-maps-search-this-area-background-color: white;

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -181,4 +181,8 @@
       font-weight: var(--yxt-font-weight-medium);
     }
   }
+
+  .yxt-Results--searchLoading {
+    opacity: var(--yxt-search-loading-opacity);
+  }
 }

--- a/templates/common-partials/script/searchbar.hbs
+++ b/templates/common-partials/script/searchbar.hbs
@@ -26,6 +26,9 @@ ANSWERS.addComponent("SearchBar", Object.assign({}, {
   {{#if verticalKey}}
     verticalKey: "{{{verticalKey}}}",
   {{/if}}
+  loadingIndicator: {
+    display: true
+  },
   ...(shouldAddOverlayConfig ? overlayConfig : {}),
   onCreate: function() {
     this._container.textContent = '';

--- a/templates/common-partials/script/searchbar.hbs
+++ b/templates/common-partials/script/searchbar.hbs
@@ -26,9 +26,6 @@ ANSWERS.addComponent("SearchBar", Object.assign({}, {
   {{#if verticalKey}}
     verticalKey: "{{{verticalKey}}}",
   {{/if}}
-  loadingIndicator: {
-    display: true
-  },
   ...(shouldAddOverlayConfig ? overlayConfig : {}),
   onCreate: function() {
     this._container.textContent = '';

--- a/templates/universal-standard/page-config.json
+++ b/templates/universal-standard/page-config.json
@@ -21,7 +21,11 @@
       }
     },
     "SearchBar": {
-      "placeholderText": "Search" // The placeholder text in the answers search bar
+      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "loadingIndicator": {
+        "display": true //Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+      }
     }
   },
   "verticalsToConfig": {

--- a/templates/vertical-full-page-map/page-config.json
+++ b/templates/vertical-full-page-map/page-config.json
@@ -41,7 +41,11 @@
     },
     "SearchBar": {
       "placeholderText": "Search for locations", // The placeholder text in the answers search bar
-      "allowEmptySearch": true // Allows users to submit an empty search in the searchbar
+      "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
+      "loadingIndicator": {
+        "display": true //Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+      }
     },
     "Pagination": {
       "noResults": {

--- a/templates/vertical-grid/page-config.json
+++ b/templates/vertical-grid/page-config.json
@@ -43,7 +43,11 @@
     },
     "SearchBar": {
       "placeholderText": "Search", // The placeholder text in the answers search bar
-      "allowEmptySearch": true // Allows users to submit an empty search in the searchbar
+      "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
+      "loadingIndicator": {
+        "display": true //Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+      }
     },
     "Pagination": {
       "noResults": {

--- a/templates/vertical-map/page-config.json
+++ b/templates/vertical-map/page-config.json
@@ -43,7 +43,11 @@
     },
     "SearchBar": {
       "placeholderText": "Search", // The placeholder text in the answers search bar
-      "allowEmptySearch": true // Allows users to submit an empty search in the searchbar
+      "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
+      "loadingIndicator": {
+        "display": true //Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+      }
     },
     "Pagination": {
       "noResults": {

--- a/templates/vertical-standard/page-config.json
+++ b/templates/vertical-standard/page-config.json
@@ -43,7 +43,11 @@
     },
     "SearchBar": {
       "placeholderText": "Search", // The placeholder text in the answers search bar
-      "allowEmptySearch": true // Allows users to submit an empty search in the searchbar
+      "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
+      "loadingIndicator": {
+        "display": true //Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+      }
     },
     "Pagination": {
       "noResults": {


### PR DESCRIPTION
- add opacity setting in theme css
- add default loadingIndicator to true in searchbar

Note: loading indicator changes require corresponding loading indicator udpates from SDK

J=SLAP-1335
TEST=manual
- Loading indicator is present when set to true during loading
- During loading, universal result section have opacity set to 0.5 and 1. Confirm visual update on page
