### PR TITLE
TestCafe: concurrency to acceptance tests

### DIFF
--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 export BROWSERSTACK_USE_AUTOMATE="1"
 export BROWSERSTACK_PROJECT_NAME="Answers Hitchhiker Theme"
-# GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
-GITHUB_BRANCH="hotfix/fake-branch"
+GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
 export BROWSERSTACK_BUILD_ID="${GITHUB_BRANCH} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE

--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 export BROWSERSTACK_USE_AUTOMATE="1"
 export BROWSERSTACK_PROJECT_NAME="Answers Hitchhiker Theme"
-GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
+# GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
+GITHUB_BRANCH="hotfix/fake-branch"
 export BROWSERSTACK_BUILD_ID="${GITHUB_BRANCH} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npm run acceptance -- --browsers browserstack:ie@11.0 browserstack:safari browserstack:firefox
+if [[ $GITHUB_BRANCH == release/*
+  || $GITHUB_BRANCH == hotfix/*
+  || $GITHUB_BRANCH == master
+  || $GITHUB_BRANCH == support* ]]
+then
+  npm run acceptance -- --browsers browserstack:ie@11.0 browserstack:safari browserstack:firefox
+else
+  npm run acceptance -- --browsers browserstack:ie@11.0 --concurrency 2
+fi

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -3,24 +3,33 @@ const { PORT } = require('./constants');
 const yargs = require('yargs');
 
 const argv = yargs
-  .option('browsers', {
-    description: 'The browsers to run the tests on',
-    alias: 'b',
-    type: 'array',
-    default: 'chrome'
+  .options({
+    'browsers': {
+      description: 'The browsers to run the tests on',
+      alias: 'b',
+      type: 'array',
+      default: 'chrome'
+    },
+    'concurrency': {
+      description: 'Number of instances of each browser type',
+      alias: 'c',
+      type: 'number',
+      default: 1
+    }
   })
   .help()
   .alias('help', 'h')
   .parse();
 
-runTests(argv.browsers);
+runTests(argv.browsers, argv.concurrency);
 
 /**
  * Run the acceptance tests
  * 
  * @param {string[]} browsers The browsers to run the tests on
+ * @param {number} concurrency Number of instances of each browser type
  */
-async function runTests (browsers) {
+async function runTests (browsers, concurrency) {
   const testcafe = await createTestCafe({
     configFile: './testcafe.json'
   });
@@ -28,7 +37,7 @@ async function runTests (browsers) {
     const numberTestsFailed = await testcafe.createRunner()
       .src('tests/acceptance/suites/*.js')
       .browsers(browsers)
-      .concurrency(2)
+      .concurrency(concurrency)
       .startApp(`npx serve -l tcp://0.0.0.0:${PORT} test-site/public`, 4000)
       .run({ quarantineMode: true });
     if (numberTestsFailed > 0) {

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -13,23 +13,57 @@ const argv = yargs
   .alias('help', 'h')
   .parse();
 
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+async function serveSite() {
+  await exec(`npx serve -l tcp://0.0.0.0:${PORT} test-site/public`);
+}
+
+serveSite();
 runTests(argv.browsers);
+
+// runSampleTest(argv.browsers);
+// console.log('out');
+// async function runSampleTest (browsers) {
+//   const testcafe = await createTestCafe();
+//   try {
+//   const runner = testcafe.createRunner();
+//   const failedCount = await runner
+//     .src('tests/acceptance/suites/vertical-full-page-map.js')
+//     .browsers(browsers)
+//     .concurrency(2)
+//     .run();
+//     console.log('Tests failed: ' + failedCount);
+//   }
+//   finally {
+//       console.log('closing..');
+//       await testcafe.close();
+//       console.log('closed.');
+//   }
+//   console.log('done');
+// }
 
 /**
  * Run the acceptance tests
  * 
  * @param {string[]} browsers The browsers to run the tests on
  */
-async function runTests (browsers) {
+function runTests (browsers) {
+  const tests = [];
+  browsers.forEach(browser => tests.push(testCafeInstance(browser)));
+  Promise.all(tests).then(() => {console.log("Completed all testcafe acceptance tests.");});
+}
+
+async function testCafeInstance(browser) {
   const testcafe = await createTestCafe({
     configFile: './testcafe.json'
   });
   try {
     const numberTestsFailed = await testcafe.createRunner()
       .src('tests/acceptance/suites/*.js')
-      .browsers(browsers)
+      .browsers(browser)
       .concurrency(2)
-      .startApp(`npx serve -l tcp://0.0.0.0:${PORT} test-site/public`, 4000)
       .run({ quarantineMode: true });
     if (numberTestsFailed > 0) {
       await testcafe.close();

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -13,57 +13,23 @@ const argv = yargs
   .alias('help', 'h')
   .parse();
 
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
-
-async function serveSite() {
-  await exec(`npx serve -l tcp://0.0.0.0:${PORT} test-site/public`);
-}
-
-serveSite();
 runTests(argv.browsers);
-
-// runSampleTest(argv.browsers);
-// console.log('out');
-// async function runSampleTest (browsers) {
-//   const testcafe = await createTestCafe();
-//   try {
-//   const runner = testcafe.createRunner();
-//   const failedCount = await runner
-//     .src('tests/acceptance/suites/vertical-full-page-map.js')
-//     .browsers(browsers)
-//     .concurrency(2)
-//     .run();
-//     console.log('Tests failed: ' + failedCount);
-//   }
-//   finally {
-//       console.log('closing..');
-//       await testcafe.close();
-//       console.log('closed.');
-//   }
-//   console.log('done');
-// }
 
 /**
  * Run the acceptance tests
  * 
  * @param {string[]} browsers The browsers to run the tests on
  */
-function runTests (browsers) {
-  const tests = [];
-  browsers.forEach(browser => tests.push(testCafeInstance(browser)));
-  Promise.all(tests).then(() => {console.log("Completed all testcafe acceptance tests.");});
-}
-
-async function testCafeInstance(browser) {
+async function runTests (browsers) {
   const testcafe = await createTestCafe({
     configFile: './testcafe.json'
   });
   try {
     const numberTestsFailed = await testcafe.createRunner()
       .src('tests/acceptance/suites/*.js')
-      .browsers(browser)
+      .browsers(browsers)
       .concurrency(2)
+      .startApp(`npx serve -l tcp://0.0.0.0:${PORT} test-site/public`, 4000)
       .run({ quarantineMode: true });
     if (numberTestsFailed > 0) {
       await testcafe.close();

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -28,6 +28,7 @@ async function runTests (browsers) {
     const numberTestsFailed = await testcafe.createRunner()
       .src('tests/acceptance/suites/*.js')
       .browsers(browsers)
+      .concurrency(2)
       .startApp(`npx serve -l tcp://0.0.0.0:${PORT} test-site/public`, 4000)
       .run({ quarantineMode: true });
     if (numberTestsFailed > 0) {


### PR DESCRIPTION
- update testcafe runner configuration to opens 2 instances of the same browser
- update run_browserstack_acceptance script to spin 1 instance of all three browser types on feature, hotfix, master, and support branch. All other branches will spin up 2 instances of ie11.

J=1431
TEST=auto

- ran acceptance tests from circleCI workflow multiple times. See that 2 sessions of each browser type is setup in browserStack. See that the time, for the most part, is reduced by 2-3 mins.
- tested script locally: change the GITHUB_BRANCH var to different branch names and see what command line is called
- tested script through circleCI from pr: made a push to pr with a hardcoded GITHUB_BRANCH value (hotfix/test-something) and see that it spin up 2 ie11 instance in browserstack. made a push without hardcoded value (which will take this pr name dev/testcafe-concurrency) and see that 6 instances (2 of each browser type) is up in browserstack.