### PR TITLE
Fix voice icon shifting

### DIFF
--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -46,6 +46,12 @@
       padding-right: var(--yxt-base-spacing);
       font-size: var(--yxt-font-size-lg);
     }
+
+    .yxt-SearchBar-voiceSearch svg, img
+    {
+      max-width: none;
+      max-height: none;
+    }
   }
 
   &-nav


### PR DESCRIPTION
Fix shifting of the voice icon which occurs when clicking the clear button

J=SLAP-1473
TEST=manual

Click the clear button and confirm the icon no longer shifts. Test with the default voice icon SVGs and with custom images