### PR TITLE
fix tests not being removed on upgrade, also remove test-site on upgrade

### DIFF
--- a/postupgrade/PostUpgradeHandler.js
+++ b/postupgrade/PostUpgradeHandler.js
@@ -15,7 +15,8 @@ class PostUpgradeHandler {
   }
 
   async handlePostUpgrade() {
-    if (!isGitSubmodule(this.themeDir)) {
+    const isSubmodule = await isGitSubmodule(this.themeDir)
+    if (!isSubmodule) {
       this.removeFromTheme('.gitignore', 'tests', 'test-site');
     }
     this.copyStaticFilesToTopLevel(

--- a/postupgrade/PostUpgradeHandler.js
+++ b/postupgrade/PostUpgradeHandler.js
@@ -16,7 +16,7 @@ class PostUpgradeHandler {
 
   async handlePostUpgrade() {
     if (!isGitSubmodule(this.themeDir)) {
-      this.removeFromTheme('.gitignore', 'tests');
+      this.removeFromTheme('.gitignore', 'tests', 'test-site');
     }
     this.copyStaticFilesToTopLevel(
       'package.json', 'Gruntfile.js', 'webpack-config.js', 'package-lock.json');

--- a/postupgrade/PostUpgradeHandler.js
+++ b/postupgrade/PostUpgradeHandler.js
@@ -15,7 +15,7 @@ class PostUpgradeHandler {
   }
 
   async handlePostUpgrade() {
-    const isSubmodule = await isGitSubmodule(this.themeDir)
+    const isSubmodule = await isGitSubmodule(this.themeDir);
     if (!isSubmodule) {
       this.removeFromTheme('.gitignore', 'tests', 'test-site');
     }


### PR DESCRIPTION
This folder is not needed by hitchhikers, and will slightly slow down the build
when jambo tries to register all files in themes/[theme] as partials.

Previously, there was a bug introduced in https://github.com/yext/answers-hitchhiker-theme/pull/441 where an async method was not being awaited,
causing the tests folder to not be deleted.

J=SLAP-1452
TEST=manual

test upgrading yanswers to this branch, and see that there's no test-site or tests folder