### PR TITLE
Fix Grunt memory leak

### DIFF
--- a/static/Gruntfile.js
+++ b/static/Gruntfile.js
@@ -12,18 +12,17 @@ module.exports = function (grunt) {
     watch: {
       all: {
         files: ['**', '!**/node_modules/**', `!${outputDir}/**`],
-        tasks: ['build',],
+        tasks: ['build-site'],
         options: {
           spawn: false,
         },
       },
     },
   });
-
   grunt.loadNpmTasks('grunt-webpack');
   grunt.loadNpmTasks('grunt-contrib-watch');
 
-  grunt.registerTask('build', 'jambo build -> grunt webpack', () => {
+  grunt.registerTask('build-site', 'Builds the site', () => {
     spawnSync('npm', ['run',  'build', '--silent'], { stdio: 'inherit' });
   });
 }

--- a/static/package.json
+++ b/static/package.json
@@ -5,7 +5,7 @@
   "main": "Gruntfile.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "jambo build && grunt webpack"
+    "build": "jambo build && webpack --config webpack-config.js"
   },
   "author": "tmeyer@yext.com",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Fix the grunt memory leak by isolating the jambo and webpack build into their own process

J=SLAP-1484
TEST=manual

Run "grunt watch" and confirm the build runs when files change