### PR TITLE
Post SessionID to Parent

### DIFF
--- a/script/iframe-messaging.js
+++ b/script/iframe-messaging.js
@@ -9,7 +9,8 @@ ANSWERS.core.storage.registerListener({
   storageKey: 'query-id',
   callback: id => {
     window.parentIFrame.sendMessage(JSON.stringify({
-      queryId: id
+      queryId: id,
+      sessionId: ANSWERS.core.getOrSetupSessionId()
     }));
   }
 });


### PR DESCRIPTION
send the sessionId in the same message that the queryId is being sent

J=SLAP-1450
TEST=manual

Launched iframe test site, performed a search and verified through console log in iframe-common.js onMessage() that a message is delivered to parent page with queryId and sessionId.