### PR TITLE
v1.22.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "A starter answers theme for hitchhikers",
   "scripts": {
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu jest --verbose",

--- a/static/Gruntfile.js
+++ b/static/Gruntfile.js
@@ -1,5 +1,5 @@
 const webpackConfig = require('./webpack-config');
-const { exec } = require("child_process");
+const { spawnSync } = require('child_process');
 const jamboConfig = require('./jambo.json');
 
 const outputDir = jamboConfig.dirs.output;
@@ -12,34 +12,16 @@ module.exports = function (grunt) {
     watch: {
       all: {
         files: ['**', '!**/node_modules/**', `!${outputDir}/**`],
-        tasks: ['jambobuild', 'webpack',],
-        options: {
-          spawn: false,
-        },
+        tasks: ['build-site']
       },
     },
   });
-
   grunt.loadNpmTasks('grunt-webpack');
   grunt.loadNpmTasks('grunt-contrib-watch');
-
-  grunt.registerTask('jambobuild', 'Jambo build.',
-  function() {
-    // Force task into async mode and grab a handle to the "done" function.
-    var done = this.async();
-    // Run some sync stuff.
-    grunt.log.writeln('Processing task...');
-    // And some async stuff.
-    exec('npx jambo build', (error, stdout, stderr) => {
-      if (error) {
-        console.log(error.message);
-        done(false);
-        return;
-      }
-
-      stderr && console.error(stderr);
-      stdout && console.log(stdout);
-      done();
+  grunt.registerTask('build-site', 'Builds the site.', () => {
+    spawnSync('npx jambo build && npx webpack --config webpack-config.js', {
+      shell: true,
+      stdio: 'inherit'
     });
   });
 }

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {


### PR DESCRIPTION
### Bug Fixes
- Fixed a memory leak in the Theme that occurred when the `grunt watch` task was used. Builds kicked off by the `watch` would retain a significant chunk of their allocated memory, even after completion. This behavior was corrected. (#906)