### PR TITLE
RTL Answers CSS and chevrons

### DIFF
--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -18,21 +18,13 @@
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}
-    {{> chevron_icon }}
+    {{> icons/builtInIcon iconName='chevron'}}
   </a>
   {{else}}
   {{{card.title}}}
   {{/if}}
 </div>
 {{/if}}
-{{/inline}}
-
-{{#*inline 'chevron_icon'}}
-<svg viewBox="0 0 7 9" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(-1 -8)">
-    <path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"></path>
-  </g>
-</svg>
 {{/inline}}
 
 {{#*inline 'subtitle'}}

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -18,21 +18,13 @@
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}
-    {{> chevron_icon }}
+    {{> icons/builtInIcon iconName='chevron'}}
   </a>
   {{else}}
   {{{card.title}}}
   {{/if}}
 </div>
 {{/if}}
-{{/inline}}
-
-{{#*inline 'chevron_icon'}}
-<svg viewBox="0 0 7 9" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(-1 -8)">
-    <path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"></path>
-  </g>
-</svg>
 {{/inline}}
 
 {{#*inline 'subtitle'}}

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="YxtPage-doc">
+<html class="YxtPage-doc" {{#if (isRTL global_config.locale) }}dir="rtl"{{/if}}>
   <head>
     <script>
       {{#babel}}
@@ -143,7 +143,11 @@
     {{/babel}}
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="{{sdkAssetUrl global_config.sdkVersion 'en' 'answers.css'}}">
+    {{#if (isRTL global_config.locale) }}
+      <link rel="stylesheet" type="text/css" href="{{sdkAssetUrl global_config.sdkVersion 'en' 'answers.rtl.css'}}">
+    {{else}}
+      <link rel="stylesheet" type="text/css" href="{{sdkAssetUrl global_config.sdkVersion 'en' 'answers.css'}}">
+    {{/if}}
     <link rel="stylesheet" type="text/css"
       {{#if (isRTL global_config.locale) }}
         href="{{relativePath}}/bundle.rtl.css"
@@ -159,7 +163,7 @@
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->
     {{/if}}
-    <div {{#if (isRTL global_config.locale) }}dir="rtl"{{/if}} class="YxtPage-wrapper {{pageWrapperCss}}">
+    <div class="YxtPage-wrapper {{pageWrapperCss}}">
       {{> overlay/markup/overlay-header }}
       {{> layouts/header }}
       <div class="YxtPage-content">

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -143,11 +143,13 @@
     {{/babel}}
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.10/iframeResizer.contentWindow.min.js"></script>
-    {{#if (isRTL global_config.locale) }}
-      <link rel="stylesheet" type="text/css" href="{{sdkAssetUrl global_config.sdkVersion 'en' 'answers.rtl.css'}}">
-    {{else}}
-      <link rel="stylesheet" type="text/css" href="{{sdkAssetUrl global_config.sdkVersion 'en' 'answers.css'}}">
-    {{/if}}
+    <link rel="stylesheet" type="text/css"
+      {{#if (isRTL global_config.locale) }}
+        href="{{sdkAssetUrl global_config.sdkVersion 'en' 'answers.rtl.css'}}"
+      {{else}}
+        href="{{sdkAssetUrl global_config.sdkVersion 'en' 'answers.css'}}"
+      {{/if}}
+      >
     <link rel="stylesheet" type="text/css"
       {{#if (isRTL global_config.locale) }}
         href="{{relativePath}}/bundle.rtl.css"

--- a/static/js/overlay/answers-frame/dom/promptinjector.js
+++ b/static/js/overlay/answers-frame/dom/promptinjector.js
@@ -117,14 +117,17 @@ export default class PromptInjector {
   _appendChevronRight(el) {
     const iconEl = document.createElement('div');
     iconEl.classList.add('OverlayPrompt-buttonIcon');
-    iconEl.innerHTML = `<?xml version="1.0" encoding="UTF-8"?>
-      <svg viewBox="0.5 0 6 9"
-        version="1.1" xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink">
-        <g fill-rule="evenodd" transform="translate(-1 -8)">
-          <path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"/>
-        </g>
-      </svg>`;
+    iconEl.innerHTML = `
+      <div class="Icon Icon--chevron">
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg viewBox="0.5 0 6 9"
+          version="1.1" xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+          <g fill-rule="evenodd" transform="translate(-1 -8)">
+            <path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"/>
+          </g>
+        </svg>
+      </div>`;
 
     el.appendChild(iconEl);
   }

--- a/static/js/overlay/answers-frame/dom/promptinjector.js
+++ b/static/js/overlay/answers-frame/dom/promptinjector.js
@@ -117,17 +117,16 @@ export default class PromptInjector {
   _appendChevronRight(el) {
     const iconEl = document.createElement('div');
     iconEl.classList.add('OverlayPrompt-buttonIcon');
-    iconEl.innerHTML = `
-      <div class="Icon Icon--chevron">
-        <?xml version="1.0" encoding="UTF-8"?>
-        <svg viewBox="0.5 0 6 9"
-          version="1.1" xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink">
-          <g fill-rule="evenodd" transform="translate(-1 -8)">
-            <path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"/>
-          </g>
-        </svg>
-      </div>`;
+    iconEl.classList.add('Icon')
+    iconEl.classList.add('Icon--chevron')
+    iconEl.innerHTML = `<?xml version="1.0" encoding="UTF-8"?>
+      <svg viewBox="0.5 0 6 9"
+        version="1.1" xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g fill-rule="evenodd" transform="translate(-1 -8)">
+          <path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"/>
+        </g>
+      </svg>`;
 
     el.appendChild(iconEl);
   }


### PR DESCRIPTION
Update to use the answers.rtl.css if the locale is an rtl locale, and update the chevron_icons in the link components so that they will flip for RTL locales

J=SLAP-1465
TEST=manual

See that on an RTL locale, the answers.rtl.css bundle is used and the link title chevron icon flips. Test that the overlay chevron is flipped when using the answers.rtl.css bundle.