### PR TITLE
add templateValidator to the Theme

### DIFF
--- a/commands/helpers/utils/logger.js
+++ b/commands/helpers/utils/logger.js
@@ -1,0 +1,41 @@
+const log = require('npmlog');
+
+log.heading = 'jambo';
+log.headingStyle = { fg: 'magenta' };
+
+// Don't display a log prefix.
+const PREFIX = '';
+
+/**
+ * Sets the global logging level.
+ */
+exports.setLogLevel = function(level) {
+  log.level = level;
+}
+
+/**
+ * Logs an error.
+ *
+ * @param  {...any} args 
+ */
+exports.error = function(...args) {
+  log.error(PREFIX, ...args)
+}
+
+/**
+ * Logs a warning.
+ *
+ * @param  {...any} args 
+ */
+exports.warn = function(...args) {
+  log.warn(PREFIX, ...args)
+}
+
+/**
+ * Logs info.
+ *
+ * @param  {...any} args 
+ */
+exports.info = function(...args) {
+  log.info(PREFIX, ...args)
+}

--- a/hooks/templatedatavalidator.js
+++ b/hooks/templatedatavalidator.js
@@ -51,8 +51,11 @@ function isPageVerticalConfigValid(pageData, jamboConfig) {
     }
     const universalSectionTemplate = pageData.verticalsToConfig[key].universalSectionTemplate;
     const cardType = pageData.verticalsToConfig[key].cardType;
-    if (!isUniversalSectionTemplateValid(key, themeDirectory, universalSectionTemplate)
-      | !isCardTypeValid(key, themeDirectory, cardType)) {
+    const validatorResults = [
+      isUniversalSectionTemplateValid(key, themeDirectory, universalSectionTemplate), 
+      isCardTypeValid(key, themeDirectory, cardType)
+    ];
+    if(validatorResults.some((result) => !result)) {
       isValid = false;
     }
   });

--- a/hooks/templatedatavalidator.js
+++ b/hooks/templatedatavalidator.js
@@ -10,7 +10,12 @@ const { error } = require('../commands/helpers/utils/logger');
  */
 module.exports = function (pageData) {
   const jamboConfig = parseJamboConfig();
-  return isGlobalConfigValid(pageData.global_config) & isPageVerticalConfigValid(pageData, jamboConfig);
+  const validatorResults = [
+    isGlobalConfigValid(pageData.global_config), 
+    isPageVerticalConfigValid(pageData, jamboConfig)
+  ];
+  const isValid = !validatorResults.some((result) => !result);
+  return isValid;
 }
 
 /**

--- a/hooks/templatedatavalidator.js
+++ b/hooks/templatedatavalidator.js
@@ -5,23 +5,23 @@ const { error } = require('../commands/helpers/utils/logger');
 /**
  * Validates page template's data configuration
  * 
- * @param {Object} pageData configuration of a page template
+ * @param {Object} pageData data that gets passed into a page template
  * @returns {boolean} false if validator should throw an error
  */
 module.exports = function (pageData) {
   const jamboConfig = parseJamboConfig();
-  return isGlobalConfigValid(pageData.global_config) && isPageVerticalConfigValid(pageData, jamboConfig);
+  return isGlobalConfigValid(pageData.global_config) & isPageVerticalConfigValid(pageData, jamboConfig);
 }
 
 /**
  * Validates global config for the page template
  * 
- * @param {Object} global_config 
+ * @param {Object} globalConfig 
  * @returns {boolean}
  */
