### PR TITLE
fix get language locale from map provider

### DIFF
--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -5,10 +5,7 @@ import { RendererOptions } from './Renderer/Renderer.js';
 import { PinProperties } from './Maps/PinProperties.js';
 import { PinClustererOptions } from './PinClusterer/PinClusterer.js';
 import { transformDataToUniversalData, transformDataToVerticalData } from './Util/transformers.js';
-import { getEncodedSvg } from './Util/helpers.js';
-
-import { GoogleMaps } from './Maps/Providers/Google.js';
-import { MapboxMaps } from './Maps/Providers/Mapbox.js';
+import { getEncodedSvg, getMapProvider } from './Util/helpers.js';
 
 import ThemeMapConfig from './ThemeMapConfig.js'
 import StorageKeys from '../constants/storage-keys.js';
@@ -106,7 +103,7 @@ class ThemeMap extends ANSWERS.Component {
    * Load the map provider scripts and initialize the map with the configuration options
    */
   async loadAndInitializeMap () {
-    const mapProviderImpl = (this.config.mapProvider === 'google') ? GoogleMaps : MapboxMaps;
+    const mapProviderImpl = getMapProvider(this.config.mapProvider);
     await mapProviderImpl.load(this.config.apiKey, {
       client: this.config.clientId,
       language: this.config.language,

--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -40,7 +40,6 @@ const getMapProvider = (mapProvider) => {
   if (mapProvider === 'mapbox') {
     return MapboxMaps;
   }
-  console.warn(`Map provider ${mapProvider} is not supported in the theme. Default to MapBox.`);
   return MapboxMaps;
 }
 

--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -1,3 +1,6 @@
+import { GoogleMaps } from '../Maps/Providers/Google.js';
+import { MapboxMaps } from '../Maps/Providers/Mapbox.js';
+
 /**
  * Gets the language locale according to specific fallback logic
  * 1. The user-specified locale to the component
@@ -5,21 +8,22 @@
  * 3. If still invalid, providers fallback to en
  *
  * @param {string} localeStr The user-defined locale string
- * @param {string[]} supportedLocales The locales supported by the current map provider
+ * @param {string} mapProvider name of the current map provider
  * @return {string} The language locale for the map
  */
-const getLanguageForProvider = (localeStr, supportedLocales) => {
+const getLanguageForProvider = (localeStr, mapProvider) => {
   if (localeStr.length == 2) {
     return localeStr;
   } 
 
   if (localeStr.length > 2) {
-    if (supportedLocalesForProvider.includes(localeStr)) {
-      return localeStr;
-    } 
+    const provider = (mapProvider === 'google') ? GoogleMaps : MapboxMaps;
+    const formattedLocaleStr = localeStr.replace('_', '-');
+    if (provider.getSupportedLocales().includes(formattedLocaleStr)) {
+      return formattedLocaleStr;
+    }
     return localeStr.substring(0, 2);
   }
-
   return 'en';
 };
 

--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -17,7 +17,7 @@ const getLanguageForProvider = (localeStr, mapProvider) => {
   } 
 
   if (localeStr.length > 2) {
-    const provider = (mapProvider === 'google') ? GoogleMaps : MapboxMaps;
+    const provider = getMapProvider(mapProvider);
     const formattedLocaleStr = localeStr.replace('_', '-');
     if (provider.getSupportedLocales().includes(formattedLocaleStr)) {
       return formattedLocaleStr;
@@ -26,6 +26,23 @@ const getLanguageForProvider = (localeStr, mapProvider) => {
   }
   return 'en';
 };
+
+/**
+ * Returns the corresponding MapProvider instance (Default to MapBox)
+ * 
+ * @param {string} mapProvider
+ * @return {MapProvider}
+ */
+const getMapProvider = (mapProvider) => {
+  if (mapProvider === 'google') {
+    return GoogleMaps;
+  }
+  if (mapProvider === 'mapbox') {
+    return MapboxMaps;
+  }
+  console.warn(`Map provider ${mapProvider} is not supported in the theme. Default to MapBox.`);
+  return MapboxMaps;
+}
 
 /**
  * Returns a utf-8 encoding of an SVG
@@ -128,6 +145,7 @@ const removeElement = (element) => {
 
 export {
   getLanguageForProvider,
+  getMapProvider,
   getEncodedSvg,
   getNormalizedLongitude,
   isViewableWithinContainer,

--- a/tests/static/js/theme-map/Util/helpers.js
+++ b/tests/static/js/theme-map/Util/helpers.js
@@ -1,4 +1,4 @@
-import { getNormalizedLongitude } from 'static/js/theme-map/Util/helpers.js';
+import { getNormalizedLongitude, getLanguageForProvider } from 'static/js/theme-map/Util/helpers.js';
 
 describe('getNormalizedLongitude', () => {
   describe('it works within normal longitude bounds', () => {
@@ -49,6 +49,28 @@ describe('getNormalizedLongitude', () => {
       expect(getNormalizedLongitude(-450)).toEqual(-90);
       expect(getNormalizedLongitude(-540)).toEqual(-180);
       expect(getNormalizedLongitude(-720)).toEqual(0);
+    });
+  });
+});
+
+describe('getLanguageForProvider', () => {
+  describe('it works with different language/locale pairs', () => {
+    it('works with 0', () => {
+      expect(getNormalizedLongitude(0)).toEqual(0);
+    });
+
+    it('works with map provider google', () => {
+      expect(getLanguageForProvider('en', 'google')).toEqual('en');
+      expect(getLanguageForProvider('a', 'google')).toEqual('en');
+      expect(getLanguageForProvider('en-IDK', 'google')).toEqual('en');
+      expect(getLanguageForProvider('en-GB', 'google')).toEqual('en-GB');
+      expect(getLanguageForProvider('en_GB', 'google')).toEqual('en-GB');
+    });
+
+    it('works with map provider mapbox', () => {
+      expect(getLanguageForProvider('a', 'mapbox')).toEqual('en');
+      expect(getLanguageForProvider('fr', 'mapbox')).toEqual('fr');
+      expect(getLanguageForProvider('fr-CA', 'mapbox')).toEqual('fr');
     });
   });
 });

--- a/tests/static/js/theme-map/Util/helpers.js
+++ b/tests/static/js/theme-map/Util/helpers.js
@@ -55,10 +55,6 @@ describe('getNormalizedLongitude', () => {
 
 describe('getLanguageForProvider', () => {
   describe('it works with different language/locale pairs', () => {
-    it('works with 0', () => {
-      expect(getNormalizedLongitude(0)).toEqual(0);
-    });
-
     it('works with map provider google', () => {
       expect(getLanguageForProvider('en', 'google')).toEqual('en');
       expect(getLanguageForProvider('a', 'google')).toEqual('en');

--- a/tests/static/js/theme-map/Util/helpers.js
+++ b/tests/static/js/theme-map/Util/helpers.js
@@ -1,4 +1,7 @@
-import { getNormalizedLongitude, getLanguageForProvider } from 'static/js/theme-map/Util/helpers.js';
+import { getNormalizedLongitude, getLanguageForProvider, getMapProvider } from 'static/js/theme-map/Util/helpers.js';
+import { GoogleMaps } from 'static/js/theme-map/Maps/Providers/Google.js';
+import { MapboxMaps } from 'static/js/theme-map//Maps/Providers/Mapbox.js';
+
 
 describe('getNormalizedLongitude', () => {
   describe('it works within normal longitude bounds', () => {
@@ -50,6 +53,19 @@ describe('getNormalizedLongitude', () => {
       expect(getNormalizedLongitude(-540)).toEqual(-180);
       expect(getNormalizedLongitude(-720)).toEqual(0);
     });
+  });
+});
+
+describe('getMapProvider', () => {
+  it('returns the right mapProvider instance', () => {
+      expect(getMapProvider('google')).toEqual(GoogleMaps);
+      expect(getMapProvider('mapbox')).toEqual(MapboxMaps);
+  }); 
+
+  it('returns MapBox on unsupported mapProvider name', () => {
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+    expect(getMapProvider('unknown')).toEqual(MapboxMaps);
+    expect(consoleWarn).toHaveBeenCalled();
   });
 });
 

--- a/tests/static/js/theme-map/Util/helpers.js
+++ b/tests/static/js/theme-map/Util/helpers.js
@@ -63,9 +63,7 @@ describe('getMapProvider', () => {
   }); 
 
   it('returns MapBox on unsupported mapProvider name', () => {
-    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
     expect(getMapProvider('unknown')).toEqual(MapboxMaps);
-    expect(consoleWarn).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
- `getLanguageForProvider` was using an undefined variable supportedLocalesforProvider. Updated function to 
get provider instance based on given provider name, and check if the given locale is within the list of provider's supported locales.

J=TECHOPS-1288
TEST=manual

used client experience that uses locale en_GB and see that map is loaded on page
added jest test for getLanguageForProvider()