### PR TITLE
Remove 100% sizing for images and SVGs

### DIFF
--- a/static/scss/answers/common/base.scss
+++ b/static/scss/answers/common/base.scss
@@ -189,13 +189,6 @@ html
   display: flex;
 }
 
-img,
-svg
-{
-  max-width: 100%;
-  max-height: 100%;
-}
-
 button,
 textarea
 {


### PR DESCRIPTION
Remove this CSS because it causes the voice search icon to shift when interacting with the search bar

Using 100% for width or height often causes issues because it doesn't take into account padding, margins, and borders the same way that auto does.

J=SLAP-1473
TEST=manual

Enable voice and the loading indicator and see that the icons don't shift around while interacting with the search bar