-function isGlobalConfigValid(global_config) {
-  if (!global_config.experienceKey) {
-    error('Missing Info: no experienceKey found in config file.');
+function isGlobalConfigValid(globalConfig) {
+  if (!globalConfig.experienceKey) {
+    error('Missing Info: no experienceKey found.');
     return false;
   }
   return true;
@@ -36,10 +36,9 @@ function isGlobalConfigValid(global_config) {
  */
 function isPageVerticalConfigValid(pageData, jamboConfig) {
   let isValid = true;
-  const themeDirectory = path.resolve(process.cwd(), jamboConfig.dirs.themes, jamboConfig.defaultTheme);
+  const themeDirectory = path.resolve(jamboConfig.dirs.themes, jamboConfig.defaultTheme);
   Object.keys(pageData.verticalsToConfig).forEach(key => {
     if (key === 'Universal') {
-      console.log(pageData);
       if (!isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig)) {
         isValid = false;
       }

--- a/hooks/templatedatavalidator.js
+++ b/hooks/templatedatavalidator.js
@@ -43,7 +43,7 @@ function isPageVerticalConfigValid(pageData, jamboConfig) {
   const themeDirectory = path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme);
   return Object.keys(pageData.verticalsToConfig).reduce((isValid, key) => {
     if (key === 'Universal') {
-      return isValid && isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig);
+      return isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig) && isValid;
     }
     const universalSectionTemplate = pageData.verticalsToConfig[key].universalSectionTemplate;
     const cardType = pageData.verticalsToConfig[key].cardType;
@@ -51,7 +51,7 @@ function isPageVerticalConfigValid(pageData, jamboConfig) {
       isUniversalSectionTemplateValid(key, themeDirectory, universalSectionTemplate), 
       isCardTypeValid(key, themeDirectory, cardType)
     ];
-    return isValid && !validatorResults.some((result) => !result);
+    return !validatorResults.some((result) => !result) && isValid;
   }, true);
 }
 
@@ -106,6 +106,6 @@ function isAllVerticalConfigsValid(verticalConfigs, jamboConfig) {
     return true;
   }
   return Object.keys(verticalConfigs).reduce((isValid, key) => {
-    return isValid && isPageVerticalConfigValid(verticalConfigs[key], jamboConfig);
+    return isPageVerticalConfigValid(verticalConfigs[key], jamboConfig) && isValid;
   }, true);
 }

--- a/hooks/templatedatavalidator.js
+++ b/hooks/templatedatavalidator.js
@@ -40,14 +40,10 @@ function isGlobalConfigValid(globalConfig) {
  * @returns {boolean}
  */
 function isPageVerticalConfigValid(pageData, jamboConfig) {
-  let isValid = true;
   const themeDirectory = path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme);
-  Object.keys(pageData.verticalsToConfig).forEach(key => {
+  return Object.keys(pageData.verticalsToConfig).reduce((isValid, key) => {
     if (key === 'Universal') {
-      if (!isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig)) {
-        isValid = false;
-      }
-      return;
+      return isValid && isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig);
     }
     const universalSectionTemplate = pageData.verticalsToConfig[key].universalSectionTemplate;
     const cardType = pageData.verticalsToConfig[key].cardType;
@@ -55,11 +51,8 @@ function isPageVerticalConfigValid(pageData, jamboConfig) {
       isUniversalSectionTemplateValid(key, themeDirectory, universalSectionTemplate), 
       isCardTypeValid(key, themeDirectory, cardType)
     ];
-    if(validatorResults.some((result) => !result)) {
-      isValid = false;
-    }
-  });
-  return isValid;
+    return isValid && !validatorResults.some((result) => !result);
+  }, true);
 }
 
 /**
@@ -112,11 +105,7 @@ function isAllVerticalConfigsValid(verticalConfigs, jamboConfig) {
   if (!verticalConfigs) {
     return true;
   }
-  let isValid = true;
-  Object.keys(verticalConfigs).forEach(key => {
-    if (!isPageVerticalConfigValid(verticalConfigs[key], jamboConfig)) {
-      isValid = false;
-    }
-  });
-  return isValid;
+  return Object.keys(verticalConfigs).reduce((isValid, key) => {
+    return isValid && isPageVerticalConfigValid(verticalConfigs[key], jamboConfig);
+  }, true);
 }

--- a/hooks/templatedatavalidator.js
+++ b/hooks/templatedatavalidator.js
@@ -41,7 +41,7 @@ function isGlobalConfigValid(globalConfig) {
  */
 function isPageVerticalConfigValid(pageData, jamboConfig) {
   let isValid = true;
-  const themeDirectory = path.resolve(jamboConfig.dirs.themes, jamboConfig.defaultTheme);
+  const themeDirectory = path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme);
   Object.keys(pageData.verticalsToConfig).forEach(key => {
     if (key === 'Universal') {
       if (!isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig)) {
@@ -72,7 +72,7 @@ function isPageVerticalConfigValid(pageData, jamboConfig) {
  */
 function isUniversalSectionTemplateValid(verticalName, themeDir, template) {
   if (template) {
-    const universalSectionPath = path.resolve(themeDir, 'universalsectiontemplates/', template + '.hbs');
+    const universalSectionPath = path.join(themeDir, 'universalsectiontemplates/', template + '.hbs');
     if (!fs.existsSync(universalSectionPath)) {
       error(`Invalid universalSectionTemplate: can't find "${template}" at the expected path "${universalSectionPath}" for vertical "${verticalName}".`);
       return false;
@@ -91,8 +91,8 @@ function isUniversalSectionTemplateValid(verticalName, themeDir, template) {
  */
 function isCardTypeValid(verticalName, themeDir, cardType) {
   if (cardType) {
-    const cardTypePath = path.resolve(themeDir, 'cards/', cardType);
-    const customCardTypePath = path.resolve('cards/', cardType);
+    const cardTypePath = path.join(themeDir, 'cards/', cardType);
+    const customCardTypePath = path.join('cards/', cardType);
     if (!fs.existsSync(cardTypePath) && !fs.existsSync(customCardTypePath)) {
       error(`Invalid cardType: can't find "${cardType}" at at the expected paths "${cardTypePath}" or "${customCardTypePath}" for vertical "${verticalName}".`);
       return false;

--- a/hooks/templatedatavalidator.js
+++ b/hooks/templatedatavalidator.js
@@ -14,7 +14,7 @@ module.exports = function (pageData) {
     isGlobalConfigValid(pageData.global_config), 
     isPageVerticalConfigValid(pageData, jamboConfig)
   ];
-  const isValid = !validatorResults.some((result) => !result);
+  const isValid = validatorResults.every(result => result);
   return isValid;
 }
 
@@ -41,18 +41,20 @@ function isGlobalConfigValid(globalConfig) {
  */
 function isPageVerticalConfigValid(pageData, jamboConfig) {
   const themeDirectory = path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme);
-  return Object.keys(pageData.verticalsToConfig).reduce((isValid, key) => {
-    if (key === 'Universal') {
-      return isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig) && isValid;
-    }
-    const universalSectionTemplate = pageData.verticalsToConfig[key].universalSectionTemplate;
-    const cardType = pageData.verticalsToConfig[key].cardType;
-    const validatorResults = [
-      isUniversalSectionTemplateValid(key, themeDirectory, universalSectionTemplate), 
-      isCardTypeValid(key, themeDirectory, cardType)
-    ];
-    return !validatorResults.some((result) => !result) && isValid;
-  }, true);
+  return Object.keys(pageData.verticalsToConfig)
+    .map(key => {
+      if (key === 'Universal') {
+        return isAllVerticalConfigsValid(pageData.verticalConfigs, jamboConfig);
+      }
+      const universalSectionTemplate = pageData.verticalsToConfig[key].universalSectionTemplate;
+      const cardType = pageData.verticalsToConfig[key].cardType;
+      const validatorResults = [
+        isUniversalSectionTemplateValid(key, themeDirectory, universalSectionTemplate), 
+        isCardTypeValid(key, themeDirectory, cardType)
+      ];
+      return validatorResults.every(result => result);
+    })
+    .every(result => result);
 }
 
 /**
@@ -105,7 +107,9 @@ function isAllVerticalConfigsValid(verticalConfigs, jamboConfig) {
   if (!verticalConfigs) {
     return true;
   }
-  return Object.keys(verticalConfigs).reduce((isValid, key) => {
-    return isPageVerticalConfigValid(verticalConfigs[key], jamboConfig) && isValid;
-  }, true);
+  return Object.keys(verticalConfigs)
+    .map(key => {
+      return isPageVerticalConfigValid(verticalConfigs[key], jamboConfig);
+    })
+    .every(result => result);
 }


### PR DESCRIPTION
- Add logger using npmlog package for color in logs
- Add templatedatavalidator hook to check for missing experienceKey, and invalid cardTypes or universalSectionTemplates

J=SLAP-1424
TEST=compile

- Changed a vertical config to use invalid cardType and universalSectionTemplates. Verified errors show up in console during jambo build (using local jambo that point to develop branch)
- Changed a universal config and verified errors show up in console