### PR TITLE
Add HitchhikerCTA-icon classes back

### DIFF
--- a/cards/document-standard/template.hbs
+++ b/cards/document-standard/template.hbs
@@ -76,10 +76,12 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -98,10 +98,12 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -98,10 +98,12 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -135,10 +135,12 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -100,10 +100,12 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -135,10 +135,12 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -100,10 +100,12 @@
     {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -170,10 +170,12 @@
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -101,7 +101,7 @@
       target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
       {{#if (any iconName iconUrl)}}
       <div class="HitchhikerCTA-iconWrapper">
-        <div class="HitchhikerCTA-icon" data-component="IconComponent">
+        <div class="HitchhikerCTA-icon">
           {{> icons/iconPartial
               iconName=iconName
               iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -170,10 +170,12 @@
     target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
     {{#if (any iconName iconUrl)}}
     <div class="HitchhikerCTA-iconWrapper">
-      {{> icons/iconPartial
-          iconName=iconName
-          iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
-      }}
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
     </div>
     {{/if}}
     <div class='HitchhikerCTA-iconLabel'>


### PR DESCRIPTION
Add back the HitchhikerCTA divs and classes that were removed in #874

J=SLAP-1473
TEST=visual

Inspect the DOM and see the div and class present for the standard card. Inspect the updated Percy snapshots and see some of the icons change size slightly due to the CSS targeting the div. Also see the icon appear for the standard card which was previously missing.