### PR TITLE
Add sessionTrackingEnabled and analyticsEventsEnabled to global_config

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -5,6 +5,8 @@
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
   // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
   // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build output and the token must be specified through manual initialization.
+  "sessionTrackingEnabled": true, // Whether or not session tracking is enabled for all pages
+  "analyticsEventsEnabled": true, // Whether or not to submit user interaction analytics events
   "logo": "", // The link to the logo for open graph meta tag - og:image.
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -5,6 +5,8 @@
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
   // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
   // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build and the token must be specified through the runtime config.
+  "sessionTrackingEnabled": true, // Whether or not session tracking is enabled for all pages
+  "analyticsEventsEnabled": true, // Whether or not to submit user interaction analytics events
   "logo": "", // The link to the logo for open graph meta tag - og:image.
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer


### PR DESCRIPTION
Add sessionTrackingEnabled and analyticsEventsEnabled to global_config in accordance with QA feedback from product

J=SLAP-1473
TEST=manual

Launch the test site and confirm that analytics are enabled (so long as a business ID is included) and confirm that session tracking is also enabled