### PR TITLE
loading opacity styling to default scss file

### DIFF
--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -54,6 +54,7 @@ $container-width: 1000px;
   --yxt-text-snippet-highlight-color: #eef3fb;
   --yxt-text-snippet-font-color: var(--yxt-color-text-primary);
   --yxt-direct-answer-view-details-font-weight: var(--yxt-font-weight-normal);
+  --yxt-search-loading-opacity: 0.5;
 
   // interactive map variables
   --yxt-maps-search-this-area-background-color: white;


### PR DESCRIPTION
add --yxt-search-loading-opacity to answers-variables-default.scss

J=SLAP-1516
TEST=manual

see that opacity style is used when search