### PR TITLE
await logger results

### DIFF
--- a/tests/acceptance/searchrequestlogger.js
+++ b/tests/acceptance/searchrequestlogger.js
@@ -43,7 +43,7 @@ class SearchRequestLogger {
     const responseWaitTimeout = 10000;
     const waitTimeInterval = 200;
     let totalWaitTime = 0;
-    while (totalWaitTime < responseWaitTimeout && !this.isLoggerResultsPresent()) {
+    while (totalWaitTime < responseWaitTimeout && !await this.isLoggerResultsPresent()) {
       await t.wait(waitTimeInterval);
       totalWaitTime += waitTimeInterval;
     }
@@ -52,7 +52,7 @@ class SearchRequestLogger {
 
   /**
    * Returns true if there exists a query response from logger with status code 200
-   * @returns {boolean}
+   * @returns {Promise<boolean>}
    */
   async isLoggerResultsPresent() {
     return await this._queryRequestLogger.contains(r => r.response.statusCode === 200);


### PR DESCRIPTION
async function `isLoggerResultsPresent` returns a promise<boolean> on query response,  added the missing `await` keyword when invoking the function. 
