### PR TITLE
remove duplicated global config commented out props on upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5446,9 +5446,9 @@
       "dev": true
     },
     "comment-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.0.tgz",
-      "integrity": "sha512-WEghmVYaNq9NlWbrkzQTSsya9ycLyxJxpTQfZEan6a5Jomnjw18zS3Podf8q1Zf9BvonvQd/+Z7Z39L7KKzzdQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
+      "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
       "dev": true,
       "requires": {
         "array-timsort": "^1.0.3",
@@ -6981,10 +6981,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.67.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7548,12 +7545,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.19",
     "@yext/cta-formatter": "^1.0.0",
     "babel-jest": "^25.5.1",
-    "comment-json": "^4.1.0",
+    "comment-json": "^4.1.1",
     "cross-env": "^7.0.2",
     "express": "^4.17.1",
     "file-system": "^2.2.2",

--- a/postupgrade/PostUpgradeHandler.js
+++ b/postupgrade/PostUpgradeHandler.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const fsExtra = require('fs-extra');
 const path = require('path');
-const { mergeJson, isGitSubmodule } = require('./utils');
+const { mergeGlobalConfigs, isGitSubmodule } = require('./utils');
 const { spawnSync } = require('child_process');
 
 /**
@@ -51,7 +51,7 @@ class PostUpgradeHandler {
   async mergeThemeGlobalConfig(userGlobalConfigPath, themeGlobalConfigPath) {
     const updatedCommentJson = fs.readFileSync(themeGlobalConfigPath, 'utf-8');
     const originalCommentJson = fs.readFileSync(userGlobalConfigPath, 'utf-8');
-    return mergeJson(updatedCommentJson, originalCommentJson);
+    return mergeGlobalConfigs(updatedCommentJson, originalCommentJson);
   }
 
   /**

--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -5,21 +5,83 @@ const simpleGit = require('simple-git/promise')();
 
 /**
  * Merges two comment-json files, with the original having higher priority.
- * @param {string} updatedCommentJson 
- * @param {string} originalCommentJson 
+ * Prunes away duplicated commented out props.
+ *
+ * @param {string} newJson 
+ * @param {string} originalJson 
  * @returns {string}
  */
-exports.mergeJson = function(updatedCommentJson, originalCommentJson) {
-  const merged = assign(parse(updatedCommentJson), parse(originalCommentJson));
+exports.mergeGlobalConfigs = function (newJson, originalJson) {
+  const originalParsed = parse(originalJson);
+  const commentsFromOriginal = parseCommentedOutConfig(originalParsed);
+  const newPruned = pruneDuplicatedComments(parse(newJson), commentsFromOriginal);
+  const merged = assign(newPruned, originalParsed);
   return stringify(merged, null, 2);
 }
+
+/**
+ * Parses "commented out" config values.
+ *
+ * @param {import('comment-json').CommentJSONValue} jsonWithComments
+ * @returns {import('comment-json').CommentToken[]}
+ */
+function parseCommentedOutConfig(commentJsonValue) {
+  return getPropCommentSymbols(commentJsonValue).flatMap(symbol => {
+    const commentArr = commentJsonValue[symbol] || [];
+    // We only care about non-inline LineComments that "look like" a config option
+    return commentArr.filter(c => {
+      return !c.inline && c.type === 'LineComment' && c.value.match(/^\s?"\w+":/)
+    })
+  });
+}
+exports.parseCommentedOutConfig = parseCommentedOutConfig;
+
+/**
+ * Removes all comments in CommentJSONValue that have the same value and type as the given
+ * commentsToDedupe.
+ *
+ * @param {import('comment-json').CommentJSONValue} commentJsonValue
+ * @param {import('comment-json').CommentToken[]} commentsToDedupe
+ * @returns {import('comment-json').CommentJSONValue} the updated value
+ */
+function pruneDuplicatedComments(commentJsonValue, commentsToDedupe) {
+  return getPropCommentSymbols(commentJsonValue).reduce((prunedJson, symbol) => {
+    if (!commentJsonValue[symbol]) {
+      return prunedJson;
+    }
+    prunedJson[symbol] = commentJsonValue[symbol].filter(commentToCheck => {
+      return !commentsToDedupe.find(c => {
+        return c.value === commentToCheck.value
+          && c.type === commentToCheck.type
+          && c.inline === commentToCheck.inline;
+      })
+    });
+    return prunedJson;
+  }, { ...commentJsonValue });
+}
+exports.pruneDuplicatedComments = pruneDuplicatedComments
+
+/**
+ * Returns an array of global symbols for before, before:[prop], and after:[prop] comments.
+ * These are the comment types that can be used for commented out config props.
+ * 
+ * @param {import('comment-json').CommentJSONValue} commentJsonValue
+ * @returns {symbol[]}
+ */
+function getPropCommentSymbols(commentJsonValue) {
+  const beforeAndAfterSymbols = Object.keys(commentJsonValue).flatMap(prop => {
+    return [Symbol.for(`before:${prop}`), Symbol.for(`after:${prop}`)]
+  });
+  return beforeAndAfterSymbols.concat(Symbol.for('before'));
+}
+exports.getPropCommentSymbols = getPropCommentSymbols;
 
 /**
  * Gets the value of a given --jambo command line argument.
  * @param {string} param 
  * @returns {string}
  */
-exports.getJamboParam = function(param) {
+exports.getJamboParam = function (param) {
   const getProcessArgument = (param) => {
     const nameIndex = process.argv.indexOf(param);
     if (nameIndex === -1) {

--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -81,7 +81,7 @@ exports.getPropCommentSymbols = getPropCommentSymbols;
  * @param {string} param 
  * @returns {string}
  */
-exports.getJamboParam = function (param) {
+exports.getJamboParam = function(param) {
   const getProcessArgument = (param) => {
     const nameIndex = process.argv.indexOf(param);
     if (nameIndex === -1) {

--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -13,7 +13,7 @@ const simpleGit = require('simple-git/promise')();
  */
 exports.mergeGlobalConfigs = function (newJson, originalJson) {
   const originalParsed = parse(originalJson);
-  const commentsFromOriginal = parseCommentedOutConfig(originalParsed);
+  const commentsFromOriginal = parseCommentedOutProps(originalParsed);
   const newPruned = pruneDuplicatedComments(parse(newJson), commentsFromOriginal);
   const merged = assign(newPruned, originalParsed);
   return stringify(merged, null, 2);
@@ -25,7 +25,7 @@ exports.mergeGlobalConfigs = function (newJson, originalJson) {
  * @param {import('comment-json').CommentJSONValue} jsonWithComments
  * @returns {import('comment-json').CommentToken[]}
  */
-function parseCommentedOutConfig(commentJsonValue) {
+function parseCommentedOutProps(commentJsonValue) {
   return getPropCommentSymbols(commentJsonValue).flatMap(symbol => {
     const commentArr = commentJsonValue[symbol] || [];
     // We only care about non-inline LineComments that "look like" a config option
@@ -34,7 +34,7 @@ function parseCommentedOutConfig(commentJsonValue) {
     })
   });
 }
-exports.parseCommentedOutConfig = parseCommentedOutConfig;
+exports.parseCommentedOutProps = parseCommentedOutProps;
 
 /**
  * Removes all comments in CommentJSONValue that have the same value and type as the given

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1603,6 +1603,12 @@
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
     },
+    "array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -1999,10 +2005,12 @@
       "dev": true
     },
     "comment-json": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-3.0.2.tgz",
-      "integrity": "sha512-ysJasbJ671+8mPEmwLOfLFqxoGtSmjyoep+lKRVH4J1/hsGu79fwetMDQWk8de8mVgqDZ43D7JuJAlACqjI1pg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
+      "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
+      "dev": true,
       "requires": {
+        "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.2",
         "esprima": "^4.0.1",
         "has-own-prop": "^2.0.0",
@@ -2088,7 +2096,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cp-file": {
       "version": "6.2.0",
@@ -2695,7 +2704,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -3517,7 +3527,8 @@
     "has-own-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
-      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -4051,6 +4062,18 @@
         "yargs": "^17.0.0"
       },
       "dependencies": {
+        "comment-json": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-3.0.3.tgz",
+          "integrity": "sha512-P7XwYkC3qjIK45EAa9c5Y3lR7SMXhJqwFdWg3niAIAcbk3zlpKDdajV8Hyz/Y3sGNn3l+YNMl8A2N/OubSArHg==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "^1.0.2",
+            "esprima": "^4.0.1",
+            "has-own-prop": "^2.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -5539,7 +5562,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",

--- a/static/package.json
+++ b/static/package.json
@@ -20,7 +20,7 @@
     "@babel/runtime-corejs3": "^7.9.6",
     "@yext/cta-formatter": "^1.0.0",
     "babel-loader": "^8.1.0",
-    "comment-json": "^3.0.2",
+    "comment-json": "^4.1.1",
     "css-loader": "^3.4.2",
     "esbuild-loader": "^2.13.1",
     "file-system": "^2.2.2",
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@vimeo/player": "^2.15.3",
-    "comment-json": "^3.0.2",
     "core-js": "^3.6.5",
     "css-vars-ponyfill": "^2.3.1",
     "file-system": "^2.2.2",

--- a/tests/postupgrade/config1.json
+++ b/tests/postupgrade/config1.json
@@ -1,5 +1,0 @@
-{
-  // Comment1
-  "one": "hi", // Inline comment
-  "onetwo": "hello"
-}

--- a/tests/postupgrade/config2.json
+++ b/tests/postupgrade/config2.json
@@ -1,5 +1,0 @@
-{
-  "two": "bye",
-  "onetwo": "goodbye"
-  // Comment2
-}

--- a/tests/postupgrade/config3.json
+++ b/tests/postupgrade/config3.json
@@ -1,7 +1,0 @@
-{
-  // Comment1
-  "one": "hi", // Inline comment
-  "onetwo": "goodbye",
-  // Comment2
-  "two": "bye"
-}

--- a/tests/postupgrade/merged.json
+++ b/tests/postupgrade/merged.json
@@ -1,0 +1,16 @@
+{
+  "sdkVersion": "1.9", // The version of the Answers SDK to use
+  "sessionTrackingEnabled": true, // Whether or not session tracking is enabled for all pages
+  "analyticsEventsEnabled": true, // Whether or not to submit user interaction analytics events
+  // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
+  // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
+  // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
+  // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
+  // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build output and the token must be specified through manual initialization.
+  "logo": "", // The link to the logo for open graph meta tag - og:image.
+  "favicon": "",
+  "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer
+  "googleTagManagerId": "", // The container id associated with your Google Tag Manager container
+  "googleAnalyticsId": "", // The tracking Id associated with your Google Analytics account
+  "conversionTrackingEnabled": true // Whether or not conversion tracking is enabled for all pages
+}

--- a/tests/postupgrade/new.json
+++ b/tests/postupgrade/new.json
@@ -1,0 +1,16 @@
+{
+  "sdkVersion": "early-access-summer-21", // The version of the Answers SDK to use
+  // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
+  // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
+  // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
+  // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
+  // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build output and the token must be specified through manual initialization.
+  "sessionTrackingEnabled": true, // Whether or not session tracking is enabled for all pages
+  "analyticsEventsEnabled": true, // Whether or not to submit user interaction analytics events
+  "logo": "", // The link to the logo for open graph meta tag - og:image.
+  "favicon": "",
+  "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer
+  "googleTagManagerId": "", // The container id associated with your Google Tag Manager container
+  "googleAnalyticsId": "", // The tracking Id associated with your Google Analytics account
+  "conversionTrackingEnabled": true // Whether or not conversion tracking is enabled for all pages
+}

--- a/tests/postupgrade/original.json
+++ b/tests/postupgrade/original.json
@@ -1,0 +1,14 @@
+{
+  "sdkVersion": "1.9", // The version of the Answers SDK to use
+  // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
+  // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
+  // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
+  // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
+  // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build output and the token must be specified through manual initialization.
+  "logo": "", // The link to the logo for open graph meta tag - og:image.
+  "favicon": "",
+  "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer
+  "googleTagManagerId": "", // The container id associated with your Google Tag Manager container
+  "googleAnalyticsId": "", // The tracking Id associated with your Google Analytics account
+  "conversionTrackingEnabled": true // Whether or not conversion tracking is enabled for all pages
+}

--- a/tests/postupgrade/utils.js
+++ b/tests/postupgrade/utils.js
@@ -1,17 +1,79 @@
-const { mergeJson } = require('postupgrade/utils.js');
+const { parse, stringify } = require('comment-json');
 const fs = require('fs');
+const {
+  parseCommentedOutConfig,
+  mergeGlobalConfigs,
+  getPropCommentSymbols,
+  pruneDuplicatedComments
+} = require('../../postupgrade/utils');
 
-describe('postupgrade utils', () => {
-  describe('mergeJson', () => {
-    it('puts together two comment JSON strings', () => {
-      const config1 = fs.readFileSync('./tests/postupgrade/config1.json', 'utf-8');
-      const config2 = fs.readFileSync('./tests/postupgrade/config2.json', 'utf-8');
-      const expected = fs.readFileSync('./tests/postupgrade/config3.json', 'utf-8');
+it('mergeGlobalConfigs merges together two global configs, and removes duplicated comments', () => {
+  const originalConfig = fs.readFileSync('./tests/postupgrade/original.json', 'utf-8');
+  const newConfig = fs.readFileSync('./tests/postupgrade/new.json', 'utf-8');
+  const expected = fs.readFileSync('./tests/postupgrade/merged.json', 'utf-8');
+  const mergedConfig = mergeGlobalConfigs(newConfig, originalConfig);
+  expect(mergedConfig).toEqual(expected);
+});
 
-      // if this passes, then it is correctly not deleting any fields or comments
-      // and it is giving precedence to the second parameter config
-      const mergedConfig = mergeJson(config1, config2);
-      expect(mergedConfig).toEqual(expected);
-    });
-  });
+it('getPropCommentSymbols ', () => {
+  const testJson = parse(`{
+    // "sdkVersion": "1.9", // sdkVersion comment
+    "experienceVersion": "<REPLACE ME>", // experienceVersion comment
+    "businessId": "<REPLACE ME>", // businessId comment
+    // "initializeManually": true, // manualInit comment
+  }`);
+  const commentSymbols = getPropCommentSymbols(testJson);
+  expect(commentSymbols).toEqual([
+    Symbol.for('before:experienceVersion'),
+    Symbol.for('after:experienceVersion'),
+    Symbol.for('before:businessId'),
+    Symbol.for('after:businessId'),
+    Symbol.for('before')
+  ]);
+});
+
+it('parseCommentedOutConfig parses correctly', () => {
+  const commentJson = parse(`{
+    // "sdkVersion": "1.9", // sdkVersion comment
+    "experienceVersion": "<REPLACE ME>", // experienceVersion comment
+    "businessId": "<REPLACE ME>", // businessId comment
+    // "initializeManually": true, // manualInit comment
+  }`);
+  const commentTokens = parseCommentedOutConfig(commentJson);
+  expect(commentTokens).toMatchObject([
+    {
+      'inline': false,
+      'type': 'LineComment',
+      'value': ' "sdkVersion": "1.9", // sdkVersion comment'
+    },
+    {
+      'inline': false,
+      'type': 'LineComment',
+      'value': ' "initializeManually": true, // manualInit comment'
+    }
+  ]);
+});
+
+it('pruneDuplicatedComments prunes all comments that match value, type, and inlining', () => {
+  const jsonToPrune = parse(`{
+    //a comment
+    "experienceVersion": "<REPLACE ME>", //a comment
+    /*a comment*/
+    "businessId": "<REPLACE ME>" //a comment
+    //a comment
+  }`);
+  const commentsToDedupe = [
+    {
+      'inline': false,
+      'type': 'LineComment',
+      'value': 'a comment'
+    }
+  ];
+  const prunedJson = stringify(pruneDuplicatedComments(jsonToPrune, commentsToDedupe), null, 2);
+  const expected = stringify(parse(`{
+    "experienceVersion": "<REPLACE ME>", //a comment
+    /*a comment*/
+    "businessId": "<REPLACE ME>" //a comment
+  }`), null, 2);
+  expect(prunedJson).toEqual(expected);
 });

--- a/tests/postupgrade/utils.js
+++ b/tests/postupgrade/utils.js
@@ -1,7 +1,7 @@
 const { parse, stringify } = require('comment-json');
 const fs = require('fs');
 const {
-  parseCommentedOutConfig,
+  parseCommentedOutProps,
   mergeGlobalConfigs,
   getPropCommentSymbols,
   pruneDuplicatedComments
@@ -32,26 +32,40 @@ it('getPropCommentSymbols ', () => {
   ]);
 });
 
-it('parseCommentedOutConfig parses correctly', () => {
-  const commentJson = parse(`{
-    // "sdkVersion": "1.9", // sdkVersion comment
-    "experienceVersion": "<REPLACE ME>", // experienceVersion comment
-    "businessId": "<REPLACE ME>", // businessId comment
-    // "initializeManually": true, // manualInit comment
-  }`);
-  const commentTokens = parseCommentedOutConfig(commentJson);
-  expect(commentTokens).toMatchObject([
-    {
-      'inline': false,
-      'type': 'LineComment',
-      'value': ' "sdkVersion": "1.9", // sdkVersion comment'
-    },
-    {
-      'inline': false,
-      'type': 'LineComment',
-      'value': ' "initializeManually": true, // manualInit comment'
-    }
-  ]);
+describe('parseCommentedOutProps', () => {
+  it('parses comments correctly', () => {
+    const commentJson = parse(`{
+      // "sdkVersion": "1.9", // sdkVersion comment
+      "experienceVersion": "<REPLACE ME>", // experienceVersion comment
+      "businessId": "<REPLACE ME>", // businessId comment
+      // "initializeManually": true, // manualInit comment
+    }`);
+    const commentTokens = parseCommentedOutProps(commentJson);
+    expect(commentTokens).toMatchObject([
+      {
+        'inline': false,
+        'type': 'LineComment',
+        'value': ' "sdkVersion": "1.9", // sdkVersion comment'
+      },
+      {
+        'inline': false,
+        'type': 'LineComment',
+        'value': ' "initializeManually": true, // manualInit comment'
+      }
+    ]);
+  });
+
+  it('ignores block comments, and comments that dont "look like" config props', () => {
+    const commentJson = parse(`{
+      // ignore me
+      "experienceVersion": "<REPLACE ME>",
+      /* ignore me too */
+      "businessId": "<REPLACE ME>",
+      // 'lol': "only double quotes are valid json"
+    }`);
+    const commentTokens = parseCommentedOutProps(commentJson);
+    expect(commentTokens).toEqual([]);
+  });
 });
 
 it('pruneDuplicatedComments prunes all comments that match value, type, and inlining', () => {

--- a/tests/postupgrade/utils.js
+++ b/tests/postupgrade/utils.js
@@ -1,10 +1,10 @@
 const { parse, stringify } = require('comment-json');
 const fs = require('fs');
 const {
-  parseCommentedOutProps,
+  parseAllCommentedOutProps,
   mergeGlobalConfigs,
   getPropCommentSymbols,
-  pruneDuplicatedComments
+  pruneComments
 } = require('../../postupgrade/utils');
 
 it('mergeGlobalConfigs merges together two global configs, and removes duplicated comments', () => {
@@ -20,7 +20,7 @@ it('getPropCommentSymbols ', () => {
     // "sdkVersion": "1.9", // sdkVersion comment
     "experienceVersion": "<REPLACE ME>", // experienceVersion comment
     "businessId": "<REPLACE ME>", // businessId comment
-    // "initializeManually": true, // manualInit comment
+    // "initializeManually": true // manualInit comment
   }`);
   const commentSymbols = getPropCommentSymbols(testJson);
   expect(commentSymbols).toEqual([
@@ -32,15 +32,15 @@ it('getPropCommentSymbols ', () => {
   ]);
 });
 
-describe('parseCommentedOutProps', () => {
+describe('parseAllCommentedOutProps', () => {
   it('parses comments correctly', () => {
     const commentJson = parse(`{
       // "sdkVersion": "1.9", // sdkVersion comment
       "experienceVersion": "<REPLACE ME>", // experienceVersion comment
       "businessId": "<REPLACE ME>", // businessId comment
-      // "initializeManually": true, // manualInit comment
+      // "initializeManually": true // manualInit comment
     }`);
-    const commentTokens = parseCommentedOutProps(commentJson);
+    const commentTokens = parseAllCommentedOutProps(commentJson);
     expect(commentTokens).toMatchObject([
       {
         'inline': false,
@@ -50,7 +50,7 @@ describe('parseCommentedOutProps', () => {
       {
         'inline': false,
         'type': 'LineComment',
-        'value': ' "initializeManually": true, // manualInit comment'
+        'value': ' "initializeManually": true // manualInit comment'
       }
     ]);
   });
@@ -60,15 +60,15 @@ describe('parseCommentedOutProps', () => {
       // ignore me
       "experienceVersion": "<REPLACE ME>",
       /* ignore me too */
-      "businessId": "<REPLACE ME>",
+      "businessId": "<REPLACE ME>"
       // 'lol': "only double quotes are valid json"
     }`);
-    const commentTokens = parseCommentedOutProps(commentJson);
+    const commentTokens = parseAllCommentedOutProps(commentJson);
     expect(commentTokens).toEqual([]);
   });
 });
 
-it('pruneDuplicatedComments prunes all comments that match value, type, and inlining', () => {
+it('pruneComments prunes all comments that match value, type, and inlining', () => {
   const jsonToPrune = parse(`{
     //a comment
     "experienceVersion": "<REPLACE ME>", //a comment
@@ -83,7 +83,7 @@ it('pruneDuplicatedComments prunes all comments that match value, type, and inli
       'value': 'a comment'
     }
   ];
-  const prunedJson = stringify(pruneDuplicatedComments(jsonToPrune, commentsToDedupe), null, 2);
+  const prunedJson = stringify(pruneComments(jsonToPrune, commentsToDedupe), null, 2);
   const expected = stringify(parse(`{
     "experienceVersion": "<REPLACE ME>", //a comment
     /*a comment*/


### PR DESCRIPTION
This comes from a QA item where, after upgrading the theme, the global
config had duplicated "commented out" props. For example a commented out apiKey
like `// apiKey: <REPLACE_ME>`

The way comment-json works is that each comment is associated with a
specific "prop" of the json (unless the json is empty or the comment
is outside of the main json body).

If we're not careful with how we add new config to the global_config,
the prop associated with the giant commented out config block will change.
Because we merge the new theme's global_config with the user's current
global_config on upgrade (with the user's having higher priority), this
results in said huge block being duplicated, because comment-json sees
it as a *different* comment than the preexisting giant one, since it is
now associated with a different prop.

Update comment-json to latest for small parsing improvements.
There are no breaking changes we're worried about.

J=SLAP-1514
TEST=manual, auto

unit tests
test upgrading yanswers, also with some minor tweaks to their config
to test things