### PR TITLE
spellcheck clickbox

### DIFF
--- a/static/scss/answers/templates/universal-standard.scss
+++ b/static/scss/answers/templates/universal-standard.scss
@@ -5,12 +5,6 @@
     flex-grow: 1;
   }
 
-  &-filtersAndResults
-  {
-    display: flex;
-    flex-direction: column;
-  }
-
   &-directAnswer
   {
     .yxt-DirectAnswer-footer


### PR DESCRIPTION
From this pr: https://github.com/yext/answers-hitchhiker-theme/pull/734, negative bottom-margin for spellchecker creates a boundary for the div that is smaller than the content inside. When the following div "Answers-filtersAndResults" uses flex property to cover all the free space up to the boundary of its neighboring divs, this then overlap with the clickbox area of the spellcheck link. Since div "Answers-filtersAndResults" only contains a single child element and it's not directly relying on any flex styling, we can get rid of the flex display to resolve this issue.

J=TECHOPS-1295
TEST=manual

launched test site and remove the flex property for "Answers-filtersAndResults". See that there's no UI changes and spellcheck have expected clickbox area.