### PR TITLE
Send QueryId to the Parent for iframe integrations

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -99,6 +99,19 @@
           }
           return relativePath + '/' + url;
         });
+
+        // Send the queryId to the parent frame for iframe integrations
+        window.iframeLoaded.then(() => {
+          ANSWERS.core.storage.registerListener({
+            eventType: 'update',
+            storageKey: 'query-id',
+            callback: id => {
+              window.parentIFrame.sendMessage(JSON.stringify({
+                queryId: id
+              }));
+            }
+          });
+        });
       }
     }).catch(err => {
       window.AnswersExperience.AnswersInitializedPromise.reject('Answers failed to initialized.');

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -100,17 +100,8 @@
           return relativePath + '/' + url;
         });
 
-        // Send the queryId to the parent frame for iframe integrations
         window.iframeLoaded.then(() => {
-          ANSWERS.core.storage.registerListener({
-            eventType: 'update',
-            storageKey: 'query-id',
-            callback: id => {
-              window.parentIFrame.sendMessage(JSON.stringify({
-                queryId: id
-              }));
-            }
-          });
+          {{> script/iframe-messaging}}
         });
       }
     }).catch(err => {

--- a/script/iframe-messaging.js
+++ b/script/iframe-messaging.js
@@ -1,0 +1,15 @@
+/**
+ * Add code here to send messages to the parent site for iframe integrations.
+ * To listen to these messages, static/js/iframe-common.js must be overriden
+ * and the iFrameResize onMessage function must be modified.
+ */
+
+ANSWERS.core.storage.registerListener({
+  eventType: 'update',
+  storageKey: 'query-id',
+  callback: id => {
+    window.parentIFrame.sendMessage(JSON.stringify({
+      queryId: id
+    }));
+  }
+});


### PR DESCRIPTION
Add a iframe-messaging script partial which can be used to send messages to the parent site in iframe integrations

The iframe-common.js script must be overridden in order to listen to these queryId messages.

J=SLAP-1439
TEST=manual

Override the iframe-common script and print all messages received by the parent frame. Observe a message being received on every search which includes the queryId.