### PR TITLE
Support i18n on develop

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "1.9", // The version of the Answers SDK to use
+  "sdkVersion": "develop", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/hbshelpers/sdkAssetUrl.js
+++ b/hbshelpers/sdkAssetUrl.js
@@ -27,8 +27,9 @@ module.exports = function sdkAssetUrl(branch, locale, assetName) {
   const isPreReleaseBranch = 
     RELEASE_BRANCH_REGEX.test(branch) || HOTFIX_BRANCH_REGEX.test(branch);
   const isI18nFeatureBranch = I18N_FEATURE_BRANCH_REGEX.test(branch);
+  const isDevelopBranch = branch === 'develop';
   const isLocalizationSupported = 
-    (isReleasedBranch || isPreReleaseBranch || isI18nFeatureBranch) && 
+    (isReleasedBranch || isPreReleaseBranch || isI18nFeatureBranch || isDevelopBranch) && 
     !(locale.startsWith('en') || assetName === 'answers.css') ;
   
   const parsedAssetName = isLocalizationSupported ?

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "feature/develop-i18n", // The version of the Answers SDK to use
+  "sdkVersion": "develop", // The version of the Answers SDK to use
   "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/tests/hbshelpers/sdkAssetUrl.js
+++ b/tests/hbshelpers/sdkAssetUrl.js
@@ -54,6 +54,24 @@ describe('URLs are computed properly for hotfix branches', () => {
   });
 });
 
+describe('URLs are computed properly for the develop branch', () => {
+  it('works correctly when locale is "en"', () => {
+    const expectedJSUrl = 'https://assets.sitescdn.net/answers/canary/latest/answers.min.js';
+    const expectedCSSUrl = 'https://assets.sitescdn.net/answers/canary/latest/answers.css'
+
+    expect(sdkAssetUrl('develop', 'en', 'answers.min.js')).toEqual(expectedJSUrl);
+    expect(sdkAssetUrl('develop', 'en', 'answers.css')).toEqual(expectedCSSUrl);
+  });
+
+  it('works correctly when locale is not "en"', () => {
+    const expectedJSUrl = 'https://assets.sitescdn.net/answers/canary/latest/fr-answers.min.js';
+    const expectedCSSUrl = 'https://assets.sitescdn.net/answers/canary/latest/answers.css'
+
+    expect(sdkAssetUrl('develop', 'fr', 'answers.min.js')).toEqual(expectedJSUrl);
+    expect(sdkAssetUrl('develop', 'fr', 'answers.css')).toEqual(expectedCSSUrl);
+  });
+});
+
 describe('URLs are computed properly for all other branches', () => {
   it('works correctly when locale is "en"', () => {
     const expectedJSUrl = 'https://assets.sitescdn.net/answers/dev/feature-foo/answers.min.js';


### PR DESCRIPTION
Support i18n versions of the answers-search-ui when specifying the develop branch

As part of https://github.com/yext/answers-search-ui/pull/1459, develop now builds i18n assets. When specifying develop however, i18n assets weren't being used because the script partial wasn't including the locale in the asset URL. This PR adds support for that.

J=none
TEST=manual

Build the test site and see that the Spanish site correctly loads the Spanish answers assets from canary