### PR TITLE
v1.22.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "A starter answers theme for hitchhikers",
   "scripts": {
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu jest --verbose",

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -5,10 +5,7 @@ import { RendererOptions } from './Renderer/Renderer.js';
 import { PinProperties } from './Maps/PinProperties.js';
 import { PinClustererOptions } from './PinClusterer/PinClusterer.js';
 import { transformDataToUniversalData, transformDataToVerticalData } from './Util/transformers.js';
-import { getEncodedSvg } from './Util/helpers.js';
-
-import { GoogleMaps } from './Maps/Providers/Google.js';
-import { MapboxMaps } from './Maps/Providers/Mapbox.js';
+import { getEncodedSvg, getMapProvider } from './Util/helpers.js';
 
 import ThemeMapConfig from './ThemeMapConfig.js'
 import StorageKeys from '../constants/storage-keys.js';
@@ -106,7 +103,7 @@ class ThemeMap extends ANSWERS.Component {
    * Load the map provider scripts and initialize the map with the configuration options
    */
   async loadAndInitializeMap () {
-    const mapProviderImpl = (this.config.mapProvider === 'google') ? GoogleMaps : MapboxMaps;
+    const mapProviderImpl = getMapProvider(this.config.mapProvider);
     await mapProviderImpl.load(this.config.apiKey, {
       client: this.config.clientId,
       language: this.config.language,

--- a/static/js/theme-map/Util/helpers.js
+++ b/static/js/theme-map/Util/helpers.js
@@ -1,3 +1,6 @@
+import { GoogleMaps } from '../Maps/Providers/Google.js';
+import { MapboxMaps } from '../Maps/Providers/Mapbox.js';
+
 /**
  * Gets the language locale according to specific fallback logic
  * 1. The user-specified locale to the component
@@ -5,23 +8,40 @@
  * 3. If still invalid, providers fallback to en
  *
  * @param {string} localeStr The user-defined locale string
- * @param {string[]} supportedLocales The locales supported by the current map provider
+ * @param {string} mapProvider name of the current map provider
  * @return {string} The language locale for the map
  */
-const getLanguageForProvider = (localeStr, supportedLocales) => {
+const getLanguageForProvider = (localeStr, mapProvider) => {
   if (localeStr.length == 2) {
     return localeStr;
   } 
 
   if (localeStr.length > 2) {
-    if (supportedLocalesForProvider.includes(localeStr)) {
-      return localeStr;
-    } 
+    const provider = getMapProvider(mapProvider);
+    const formattedLocaleStr = localeStr.replace('_', '-');
+    if (provider.getSupportedLocales().includes(formattedLocaleStr)) {
+      return formattedLocaleStr;
+    }
     return localeStr.substring(0, 2);
   }
-
   return 'en';
 };
+
+/**
+ * Returns the corresponding MapProvider instance (Default to MapBox)
+ * 
+ * @param {string} mapProvider
+ * @return {MapProvider}
+ */
+const getMapProvider = (mapProvider) => {
+  if (mapProvider === 'google') {
+    return GoogleMaps;
+  }
+  if (mapProvider === 'mapbox') {
+    return MapboxMaps;
+  }
+  return MapboxMaps;
+}
 
 /**
  * Returns a utf-8 encoding of an SVG
@@ -124,6 +144,7 @@ const removeElement = (element) => {
 
 export {
   getLanguageForProvider,
+  getMapProvider,
   getEncodedSvg,
   getNormalizedLongitude,
   isViewableWithinContainer,

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {

--- a/static/scss/answers/templates/universal-standard.scss
+++ b/static/scss/answers/templates/universal-standard.scss
@@ -5,12 +5,6 @@
     flex-grow: 1;
   }
 
-  &-filtersAndResults
-  {
-    display: flex;
-    flex-direction: column;
-  }
-
   &-directAnswer
   {
     .yxt-DirectAnswer-footer

--- a/tests/static/js/theme-map/Util/helpers.js
+++ b/tests/static/js/theme-map/Util/helpers.js
@@ -1,4 +1,7 @@
-import { getNormalizedLongitude } from 'static/js/theme-map/Util/helpers.js';
+import { getNormalizedLongitude, getLanguageForProvider, getMapProvider } from 'static/js/theme-map/Util/helpers.js';
+import { GoogleMaps } from 'static/js/theme-map/Maps/Providers/Google.js';
+import { MapboxMaps } from 'static/js/theme-map//Maps/Providers/Mapbox.js';
+
 
 describe('getNormalizedLongitude', () => {
   describe('it works within normal longitude bounds', () => {
@@ -49,6 +52,35 @@ describe('getNormalizedLongitude', () => {
       expect(getNormalizedLongitude(-450)).toEqual(-90);
       expect(getNormalizedLongitude(-540)).toEqual(-180);
       expect(getNormalizedLongitude(-720)).toEqual(0);
+    });
+  });
+});
+
+describe('getMapProvider', () => {
+  it('returns the right mapProvider instance', () => {
+      expect(getMapProvider('google')).toEqual(GoogleMaps);
+      expect(getMapProvider('mapbox')).toEqual(MapboxMaps);
+  }); 
+
+  it('returns MapBox on unsupported mapProvider name', () => {
+    expect(getMapProvider('unknown')).toEqual(MapboxMaps);
+  });
+});
+
+describe('getLanguageForProvider', () => {
+  describe('it works with different language/locale pairs', () => {
+    it('works with map provider google', () => {
+      expect(getLanguageForProvider('en', 'google')).toEqual('en');
+      expect(getLanguageForProvider('a', 'google')).toEqual('en');
+      expect(getLanguageForProvider('en-IDK', 'google')).toEqual('en');
+      expect(getLanguageForProvider('en-GB', 'google')).toEqual('en-GB');
+      expect(getLanguageForProvider('en_GB', 'google')).toEqual('en-GB');
+    });
+
+    it('works with map provider mapbox', () => {
+      expect(getLanguageForProvider('a', 'mapbox')).toEqual('en');
+      expect(getLanguageForProvider('fr', 'mapbox')).toEqual('fr');
+      expect(getLanguageForProvider('fr-CA', 'mapbox')).toEqual('fr');
     });
   });
 });


### PR DESCRIPTION
### Bug Fixes
- Fixed the logic of the `getLanguageForProvider` utility method. This method maps the `locale` specified by the user to one that is understood by the chosen map provider. (#891)
- Corrected a styling issue with the `SpellCheck` query suggestion. This issue made it difficult to click the query suggestion and fire off a new query. (#892)