### PR TITLE
Add translations needed for the Summer Release.

### DIFF
--- a/translations/ar.po
+++ b/translations/ar.po
@@ -5,69 +5,72 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] نتائج)"
+msgstr[1] "([[resultsCount]] نتيجة)"
+msgstr[2] "([[resultsCount]] نتائج)"
+msgstr[3] "([[resultsCount]] نتائج)"
+msgstr[4] "([[resultsCount]] نتيجة)"
+msgstr[5] "([[resultsCount]] نتيجة)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] سعرات حرارية"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">لم يتم العثور على نتائج</em> في [[currentVerticalLabel]]."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "مسببات الحساسية"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "وبدلاً من ذلك، يمكنك <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> عرض النتائج عبر جميع فئات البحث</a>."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "تطبيق الآن"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "مسح البحث"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "الاتجاهات"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "الحصول على الاتجاهات"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "بحث الموقع الرئيسي"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "الخريطة"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "عناصر التحكم في الخريطة"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "لم يتم العثور على نتائج."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "الطلب الآن"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "إعادة ضبط عوامل التصفية"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "الخدمات:"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +84,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "عرض أقل"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +98,98 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "عرض أكثر"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "إظهار <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">جميع [[currentVerticalLabel]]</em> بدلاً من ذلك."
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "عمليات الفرز وعوامل التصفية"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "شكرًا على ملاحظاتك!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "أسفرت فئات البحث التالية عن نتائج لعدد <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[1] "أسفرت فئة البحث التالية عن نتائج لعدد <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[2] "أسفرت فئات البحث التالية عن نتائج لعدد <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[3] "أسفرت فئات البحث التالية عن نتائج لعدد <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[4] "أسفرت فئات البحث التالية عن نتائج لعدد <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[5] "أسفرت فئات البحث التالية عن نتائج لعدد <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "هذا أجاب عن سؤالي"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "هذا لم يُجِب على سؤالي"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "عرض [[resultsCount]] نتائج"
+msgstr[1] "عرض نتيجة واحدة"
+msgstr[2] "عرض [[resultsCount]] نتائج"
+msgstr[3] "عرض [[resultsCount]] نتائج"
+msgstr[4] "عرض [[resultsCount]] نتيجة"
+msgstr[5] "عرض [[resultsCount]] نتيجة"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "عرض التفاصيل"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "عرض القائمة"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "هل كانت هذه الإجابة التي كنت تبحث عنها؟"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "البحث عندما تتحرك الخريطة"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "البحث في هذه المنطقة"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "الاتصال"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "إغلاق البطاقة"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "طلب الاستجابة"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "القائمة"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "الخريطة"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "عرض الكل"

--- a/translations/de.po
+++ b/translations/de.po
@@ -2,125 +2,143 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: cards/multilang-menuitem-standard/component.js:27
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "([[resultsCount]] Ergebnis)"
+msgstr[1] "([[resultsCount]] Ergebnisse)"
+
+#: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]] Kalorien"
 
-#: cards/multilang-menuitem-standard/component.js:23
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Keine Ergebnisse gefunden</em> in [[currentVerticalLabel]]."
+
+#: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
 msgstr "Allergene"
 
-#: cards/multilang-job-standard/component.js:33
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Alternativ können Sie sich <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">Ergebnisse aus allen Suchkategorien anzeigen lassen</a>."
+
+#: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
 msgstr "Jetzt bewerben"
-
-#: cards/multilang-event-standard/component.js:42
-msgid "Directions"
-msgstr "Wegbeschreibung"
-
-#: cards/multilang-location-standard/component.js:41
-msgid "Get Directions"
-msgstr "Wegbeschreibung"
-
-#: cards/multilang-menuitem-standard/component.js:38
-msgid "Order Now"
-msgstr "Jetzt bestellen"
-
-#: cards/multilang-location-standard/template.hbs:136
-msgid "Services:"
-msgstr "Services:"
-
-#: cards/multilang-event-standard/component.js:28
-#: cards/multilang-job-standard/component.js:29
-#: cards/multilang-link-standard/component.js:26
-#: cards/multilang-menuitem-standard/component.js:34
-#: cards/multilang-product-prominentimage/component.js:29
-#: cards/multilang-product-standard/component.js:34
-#: cards/multilang-professional-location/component.js:36
-#: cards/multilang-professional-standard/component.js:34
-#: cards/multilang-standard/component.js:29
-msgid "Show less"
-msgstr "Weniger anzeigen"
-
-#: cards/multilang-event-standard/component.js:27
-#: cards/multilang-job-standard/component.js:28
-#: cards/multilang-link-standard/component.js:25
-#: cards/multilang-menuitem-standard/component.js:33
-#: cards/multilang-product-prominentimage/component.js:28
-#: cards/multilang-product-standard/component.js:33
-#: cards/multilang-professional-location/component.js:35
-#: cards/multilang-professional-standard/component.js:33
-#: cards/multilang-standard/component.js:28
-msgid "Show more"
-msgstr "Mehr anzeigen"
-
-#: directanswercards/multilang-allfields-standard/component.js:177
-msgid "Thank you for your feedback!"
-msgstr "Vielen Dank für Ihr Feedback!"
-
-#: directanswercards/multilang-allfields-standard/component.js:179
-msgid "This answered my question"
-msgstr "Meine Frage wurde beantwortet"
-
-#: directanswercards/multilang-allfields-standard/component.js:180
-msgid "This did not answer my question"
-msgstr "Meine Frage wurde nicht beantwortet"
-
-#: directanswercards/multilang-allfields-standard/component.js:163
-msgid "View Details"
-msgstr "Details anzeigen"
-
-#: cards/multilang-menuitem-standard/component.js:48
-msgid "View Menu"
-msgstr "Speisekarte anzeigen"
-
-#: directanswercards/multilang-allfields-standard/component.js:178
-msgid "Was this the answer you were looking for?"
-msgstr "Haben Sie nach dieser Antwort gesucht?"
-
-#: cards/multilang-location-standard/component.js:33
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "Anrufen"
-
-#: cards/multilang-event-standard/component.js:32
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "Anmelden"
-
-#: templates/universal-standard/script/universalresults.hbs:74
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "Alle anzeigen"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
 msgstr "Suche löschen"
 
+#: cards/multilang-event-standard/component.js:44
+msgid "Directions"
+msgstr "Wegbeschreibung"
+
+#: cards/multilang-location-standard/component.js:49
+msgid "Get Directions"
+msgstr "Wegbeschreibung"
+
+#: templates/vertical-full-page-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "Hauptstandortsuche"
+
+#: templates/vertical-full-page-map/page.html.hbs:67
+msgid "Map"
+msgstr "Plan"
+
+#: templates/vertical-full-page-map/page.html.hbs:62
+msgid "Map controls"
+msgstr "Kartensteuerungselemente"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
 msgstr "Keine Ergebnisse gefunden."
+
+#: cards/multilang-menuitem-standard/component.js:40
+msgid "Order Now"
+msgstr "Jetzt bestellen"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
 msgstr "Filter zurücksetzen"
 
+#: cards/multilang-location-standard/template.hbs:140
+msgid "Services:"
+msgstr "Services:"
+
+#: cards/multilang-event-standard/component.js:30
+#: cards/multilang-financial-professional-location/component.js:44
+#: cards/multilang-job-standard/component.js:31
+#: cards/multilang-link-standard/component.js:28
+#: cards/multilang-menuitem-standard/component.js:36
+#: cards/multilang-product-prominentimage/component.js:39
+#: cards/multilang-product-prominentvideo/component.js:34
+#: cards/multilang-product-standard/component.js:38
+#: cards/multilang-professional-location/component.js:44
+#: cards/multilang-professional-standard/component.js:36
+#: cards/multilang-standard/component.js:31
+msgid "Show less"
+msgstr "Weniger anzeigen"
+
+#: cards/multilang-event-standard/component.js:29
+#: cards/multilang-financial-professional-location/component.js:43
+#: cards/multilang-job-standard/component.js:30
+#: cards/multilang-link-standard/component.js:27
+#: cards/multilang-menuitem-standard/component.js:35
+#: cards/multilang-product-prominentimage/component.js:38
+#: cards/multilang-product-prominentvideo/component.js:33
+#: cards/multilang-product-standard/component.js:37
+#: cards/multilang-professional-location/component.js:43
+#: cards/multilang-professional-standard/component.js:35
+#: cards/multilang-standard/component.js:30
+msgid "Show more"
+msgstr "Mehr anzeigen"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Stattdessen werden <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alle [[currentVerticalLabel]]</em> angezeigt."
+
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "Sortieren und Filter"
 
+#: directanswercards/multilang-allfields-standard/component.js:188
+msgid "Thank you for your feedback!"
+msgstr "Vielen Dank für Ihr Feedback!"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "Die folgende Suchkategorie enthält Ergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">„[[query]]“</span>:"
+msgstr[1] "Die folgenden Suchkategorien enthalten Ergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">„[[query]]“</span>:"
+
+#: directanswercards/multilang-allfields-standard/component.js:190
+msgid "This answered my question"
+msgstr "Meine Frage wurde beantwortet"
+
+#: directanswercards/multilang-allfields-standard/component.js:191
+msgid "This did not answer my question"
+msgstr "Meine Frage wurde nicht beantwortet"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[count]] Results"
+msgid_plural "View [[resultsCount]] Results"
 msgstr[0] "1 Ergebnis anzeigen"
-msgstr[1] "[[count]] Ergebnisse anzeigen"
+msgstr[1] "[[resultsCount]] Ergebnisse anzeigen"
 
-#: cards/multilang-financial-professional-location/template.hbs:195
-#: cards/multilang-location-standard/template.hbs:206
-#: cards/multilang-professional-location/template.hbs:192
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "Karte schließen"
+#: directanswercards/multilang-allfields-standard/component.js:174
+msgid "View Details"
+msgstr "Details anzeigen"
+
+#: cards/multilang-menuitem-standard/component.js:50
+msgid "View Menu"
+msgstr "Speisekarte anzeigen"
+
+#: directanswercards/multilang-allfields-standard/component.js:189
+msgid "Was this the answer you were looking for?"
+msgstr "Haben Sie nach dieser Antwort gesucht?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -132,6 +150,23 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "In diesem Bereich suchen"
 
+#: cards/multilang-location-standard/component.js:40
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "Anruf"
+
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Karte schließen"
+
+#: cards/multilang-event-standard/component.js:34
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "Rückmeldung"
+
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -142,38 +177,7 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "Karte"
 
-#: templates/vertical-interactive-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "Hauptstandortsuche"
-
-#: templates/vertical-interactive-map/page.html.hbs:64
-msgid "Map"
-msgstr "Plan"
-
-#: templates/vertical-interactive-map/page.html.hbs:59
-msgid "Map controls"
-msgstr "Kartensteuerungselemente"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Keine Ergebnisse gefunden</em> in [[currentVerticalLabel]]."
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Stattdessen werden <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alle [[currentVerticalLabel]]</em> gezeigt."
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "Die folgenden Kategorie liefert Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[1] "Die folgenden Kategorien liefern Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "[[resultsCount]] Ergebnis"
-msgstr[1] "[[resultsCount]] Ergebnisse"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "Sehen Sie alternativ <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> Ergebnisse aus allen Kategorien</a>."
+#: templates/universal-standard/script/universalresults.hbs:78
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Alle anzeigen"

--- a/translations/de.po
+++ b/translations/de.po
@@ -2,143 +2,125 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] Ergebnis)"
-msgstr[1] "([[resultsCount]] Ergebnisse)"
-
-#: cards/multilang-menuitem-standard/component.js:29
+#: cards/multilang-menuitem-standard/component.js:27
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]] Kalorien"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Keine Ergebnisse gefunden</em> in [[currentVerticalLabel]]."
-
-#: cards/multilang-menuitem-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:23
 msgid "Allergens"
 msgstr "Allergene"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "Alternativ können Sie sich <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">Ergebnisse aus allen Suchkategorien anzeigen lassen</a>."
-
-#: cards/multilang-job-standard/component.js:35
+#: cards/multilang-job-standard/component.js:33
 msgid "Apply Now"
 msgstr "Jetzt bewerben"
 
-#: theme-components/collapsible-filters/filter-link/component.js:4
-msgid "clear search"
-msgstr "Suche löschen"
-
-#: cards/multilang-event-standard/component.js:44
+#: cards/multilang-event-standard/component.js:42
 msgid "Directions"
 msgstr "Wegbeschreibung"
 
-#: cards/multilang-location-standard/component.js:49
+#: cards/multilang-location-standard/component.js:41
 msgid "Get Directions"
 msgstr "Wegbeschreibung"
 
-#: templates/vertical-full-page-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "Hauptstandortsuche"
-
-#: templates/vertical-full-page-map/page.html.hbs:67
-msgid "Map"
-msgstr "Plan"
-
-#: templates/vertical-full-page-map/page.html.hbs:62
-msgid "Map controls"
-msgstr "Kartensteuerungselemente"
-
-#: theme-components/collapsible-filters/view-results-button/template.hbs:3
-msgid "No results found."
-msgstr "Keine Ergebnisse gefunden."
-
-#: cards/multilang-menuitem-standard/component.js:40
+#: cards/multilang-menuitem-standard/component.js:38
 msgid "Order Now"
 msgstr "Jetzt bestellen"
-
-#: theme-components/collapsible-filters/filter-link/component.js:3
-msgid "reset filters"
-msgstr "Filter zurücksetzen"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
 msgstr "Services:"
 
-#: cards/multilang-event-standard/component.js:30
-#: cards/multilang-financial-professional-location/component.js:44
-#: cards/multilang-job-standard/component.js:31
-#: cards/multilang-link-standard/component.js:28
-#: cards/multilang-menuitem-standard/component.js:36
-#: cards/multilang-product-prominentimage/component.js:39
-#: cards/multilang-product-prominentvideo/component.js:34
-#: cards/multilang-product-standard/component.js:38
-#: cards/multilang-professional-location/component.js:44
-#: cards/multilang-professional-standard/component.js:36
-#: cards/multilang-standard/component.js:31
+#: cards/multilang-event-standard/component.js:28
+#: cards/multilang-job-standard/component.js:29
+#: cards/multilang-link-standard/component.js:26
+#: cards/multilang-menuitem-standard/component.js:34
+#: cards/multilang-product-prominentimage/component.js:29
+#: cards/multilang-product-standard/component.js:34
+#: cards/multilang-professional-location/component.js:36
+#: cards/multilang-professional-standard/component.js:34
+#: cards/multilang-standard/component.js:29
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
-#: cards/multilang-event-standard/component.js:29
-#: cards/multilang-financial-professional-location/component.js:43
-#: cards/multilang-job-standard/component.js:30
-#: cards/multilang-link-standard/component.js:27
-#: cards/multilang-menuitem-standard/component.js:35
-#: cards/multilang-product-prominentimage/component.js:38
-#: cards/multilang-product-prominentvideo/component.js:33
-#: cards/multilang-product-standard/component.js:37
-#: cards/multilang-professional-location/component.js:43
-#: cards/multilang-professional-standard/component.js:35
-#: cards/multilang-standard/component.js:30
+#: cards/multilang-event-standard/component.js:27
+#: cards/multilang-job-standard/component.js:28
+#: cards/multilang-link-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:33
+#: cards/multilang-product-prominentimage/component.js:28
+#: cards/multilang-product-standard/component.js:33
+#: cards/multilang-professional-location/component.js:35
+#: cards/multilang-professional-standard/component.js:33
+#: cards/multilang-standard/component.js:28
 msgid "Show more"
 msgstr "Mehr anzeigen"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Stattdessen werden <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alle [[currentVerticalLabel]]</em> angezeigt."
+#: directanswercards/multilang-allfields-standard/component.js:177
+msgid "Thank you for your feedback!"
+msgstr "Vielen Dank für Ihr Feedback!"
+
+#: directanswercards/multilang-allfields-standard/component.js:179
+msgid "This answered my question"
+msgstr "Meine Frage wurde beantwortet"
+
+#: directanswercards/multilang-allfields-standard/component.js:180
+msgid "This did not answer my question"
+msgstr "Meine Frage wurde nicht beantwortet"
+
+#: directanswercards/multilang-allfields-standard/component.js:163
+msgid "View Details"
+msgstr "Details anzeigen"
+
+#: cards/multilang-menuitem-standard/component.js:48
+msgid "View Menu"
+msgstr "Speisekarte anzeigen"
+
+#: directanswercards/multilang-allfields-standard/component.js:178
+msgid "Was this the answer you were looking for?"
+msgstr "Haben Sie nach dieser Antwort gesucht?"
+
+#: cards/multilang-location-standard/component.js:33
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "Anrufen"
+
+#: cards/multilang-event-standard/component.js:32
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "Anmelden"
+
+#: templates/universal-standard/script/universalresults.hbs:74
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Alle anzeigen"
+
+#: theme-components/collapsible-filters/filter-link/component.js:4
+msgid "clear search"
+msgstr "Suche löschen"
+
+#: theme-components/collapsible-filters/view-results-button/template.hbs:3
+msgid "No results found."
+msgstr "Keine Ergebnisse gefunden."
+
+#: theme-components/collapsible-filters/filter-link/component.js:3
+msgid "reset filters"
+msgstr "Filter zurücksetzen"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "Sortieren und Filter"
 
-#: directanswercards/multilang-allfields-standard/component.js:188
-msgid "Thank you for your feedback!"
-msgstr "Vielen Dank für Ihr Feedback!"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "Die folgende Suchkategorie enthält Ergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">„[[query]]“</span>:"
-msgstr[1] "Die folgenden Suchkategorien enthalten Ergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">„[[query]]“</span>:"
-
-#: directanswercards/multilang-allfields-standard/component.js:190
-msgid "This answered my question"
-msgstr "Meine Frage wurde beantwortet"
-
-#: directanswercards/multilang-allfields-standard/component.js:191
-msgid "This did not answer my question"
-msgstr "Meine Frage wurde nicht beantwortet"
-
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[resultsCount]] Results"
+msgid_plural "View [[count]] Results"
 msgstr[0] "1 Ergebnis anzeigen"
-msgstr[1] "[[resultsCount]] Ergebnisse anzeigen"
+msgstr[1] "[[count]] Ergebnisse anzeigen"
 
-#: directanswercards/multilang-allfields-standard/component.js:174
-msgid "View Details"
-msgstr "Details anzeigen"
-
-#: cards/multilang-menuitem-standard/component.js:50
-msgid "View Menu"
-msgstr "Speisekarte anzeigen"
-
-#: directanswercards/multilang-allfields-standard/component.js:189
-msgid "Was this the answer you were looking for?"
-msgstr "Haben Sie nach dieser Antwort gesucht?"
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Karte schließen"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -150,23 +132,6 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "In diesem Bereich suchen"
 
-#: cards/multilang-location-standard/component.js:40
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "Anruf"
-
-#: cards/multilang-financial-professional-location/template.hbs:198
-#: cards/multilang-location-standard/template.hbs:209
-#: cards/multilang-professional-location/template.hbs:195
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "Karte schließen"
-
-#: cards/multilang-event-standard/component.js:34
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "Rückmeldung"
-
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -177,7 +142,38 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "Karte"
 
-#: templates/universal-standard/script/universalresults.hbs:78
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "Alle anzeigen"
+#: templates/vertical-interactive-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "Hauptstandortsuche"
+
+#: templates/vertical-interactive-map/page.html.hbs:64
+msgid "Map"
+msgstr "Plan"
+
+#: templates/vertical-interactive-map/page.html.hbs:59
+msgid "Map controls"
+msgstr "Kartensteuerungselemente"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Keine Ergebnisse gefunden</em> in [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Stattdessen werden <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alle [[currentVerticalLabel]]</em> gezeigt."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "Die folgenden Kategorie liefert Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Die folgenden Kategorien liefern Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "[[resultsCount]] Ergebnis"
+msgstr[1] "[[resultsCount]] Ergebnisse"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Sehen Sie alternativ <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> Ergebnisse aus allen Kategorien</a>."

--- a/translations/es.po
+++ b/translations/es.po
@@ -2,143 +2,125 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] resultado)"
-msgstr[1] "([[resultsCount]] resultados)"
-
-#: cards/multilang-menuitem-standard/component.js:29
+#: cards/multilang-menuitem-standard/component.js:27
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]] calorías"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No se han encontrado resultados</em> en [[currentVerticalLabel]]."
-
-#: cards/multilang-menuitem-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:23
 msgid "Allergens"
 msgstr "Alérgenos"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "Como alternativa, puedes <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> ver los resultados en todas las categorías de búsqueda</a>."
-
-#: cards/multilang-job-standard/component.js:35
+#: cards/multilang-job-standard/component.js:33
 msgid "Apply Now"
 msgstr "Solicitar ahora"
 
-#: theme-components/collapsible-filters/filter-link/component.js:4
-msgid "clear search"
-msgstr "borrar búsqueda"
-
-#: cards/multilang-event-standard/component.js:44
+#: cards/multilang-event-standard/component.js:42
 msgid "Directions"
 msgstr "Direcciones"
 
-#: cards/multilang-location-standard/component.js:49
+#: cards/multilang-location-standard/component.js:41
 msgid "Get Directions"
 msgstr "Obtener direcciones"
 
-#: templates/vertical-full-page-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "Búsqueda principal del local"
-
-#: templates/vertical-full-page-map/page.html.hbs:67
-msgid "Map"
-msgstr "Mapa"
-
-#: templates/vertical-full-page-map/page.html.hbs:62
-msgid "Map controls"
-msgstr "Controles del mapa"
-
-#: theme-components/collapsible-filters/view-results-button/template.hbs:3
-msgid "No results found."
-msgstr "No se encontraron resultados."
-
-#: cards/multilang-menuitem-standard/component.js:40
+#: cards/multilang-menuitem-standard/component.js:38
 msgid "Order Now"
 msgstr "Pedir ahora"
-
-#: theme-components/collapsible-filters/filter-link/component.js:3
-msgid "reset filters"
-msgstr "restablecer filtros"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
 msgstr "Servicios:"
 
-#: cards/multilang-event-standard/component.js:30
-#: cards/multilang-financial-professional-location/component.js:44
-#: cards/multilang-job-standard/component.js:31
-#: cards/multilang-link-standard/component.js:28
-#: cards/multilang-menuitem-standard/component.js:36
-#: cards/multilang-product-prominentimage/component.js:39
-#: cards/multilang-product-prominentvideo/component.js:34
-#: cards/multilang-product-standard/component.js:38
-#: cards/multilang-professional-location/component.js:44
-#: cards/multilang-professional-standard/component.js:36
-#: cards/multilang-standard/component.js:31
+#: cards/multilang-event-standard/component.js:28
+#: cards/multilang-job-standard/component.js:29
+#: cards/multilang-link-standard/component.js:26
+#: cards/multilang-menuitem-standard/component.js:34
+#: cards/multilang-product-prominentimage/component.js:29
+#: cards/multilang-product-standard/component.js:34
+#: cards/multilang-professional-location/component.js:36
+#: cards/multilang-professional-standard/component.js:34
+#: cards/multilang-standard/component.js:29
 msgid "Show less"
 msgstr "Mostrar menos"
 
-#: cards/multilang-event-standard/component.js:29
-#: cards/multilang-financial-professional-location/component.js:43
-#: cards/multilang-job-standard/component.js:30
-#: cards/multilang-link-standard/component.js:27
-#: cards/multilang-menuitem-standard/component.js:35
-#: cards/multilang-product-prominentimage/component.js:38
-#: cards/multilang-product-prominentvideo/component.js:33
-#: cards/multilang-product-standard/component.js:37
-#: cards/multilang-professional-location/component.js:43
-#: cards/multilang-professional-standard/component.js:35
-#: cards/multilang-standard/component.js:30
+#: cards/multilang-event-standard/component.js:27
+#: cards/multilang-job-standard/component.js:28
+#: cards/multilang-link-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:33
+#: cards/multilang-product-prominentimage/component.js:28
+#: cards/multilang-product-standard/component.js:33
+#: cards/multilang-professional-location/component.js:35
+#: cards/multilang-professional-standard/component.js:33
+#: cards/multilang-standard/component.js:28
 msgid "Show more"
 msgstr "Mostrar más"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Mostrando <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">todas las [[currentVerticalLabel]]</em> en su lugar."
+#: directanswercards/multilang-allfields-standard/component.js:177
+msgid "Thank you for your feedback!"
+msgstr "¡Gracias por tu comentario!"
+
+#: directanswercards/multilang-allfields-standard/component.js:179
+msgid "This answered my question"
+msgstr "Esto ha respondido a mi pregunta"
+
+#: directanswercards/multilang-allfields-standard/component.js:180
+msgid "This did not answer my question"
+msgstr "Esto no ha respondido a mi pregunta"
+
+#: directanswercards/multilang-allfields-standard/component.js:163
+msgid "View Details"
+msgstr "Ver detalles"
+
+#: cards/multilang-menuitem-standard/component.js:48
+msgid "View Menu"
+msgstr "Mira el menú"
+
+#: directanswercards/multilang-allfields-standard/component.js:178
+msgid "Was this the answer you were looking for?"
+msgstr "¿Era esta la respuesta que buscabas?"
+
+#: cards/multilang-location-standard/component.js:33
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "Llamar"
+
+#: cards/multilang-event-standard/component.js:32
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "Confirmar asistencia"
+
+#: templates/universal-standard/script/universalresults.hbs:74
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Ver todo"
+
+#: theme-components/collapsible-filters/filter-link/component.js:4
+msgid "clear search"
+msgstr "borrar búsqueda"
+
+#: theme-components/collapsible-filters/view-results-button/template.hbs:3
+msgid "No results found."
+msgstr "No se encontraron resultados."
+
+#: theme-components/collapsible-filters/filter-link/component.js:3
+msgid "reset filters"
+msgstr "restablecer filtros"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "ordenaciones y filtros"
 
-#: directanswercards/multilang-allfields-standard/component.js:188
-msgid "Thank you for your feedback!"
-msgstr "¡Gracias por tu comentario!"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La siguiente categoría de búsqueda ha dado resultados para <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Las siguientes categorías de búsqueda han dado resultados para <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-
-#: directanswercards/multilang-allfields-standard/component.js:190
-msgid "This answered my question"
-msgstr "Esto ha respondido a mi pregunta"
-
-#: directanswercards/multilang-allfields-standard/component.js:191
-msgid "This did not answer my question"
-msgstr "Esto no ha respondido a mi pregunta"
-
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Ver 1 resultado"
-msgstr[1] "Ver [[resultsCount]] resultados"
+msgid_plural "View [[count]] Results"
+msgstr[0] "Ver 1 resultado"
+msgstr[1] "Ver [[count]] resultados"
 
-#: directanswercards/multilang-allfields-standard/component.js:174
-msgid "View Details"
-msgstr "Ver detalles"
-
-#: cards/multilang-menuitem-standard/component.js:50
-msgid "View Menu"
-msgstr "Mira el menú"
-
-#: directanswercards/multilang-allfields-standard/component.js:189
-msgid "Was this the answer you were looking for?"
-msgstr "¿Era esta la respuesta que buscabas?"
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Cerrar tarjeta"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -150,23 +132,6 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "Buscar en esta zona"
 
-#: cards/multilang-location-standard/component.js:40
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "Llamar"
-
-#: cards/multilang-financial-professional-location/template.hbs:198
-#: cards/multilang-location-standard/template.hbs:209
-#: cards/multilang-professional-location/template.hbs:195
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "Cerrar tarjeta"
-
-#: cards/multilang-event-standard/component.js:34
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "Confirmar asistencia"
-
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -177,7 +142,38 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "Mapa"
 
-#: templates/universal-standard/script/universalresults.hbs:78
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "Ver todo"
+#: templates/vertical-interactive-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "Búsqueda principal del local"
+
+#: templates/vertical-interactive-map/page.html.hbs:64
+msgid "Map"
+msgstr "Mapa"
+
+#: templates/vertical-interactive-map/page.html.hbs:59
+msgid "Map controls"
+msgstr "Controles del mapa"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Ningún resultado disponible</em> en [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Mostrando <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> en vez que [[currentVerticalLabel]]</em>."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La siguiente búsqueda ha generado categoría resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La siguiente búsqueda ha generado categorias resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "[[resultsCount]] resultado"
+msgstr[1] "[[resultsCount]] resultados"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "En su defecto, puede <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> ver los resultados para todas las categorías de búsqueda</a>."

--- a/translations/es.po
+++ b/translations/es.po
@@ -2,125 +2,143 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: cards/multilang-menuitem-standard/component.js:27
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "([[resultsCount]] resultado)"
+msgstr[1] "([[resultsCount]] resultados)"
+
+#: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]] calorías"
 
-#: cards/multilang-menuitem-standard/component.js:23
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No se han encontrado resultados</em> en [[currentVerticalLabel]]."
+
+#: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
 msgstr "Alérgenos"
 
-#: cards/multilang-job-standard/component.js:33
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Como alternativa, puedes <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> ver los resultados en todas las categorías de búsqueda</a>."
+
+#: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
 msgstr "Solicitar ahora"
-
-#: cards/multilang-event-standard/component.js:42
-msgid "Directions"
-msgstr "Direcciones"
-
-#: cards/multilang-location-standard/component.js:41
-msgid "Get Directions"
-msgstr "Obtener direcciones"
-
-#: cards/multilang-menuitem-standard/component.js:38
-msgid "Order Now"
-msgstr "Pedir ahora"
-
-#: cards/multilang-location-standard/template.hbs:136
-msgid "Services:"
-msgstr "Servicios:"
-
-#: cards/multilang-event-standard/component.js:28
-#: cards/multilang-job-standard/component.js:29
-#: cards/multilang-link-standard/component.js:26
-#: cards/multilang-menuitem-standard/component.js:34
-#: cards/multilang-product-prominentimage/component.js:29
-#: cards/multilang-product-standard/component.js:34
-#: cards/multilang-professional-location/component.js:36
-#: cards/multilang-professional-standard/component.js:34
-#: cards/multilang-standard/component.js:29
-msgid "Show less"
-msgstr "Mostrar menos"
-
-#: cards/multilang-event-standard/component.js:27
-#: cards/multilang-job-standard/component.js:28
-#: cards/multilang-link-standard/component.js:25
-#: cards/multilang-menuitem-standard/component.js:33
-#: cards/multilang-product-prominentimage/component.js:28
-#: cards/multilang-product-standard/component.js:33
-#: cards/multilang-professional-location/component.js:35
-#: cards/multilang-professional-standard/component.js:33
-#: cards/multilang-standard/component.js:28
-msgid "Show more"
-msgstr "Mostrar más"
-
-#: directanswercards/multilang-allfields-standard/component.js:177
-msgid "Thank you for your feedback!"
-msgstr "¡Gracias por tu comentario!"
-
-#: directanswercards/multilang-allfields-standard/component.js:179
-msgid "This answered my question"
-msgstr "Esto ha respondido a mi pregunta"
-
-#: directanswercards/multilang-allfields-standard/component.js:180
-msgid "This did not answer my question"
-msgstr "Esto no ha respondido a mi pregunta"
-
-#: directanswercards/multilang-allfields-standard/component.js:163
-msgid "View Details"
-msgstr "Ver detalles"
-
-#: cards/multilang-menuitem-standard/component.js:48
-msgid "View Menu"
-msgstr "Mira el menú"
-
-#: directanswercards/multilang-allfields-standard/component.js:178
-msgid "Was this the answer you were looking for?"
-msgstr "¿Era esta la respuesta que buscabas?"
-
-#: cards/multilang-location-standard/component.js:33
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "Llamar"
-
-#: cards/multilang-event-standard/component.js:32
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "Confirmar asistencia"
-
-#: templates/universal-standard/script/universalresults.hbs:74
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "Ver todo"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
 msgstr "borrar búsqueda"
 
+#: cards/multilang-event-standard/component.js:44
+msgid "Directions"
+msgstr "Direcciones"
+
+#: cards/multilang-location-standard/component.js:49
+msgid "Get Directions"
+msgstr "Obtener direcciones"
+
+#: templates/vertical-full-page-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "Búsqueda principal del local"
+
+#: templates/vertical-full-page-map/page.html.hbs:67
+msgid "Map"
+msgstr "Mapa"
+
+#: templates/vertical-full-page-map/page.html.hbs:62
+msgid "Map controls"
+msgstr "Controles del mapa"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
 msgstr "No se encontraron resultados."
+
+#: cards/multilang-menuitem-standard/component.js:40
+msgid "Order Now"
+msgstr "Pedir ahora"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
 msgstr "restablecer filtros"
 
+#: cards/multilang-location-standard/template.hbs:140
+msgid "Services:"
+msgstr "Servicios:"
+
+#: cards/multilang-event-standard/component.js:30
+#: cards/multilang-financial-professional-location/component.js:44
+#: cards/multilang-job-standard/component.js:31
+#: cards/multilang-link-standard/component.js:28
+#: cards/multilang-menuitem-standard/component.js:36
+#: cards/multilang-product-prominentimage/component.js:39
+#: cards/multilang-product-prominentvideo/component.js:34
+#: cards/multilang-product-standard/component.js:38
+#: cards/multilang-professional-location/component.js:44
+#: cards/multilang-professional-standard/component.js:36
+#: cards/multilang-standard/component.js:31
+msgid "Show less"
+msgstr "Mostrar menos"
+
+#: cards/multilang-event-standard/component.js:29
+#: cards/multilang-financial-professional-location/component.js:43
+#: cards/multilang-job-standard/component.js:30
+#: cards/multilang-link-standard/component.js:27
+#: cards/multilang-menuitem-standard/component.js:35
+#: cards/multilang-product-prominentimage/component.js:38
+#: cards/multilang-product-prominentvideo/component.js:33
+#: cards/multilang-product-standard/component.js:37
+#: cards/multilang-professional-location/component.js:43
+#: cards/multilang-professional-standard/component.js:35
+#: cards/multilang-standard/component.js:30
+msgid "Show more"
+msgstr "Mostrar más"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Mostrando <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">todas las [[currentVerticalLabel]]</em> en su lugar."
+
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "ordenaciones y filtros"
 
+#: directanswercards/multilang-allfields-standard/component.js:188
+msgid "Thank you for your feedback!"
+msgstr "¡Gracias por tu comentario!"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La siguiente categoría de búsqueda ha dado resultados para <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[1] "Las siguientes categorías de búsqueda han dado resultados para <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+
+#: directanswercards/multilang-allfields-standard/component.js:190
+msgid "This answered my question"
+msgstr "Esto ha respondido a mi pregunta"
+
+#: directanswercards/multilang-allfields-standard/component.js:191
+msgid "This did not answer my question"
+msgstr "Esto no ha respondido a mi pregunta"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[count]] Results"
-msgstr[0] "Ver 1 resultado"
-msgstr[1] "Ver [[count]] resultados"
+msgid_plural "View [[resultsCount]] Results"
+msgstr[0] "Ver 1 resultado"
+msgstr[1] "Ver [[resultsCount]] resultados"
 
-#: cards/multilang-financial-professional-location/template.hbs:195
-#: cards/multilang-location-standard/template.hbs:206
-#: cards/multilang-professional-location/template.hbs:192
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "Cerrar tarjeta"
+#: directanswercards/multilang-allfields-standard/component.js:174
+msgid "View Details"
+msgstr "Ver detalles"
+
+#: cards/multilang-menuitem-standard/component.js:50
+msgid "View Menu"
+msgstr "Mira el menú"
+
+#: directanswercards/multilang-allfields-standard/component.js:189
+msgid "Was this the answer you were looking for?"
+msgstr "¿Era esta la respuesta que buscabas?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -132,6 +150,23 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "Buscar en esta zona"
 
+#: cards/multilang-location-standard/component.js:40
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "Llamar"
+
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Cerrar tarjeta"
+
+#: cards/multilang-event-standard/component.js:34
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "Confirmar asistencia"
+
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -142,38 +177,7 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "Mapa"
 
-#: templates/vertical-interactive-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "Búsqueda principal del local"
-
-#: templates/vertical-interactive-map/page.html.hbs:64
-msgid "Map"
-msgstr "Mapa"
-
-#: templates/vertical-interactive-map/page.html.hbs:59
-msgid "Map controls"
-msgstr "Controles del mapa"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Ningún resultado disponible</em> en [[currentVerticalLabel]]."
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Mostrando <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> en vez que [[currentVerticalLabel]]</em>."
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La siguiente búsqueda ha generado categoría resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[1] "La siguiente búsqueda ha generado categorias resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "[[resultsCount]] resultado"
-msgstr[1] "[[resultsCount]] resultados"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "En su defecto, puede <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> ver los resultados para todas las categorías de búsqueda</a>."
+#: templates/universal-standard/script/universalresults.hbs:78
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Ver todo"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -2,144 +2,125 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] résultat)"
-msgstr[1] "([[resultsCount]] résultats)"
-
-#: cards/multilang-menuitem-standard/component.js:29
+#: cards/multilang-menuitem-standard/component.js:27
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]] calories"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Aucun résultat trouvé</em> dans [[currentVerticalLabel]]."
-
-#: cards/multilang-menuitem-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:23
 msgid "Allergens"
 msgstr "Allergènes"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "Vous pouvez également <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">afficher les résultats de toutes les catégories de"
-" recherche</a>."
-
-#: cards/multilang-job-standard/component.js:35
+#: cards/multilang-job-standard/component.js:33
 msgid "Apply Now"
-msgstr "S'inscrire"
+msgstr "Postuler"
 
-#: theme-components/collapsible-filters/filter-link/component.js:4
-msgid "clear search"
-msgstr "Réinitialiser la recherche"
-
-#: cards/multilang-event-standard/component.js:44
+#: cards/multilang-event-standard/component.js:42
 msgid "Directions"
-msgstr "Itinéraires"
+msgstr "Itinéraire"
 
-#: cards/multilang-location-standard/component.js:49
+#: cards/multilang-location-standard/component.js:41
 msgid "Get Directions"
-msgstr "Obtenir l'itinéraire"
+msgstr "M’y rendre"
 
-#: templates/vertical-full-page-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "Recherche d'établissements principale"
-
-#: templates/vertical-full-page-map/page.html.hbs:67
-msgid "Map"
-msgstr "Carte"
-
-#: templates/vertical-full-page-map/page.html.hbs:62
-msgid "Map controls"
-msgstr "Commandes de carte"
-
-#: theme-components/collapsible-filters/view-results-button/template.hbs:3
-msgid "No results found."
-msgstr "Aucun résultat trouvé."
-
-#: cards/multilang-menuitem-standard/component.js:40
+#: cards/multilang-menuitem-standard/component.js:38
 msgid "Order Now"
 msgstr "Commander"
-
-#: theme-components/collapsible-filters/filter-link/component.js:3
-msgid "reset filters"
-msgstr "réinitialiser les filtres"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
 msgstr "Services :"
 
-#: cards/multilang-event-standard/component.js:30
-#: cards/multilang-financial-professional-location/component.js:44
-#: cards/multilang-job-standard/component.js:31
-#: cards/multilang-link-standard/component.js:28
-#: cards/multilang-menuitem-standard/component.js:36
-#: cards/multilang-product-prominentimage/component.js:39
-#: cards/multilang-product-prominentvideo/component.js:34
-#: cards/multilang-product-standard/component.js:38
-#: cards/multilang-professional-location/component.js:44
-#: cards/multilang-professional-standard/component.js:36
-#: cards/multilang-standard/component.js:31
+#: cards/multilang-event-standard/component.js:28
+#: cards/multilang-job-standard/component.js:29
+#: cards/multilang-link-standard/component.js:26
+#: cards/multilang-menuitem-standard/component.js:34
+#: cards/multilang-product-prominentimage/component.js:29
+#: cards/multilang-product-standard/component.js:34
+#: cards/multilang-professional-location/component.js:36
+#: cards/multilang-professional-standard/component.js:34
+#: cards/multilang-standard/component.js:29
 msgid "Show less"
 msgstr "Afficher moins"
 
-#: cards/multilang-event-standard/component.js:29
-#: cards/multilang-financial-professional-location/component.js:43
-#: cards/multilang-job-standard/component.js:30
-#: cards/multilang-link-standard/component.js:27
-#: cards/multilang-menuitem-standard/component.js:35
-#: cards/multilang-product-prominentimage/component.js:38
-#: cards/multilang-product-prominentvideo/component.js:33
-#: cards/multilang-product-standard/component.js:37
-#: cards/multilang-professional-location/component.js:43
-#: cards/multilang-professional-standard/component.js:35
-#: cards/multilang-standard/component.js:30
+#: cards/multilang-event-standard/component.js:27
+#: cards/multilang-job-standard/component.js:28
+#: cards/multilang-link-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:33
+#: cards/multilang-product-prominentimage/component.js:28
+#: cards/multilang-product-standard/component.js:33
+#: cards/multilang-professional-location/component.js:35
+#: cards/multilang-professional-standard/component.js:33
+#: cards/multilang-standard/component.js:28
 msgid "Show more"
 msgstr "Afficher plus"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Afficher plutôt <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">les [[currentVerticalLabel]]</em>."
+#: directanswercards/multilang-allfields-standard/component.js:177
+msgid "Thank you for your feedback!"
+msgstr "Merci pour vos commentaires !"
+
+#: directanswercards/multilang-allfields-standard/component.js:179
+msgid "This answered my question"
+msgstr "J'ai obtenu la réponse à ma question"
+
+#: directanswercards/multilang-allfields-standard/component.js:180
+msgid "This did not answer my question"
+msgstr "Ma question reste sans réponse"
+
+#: directanswercards/multilang-allfields-standard/component.js:163
+msgid "View Details"
+msgstr "Afficher les détails"
+
+#: cards/multilang-menuitem-standard/component.js:48
+msgid "View Menu"
+msgstr "Afficher le menu"
+
+#: directanswercards/multilang-allfields-standard/component.js:178
+msgid "Was this the answer you were looking for?"
+msgstr "Est-ce la réponse que vous recherchiez ?"
+
+#: cards/multilang-location-standard/component.js:33
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "Appeler"
+
+#: cards/multilang-event-standard/component.js:32
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "Réservation"
+
+#: templates/universal-standard/script/universalresults.hbs:74
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Tout afficher"
+
+#: theme-components/collapsible-filters/filter-link/component.js:4
+msgid "clear search"
+msgstr "Réinitialiser la recherche"
+
+#: theme-components/collapsible-filters/view-results-button/template.hbs:3
+msgid "No results found."
+msgstr "Aucun résultat trouvé."
+
+#: theme-components/collapsible-filters/filter-link/component.js:3
+msgid "reset filters"
+msgstr "réinitialiser les filtres"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "tris et filtres"
 
-#: directanswercards/multilang-allfields-standard/component.js:188
-msgid "Thank you for your feedback!"
-msgstr "Merci pour vos commentaires !"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La catégorie de recherche suivante a obtenu des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">« [[query]] »</span> :"
-msgstr[1] "Les catégories de recherche suivantes ont obtenu des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">« [[query]] »</span> :"
-
-#: directanswercards/multilang-allfields-standard/component.js:190
-msgid "This answered my question"
-msgstr "J'ai obtenu la réponse à ma question"
-
-#: directanswercards/multilang-allfields-standard/component.js:191
-msgid "This did not answer my question"
-msgstr "Ma question reste sans réponse"
-
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[resultsCount]] Results"
+msgid_plural "View [[count]] Results"
 msgstr[0] "Afficher 1 résultat"
-msgstr[1] "Afficher [[resultsCount]] résultats"
+msgstr[1] "Afficher [[count]] résultats"
 
-#: directanswercards/multilang-allfields-standard/component.js:174
-msgid "View Details"
-msgstr "Afficher les détails"
-
-#: cards/multilang-menuitem-standard/component.js:50
-msgid "View Menu"
-msgstr "Afficher le menu"
-
-#: directanswercards/multilang-allfields-standard/component.js:189
-msgid "Was this the answer you were looking for?"
-msgstr "Est-ce la réponse que vous recherchiez ?"
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Fermer la carte"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -151,23 +132,6 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "Rechercher dans cette zone"
 
-#: cards/multilang-location-standard/component.js:40
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "Appel téléphonique"
-
-#: cards/multilang-financial-professional-location/template.hbs:198
-#: cards/multilang-location-standard/template.hbs:209
-#: cards/multilang-professional-location/template.hbs:195
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "Fermer la carte"
-
-#: cards/multilang-event-standard/component.js:34
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "Réservation"
-
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -178,7 +142,38 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "Carte"
 
-#: templates/universal-standard/script/universalresults.hbs:78
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "Tout afficher"
+#: templates/vertical-interactive-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "Recherche d'établissements principale"
+
+#: templates/vertical-interactive-map/page.html.hbs:64
+msgid "Map"
+msgstr "Carte"
+
+#: templates/vertical-interactive-map/page.html.hbs:59
+msgid "Map controls"
+msgstr "Commandes de carte"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Aucun resultat</em> in [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Voici <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> tous/toutes les [[currentVerticalLabel]]</em> à la place."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La catégorie de recherche suivante a produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Les catégories de recherche suivantes ont produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "([[resultsCount]] résultat)"
+msgstr[1] "([[resultsCount]] résultats)"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Autrement, vous pouvez <a class=\"yxt-AlternativeVerticals-universalLink\" href=[[universalUrl]]> voir les résultats à travers toutes les catégories</a>."

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -2,125 +2,144 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: cards/multilang-menuitem-standard/component.js:27
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "([[resultsCount]] résultat)"
+msgstr[1] "([[resultsCount]] résultats)"
+
+#: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]] calories"
 
-#: cards/multilang-menuitem-standard/component.js:23
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Aucun résultat trouvé</em> dans [[currentVerticalLabel]]."
+
+#: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
 msgstr "Allergènes"
 
-#: cards/multilang-job-standard/component.js:33
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Vous pouvez également <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">afficher les résultats de toutes les catégories de"
+" recherche</a>."
+
+#: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Postuler"
-
-#: cards/multilang-event-standard/component.js:42
-msgid "Directions"
-msgstr "Itinéraire"
-
-#: cards/multilang-location-standard/component.js:41
-msgid "Get Directions"
-msgstr "M’y rendre"
-
-#: cards/multilang-menuitem-standard/component.js:38
-msgid "Order Now"
-msgstr "Commander"
-
-#: cards/multilang-location-standard/template.hbs:136
-msgid "Services:"
-msgstr "Services :"
-
-#: cards/multilang-event-standard/component.js:28
-#: cards/multilang-job-standard/component.js:29
-#: cards/multilang-link-standard/component.js:26
-#: cards/multilang-menuitem-standard/component.js:34
-#: cards/multilang-product-prominentimage/component.js:29
-#: cards/multilang-product-standard/component.js:34
-#: cards/multilang-professional-location/component.js:36
-#: cards/multilang-professional-standard/component.js:34
-#: cards/multilang-standard/component.js:29
-msgid "Show less"
-msgstr "Afficher moins"
-
-#: cards/multilang-event-standard/component.js:27
-#: cards/multilang-job-standard/component.js:28
-#: cards/multilang-link-standard/component.js:25
-#: cards/multilang-menuitem-standard/component.js:33
-#: cards/multilang-product-prominentimage/component.js:28
-#: cards/multilang-product-standard/component.js:33
-#: cards/multilang-professional-location/component.js:35
-#: cards/multilang-professional-standard/component.js:33
-#: cards/multilang-standard/component.js:28
-msgid "Show more"
-msgstr "Afficher plus"
-
-#: directanswercards/multilang-allfields-standard/component.js:177
-msgid "Thank you for your feedback!"
-msgstr "Merci pour vos commentaires !"
-
-#: directanswercards/multilang-allfields-standard/component.js:179
-msgid "This answered my question"
-msgstr "J'ai obtenu la réponse à ma question"
-
-#: directanswercards/multilang-allfields-standard/component.js:180
-msgid "This did not answer my question"
-msgstr "Ma question reste sans réponse"
-
-#: directanswercards/multilang-allfields-standard/component.js:163
-msgid "View Details"
-msgstr "Afficher les détails"
-
-#: cards/multilang-menuitem-standard/component.js:48
-msgid "View Menu"
-msgstr "Afficher le menu"
-
-#: directanswercards/multilang-allfields-standard/component.js:178
-msgid "Was this the answer you were looking for?"
-msgstr "Est-ce la réponse que vous recherchiez ?"
-
-#: cards/multilang-location-standard/component.js:33
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "Appeler"
-
-#: cards/multilang-event-standard/component.js:32
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "Réservation"
-
-#: templates/universal-standard/script/universalresults.hbs:74
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "Tout afficher"
+msgstr "S'inscrire"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
 msgstr "Réinitialiser la recherche"
 
+#: cards/multilang-event-standard/component.js:44
+msgid "Directions"
+msgstr "Itinéraires"
+
+#: cards/multilang-location-standard/component.js:49
+msgid "Get Directions"
+msgstr "Obtenir l'itinéraire"
+
+#: templates/vertical-full-page-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "Recherche d'établissements principale"
+
+#: templates/vertical-full-page-map/page.html.hbs:67
+msgid "Map"
+msgstr "Carte"
+
+#: templates/vertical-full-page-map/page.html.hbs:62
+msgid "Map controls"
+msgstr "Commandes de carte"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
 msgstr "Aucun résultat trouvé."
+
+#: cards/multilang-menuitem-standard/component.js:40
+msgid "Order Now"
+msgstr "Commander"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
 msgstr "réinitialiser les filtres"
 
+#: cards/multilang-location-standard/template.hbs:140
+msgid "Services:"
+msgstr "Services :"
+
+#: cards/multilang-event-standard/component.js:30
+#: cards/multilang-financial-professional-location/component.js:44
+#: cards/multilang-job-standard/component.js:31
+#: cards/multilang-link-standard/component.js:28
+#: cards/multilang-menuitem-standard/component.js:36
+#: cards/multilang-product-prominentimage/component.js:39
+#: cards/multilang-product-prominentvideo/component.js:34
+#: cards/multilang-product-standard/component.js:38
+#: cards/multilang-professional-location/component.js:44
+#: cards/multilang-professional-standard/component.js:36
+#: cards/multilang-standard/component.js:31
+msgid "Show less"
+msgstr "Afficher moins"
+
+#: cards/multilang-event-standard/component.js:29
+#: cards/multilang-financial-professional-location/component.js:43
+#: cards/multilang-job-standard/component.js:30
+#: cards/multilang-link-standard/component.js:27
+#: cards/multilang-menuitem-standard/component.js:35
+#: cards/multilang-product-prominentimage/component.js:38
+#: cards/multilang-product-prominentvideo/component.js:33
+#: cards/multilang-product-standard/component.js:37
+#: cards/multilang-professional-location/component.js:43
+#: cards/multilang-professional-standard/component.js:35
+#: cards/multilang-standard/component.js:30
+msgid "Show more"
+msgstr "Afficher plus"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Afficher plutôt <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">les [[currentVerticalLabel]]</em>."
+
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "tris et filtres"
 
+#: directanswercards/multilang-allfields-standard/component.js:188
+msgid "Thank you for your feedback!"
+msgstr "Merci pour vos commentaires !"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La catégorie de recherche suivante a obtenu des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">« [[query]] »</span> :"
+msgstr[1] "Les catégories de recherche suivantes ont obtenu des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">« [[query]] »</span> :"
+
+#: directanswercards/multilang-allfields-standard/component.js:190
+msgid "This answered my question"
+msgstr "J'ai obtenu la réponse à ma question"
+
+#: directanswercards/multilang-allfields-standard/component.js:191
+msgid "This did not answer my question"
+msgstr "Ma question reste sans réponse"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[count]] Results"
+msgid_plural "View [[resultsCount]] Results"
 msgstr[0] "Afficher 1 résultat"
-msgstr[1] "Afficher [[count]] résultats"
+msgstr[1] "Afficher [[resultsCount]] résultats"
 
-#: cards/multilang-financial-professional-location/template.hbs:195
-#: cards/multilang-location-standard/template.hbs:206
-#: cards/multilang-professional-location/template.hbs:192
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "Fermer la carte"
+#: directanswercards/multilang-allfields-standard/component.js:174
+msgid "View Details"
+msgstr "Afficher les détails"
+
+#: cards/multilang-menuitem-standard/component.js:50
+msgid "View Menu"
+msgstr "Afficher le menu"
+
+#: directanswercards/multilang-allfields-standard/component.js:189
+msgid "Was this the answer you were looking for?"
+msgstr "Est-ce la réponse que vous recherchiez ?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -132,6 +151,23 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "Rechercher dans cette zone"
 
+#: cards/multilang-location-standard/component.js:40
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "Appel téléphonique"
+
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Fermer la carte"
+
+#: cards/multilang-event-standard/component.js:34
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "Réservation"
+
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -142,38 +178,7 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "Carte"
 
-#: templates/vertical-interactive-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "Recherche d'établissements principale"
-
-#: templates/vertical-interactive-map/page.html.hbs:64
-msgid "Map"
-msgstr "Carte"
-
-#: templates/vertical-interactive-map/page.html.hbs:59
-msgid "Map controls"
-msgstr "Commandes de carte"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Aucun resultat</em> in [[currentVerticalLabel]]."
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Voici <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\"> tous/toutes les [[currentVerticalLabel]]</em> à la place."
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La catégorie de recherche suivante a produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[1] "Les catégories de recherche suivantes ont produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] résultat)"
-msgstr[1] "([[resultsCount]] résultats)"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "Autrement, vous pouvez <a class=\"yxt-AlternativeVerticals-universalLink\" href=[[universalUrl]]> voir les résultats à travers toutes les catégories</a>."
+#: templates/universal-standard/script/universalresults.hbs:78
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Tout afficher"

--- a/translations/hi.po
+++ b/translations/hi.po
@@ -5,69 +5,68 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] result)"
+msgstr[1] "([[resultsCount]] results)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] कैलोरी"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "[[currentVerticalLabel]] में <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em>."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "एलर्जेन"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "इसके बजाय, आप <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">सभी सर्च कैटेगरी में परिणाम देख</a> सकते हैं."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "अभी लागू करें"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "सर्च हटाएँ"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "डायरेक्शन"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "डायरेक्शन देखें"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "मुख्य लोकेशन सर्च"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "मैप"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "मैप कंट्रोल"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "कुछ नहीं मिला."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "अभी आर्डर करें"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "फ़िल्टर रीसेट करें"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "सेवाएं"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +80,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "कम देखें"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +94,90 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "ज़्यादा देखें"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "इसकी जगह <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> दिखाया जा रहा है."
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "सॉर्ट और फ़िल्टर"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "आपके फ़ीडबैक के लिए आपका धन्यवाद!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "इस सर्च केटेगरी से <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span> के परिणाम सामने आए:"
+msgstr[1] "इन सर्च कैटेगरीज़ से <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span> के परिणाम सामने आए:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "इससे मेरे सवाल का जवाब मिल गया"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "इससे मेरे सवाल का जवाब नहीं मिला"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "1 परिणाम देखें"
+msgstr[1] "[[resultsCount]] परिणाम देखें"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "जानकारी देखें"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "मेन्यू देखें"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "क्या आप इसी जवाब को ढूँढ़ रहे थे?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "जब मैप आगे बढ़ता है तो सर्च करें"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "इस जगह को सर्च करें"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "कॉल"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "कार्ड बंद करें"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "RSVP"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "लिस्ट"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "मैप"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "सब देखें"

--- a/translations/it.po
+++ b/translations/it.po
@@ -2,144 +2,125 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
-
-#: cards/multilang-menuitem-standard/component.js:29
+#: cards/multilang-menuitem-standard/component.js:27
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]] calorie"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
-
-#: cards/multilang-menuitem-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:23
 msgid "Allergens"
 msgstr "Allergeni"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
-
-#: cards/multilang-job-standard/component.js:35
+#: cards/multilang-job-standard/component.js:33
 msgid "Apply Now"
 msgstr "Richiedi subito"
 
-#: theme-components/collapsible-filters/filter-link/component.js:4
-msgid "clear search"
-msgstr "Cancella ricerca"
-
-#: cards/multilang-event-standard/component.js:44
+#: cards/multilang-event-standard/component.js:42
 msgid "Directions"
 msgstr "Indicazioni stradali"
 
-#: cards/multilang-location-standard/component.js:49
+#: cards/multilang-location-standard/component.js:41
 msgid "Get Directions"
 msgstr "Ottieni indicazioni"
 
-#: templates/vertical-full-page-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "Ricerca posizione principale"
-
-#: templates/vertical-full-page-map/page.html.hbs:67
-msgid "Map"
-msgstr "Mappa"
-
-#: templates/vertical-full-page-map/page.html.hbs:62
-msgid "Map controls"
-msgstr "Controlli mappa"
-
-#: theme-components/collapsible-filters/view-results-button/template.hbs:3
-msgid "No results found."
-msgstr "Nessun risultato trovato."
-
-#: cards/multilang-menuitem-standard/component.js:40
+#: cards/multilang-menuitem-standard/component.js:38
 msgid "Order Now"
 msgstr "Ordina ora"
-
-#: theme-components/collapsible-filters/filter-link/component.js:3
-msgid "reset filters"
-msgstr "ripristina filtri"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
 msgstr "Servizi:"
 
-#: cards/multilang-event-standard/component.js:30
-#: cards/multilang-financial-professional-location/component.js:44
-#: cards/multilang-job-standard/component.js:31
-#: cards/multilang-link-standard/component.js:28
-#: cards/multilang-menuitem-standard/component.js:36
-#: cards/multilang-product-prominentimage/component.js:39
-#: cards/multilang-product-prominentvideo/component.js:34
-#: cards/multilang-product-standard/component.js:38
-#: cards/multilang-professional-location/component.js:44
-#: cards/multilang-professional-standard/component.js:36
-#: cards/multilang-standard/component.js:31
+#: cards/multilang-event-standard/component.js:28
+#: cards/multilang-job-standard/component.js:29
+#: cards/multilang-link-standard/component.js:26
+#: cards/multilang-menuitem-standard/component.js:34
+#: cards/multilang-product-prominentimage/component.js:29
+#: cards/multilang-product-standard/component.js:34
+#: cards/multilang-professional-location/component.js:36
+#: cards/multilang-professional-standard/component.js:34
+#: cards/multilang-standard/component.js:29
 msgid "Show less"
 msgstr "Mostra meno"
 
-#: cards/multilang-event-standard/component.js:29
-#: cards/multilang-financial-professional-location/component.js:43
-#: cards/multilang-job-standard/component.js:30
-#: cards/multilang-link-standard/component.js:27
-#: cards/multilang-menuitem-standard/component.js:35
-#: cards/multilang-product-prominentimage/component.js:38
-#: cards/multilang-product-prominentvideo/component.js:33
-#: cards/multilang-product-standard/component.js:37
-#: cards/multilang-professional-location/component.js:43
-#: cards/multilang-professional-standard/component.js:35
-#: cards/multilang-standard/component.js:30
+#: cards/multilang-event-standard/component.js:27
+#: cards/multilang-job-standard/component.js:28
+#: cards/multilang-link-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:33
+#: cards/multilang-product-prominentimage/component.js:28
+#: cards/multilang-product-standard/component.js:33
+#: cards/multilang-professional-location/component.js:35
+#: cards/multilang-professional-standard/component.js:33
+#: cards/multilang-standard/component.js:28
 msgid "Show more"
 msgstr "Mostra altro"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+#: directanswercards/multilang-allfields-standard/component.js:177
+msgid "Thank you for your feedback!"
+msgstr "Grazie per il tuo feedback!"
+
+#: directanswercards/multilang-allfields-standard/component.js:179
+msgid "This answered my question"
+msgstr "La risposta è stata esauriente"
+
+#: directanswercards/multilang-allfields-standard/component.js:180
+msgid "This did not answer my question"
+msgstr "La risposta non è stata esauriente"
+
+#: directanswercards/multilang-allfields-standard/component.js:163
+msgid "View Details"
+msgstr "Visualizza dettagli"
+
+#: cards/multilang-menuitem-standard/component.js:48
+msgid "View Menu"
+msgstr "Visualizzare il menu"
+
+#: directanswercards/multilang-allfields-standard/component.js:178
+msgid "Was this the answer you were looking for?"
+msgstr "È la risposta che ti aspettavi?"
+
+#: cards/multilang-location-standard/component.js:33
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "Chiama"
+
+#: cards/multilang-event-standard/component.js:32
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "Dare conferma"
+
+#: templates/universal-standard/script/universalresults.hbs:74
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "Visualizza tutti"
+
+#: theme-components/collapsible-filters/filter-link/component.js:4
+msgid "clear search"
+msgstr "Cancella ricerca"
+
+#: theme-components/collapsible-filters/view-results-button/template.hbs:3
+msgid "No results found."
+msgstr "Nessun risultato trovato."
+
+#: theme-components/collapsible-filters/filter-link/component.js:3
+msgid "reset filters"
+msgstr "ripristina filtri"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "ordinamenti e filtri"
 
-#: directanswercards/multilang-allfields-standard/component.js:188
-msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-
-#: directanswercards/multilang-allfields-standard/component.js:190
-msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
-
-#: directanswercards/multilang-allfields-standard/component.js:191
-msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
-
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[resultsCount]] Results"
+msgid_plural "View [[count]] Results"
 msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[1] "Visualizza [[count]] risultati"
 
-#: directanswercards/multilang-allfields-standard/component.js:174
-msgid "View Details"
-msgstr "Visualizza dettagli"
-
-#: cards/multilang-menuitem-standard/component.js:50
-msgid "View Menu"
-msgstr "Visualizzare il menu"
-
-#: directanswercards/multilang-allfields-standard/component.js:189
-msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "Chiudi scheda"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -151,23 +132,6 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "Cerca in questa area"
 
-#: cards/multilang-location-standard/component.js:40
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "Chiama"
-
-#: cards/multilang-financial-professional-location/template.hbs:198
-#: cards/multilang-location-standard/template.hbs:209
-#: cards/multilang-professional-location/template.hbs:195
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "Chiudi scheda"
-
-#: cards/multilang-event-standard/component.js:34
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "Dare conferma"
-
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -178,7 +142,38 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "Mappa"
 
-#: templates/universal-standard/script/universalresults.hbs:78
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "Visualizza tutti"
+#: templates/vertical-interactive-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "Ricerca posizione principale"
+
+#: templates/vertical-interactive-map/page.html.hbs:64
+msgid "Map"
+msgstr "Mappa"
+
+#: templates/vertical-interactive-map/page.html.hbs:59
+msgid "Map controls"
+msgstr "Controlli mappa"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Non ci sono risultati disponibili</em> in [[currentVerticalLabel]]."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La categoria di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La categorie di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "[[resultsCount]] risultato"
+msgstr[1] "[[resultsCount]] risultati"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "Altrimenti, può <a class=\"yxt-AlternativeVerticals-universalLink\" href=[[universalUrl]]> vedere i risultati su tutte le categorie di ricerca</a>."

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -2,140 +2,124 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "（[[resultsCount]]件の結果）"
-
-#: cards/multilang-menuitem-standard/component.js:29
+#: cards/multilang-menuitem-standard/component.js:27
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]]カロリー"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "[[currentVerticalLabel]] で<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">結果は見つかりませんでした</em>。"
-
-#: cards/multilang-menuitem-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:23
 msgid "Allergens"
 msgstr "アレルゲン"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "代わりに<a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">すべての検索カテゴリーの結果を表示することもできます</a>。"
-
-#: cards/multilang-job-standard/component.js:35
+#: cards/multilang-job-standard/component.js:33
 msgid "Apply Now"
 msgstr "今すぐ適用"
 
-#: theme-components/collapsible-filters/filter-link/component.js:4
-msgid "clear search"
-msgstr "検索をクリア"
-
-#: cards/multilang-event-standard/component.js:44
+#: cards/multilang-event-standard/component.js:42
 msgid "Directions"
 msgstr "ルート"
 
-#: cards/multilang-location-standard/component.js:49
+#: cards/multilang-location-standard/component.js:41
 msgid "Get Directions"
 msgstr "ルート検索"
 
-#: templates/vertical-full-page-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "主なロケーション検索"
-
-#: templates/vertical-full-page-map/page.html.hbs:67
-msgid "Map"
-msgstr "マップ"
-
-#: templates/vertical-full-page-map/page.html.hbs:62
-msgid "Map controls"
-msgstr "マップコントロール"
-
-#: theme-components/collapsible-filters/view-results-button/template.hbs:3
-msgid "No results found."
-msgstr "結果が見つかりませんでした。"
-
-#: cards/multilang-menuitem-standard/component.js:40
+#: cards/multilang-menuitem-standard/component.js:38
 msgid "Order Now"
 msgstr "今すぐ注文"
-
-#: theme-components/collapsible-filters/filter-link/component.js:3
-msgid "reset filters"
-msgstr "フィルタをリセット"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
 msgstr "サービス："
 
-#: cards/multilang-event-standard/component.js:30
-#: cards/multilang-financial-professional-location/component.js:44
-#: cards/multilang-job-standard/component.js:31
-#: cards/multilang-link-standard/component.js:28
-#: cards/multilang-menuitem-standard/component.js:36
-#: cards/multilang-product-prominentimage/component.js:39
-#: cards/multilang-product-prominentvideo/component.js:34
-#: cards/multilang-product-standard/component.js:38
-#: cards/multilang-professional-location/component.js:44
-#: cards/multilang-professional-standard/component.js:36
-#: cards/multilang-standard/component.js:31
+#: cards/multilang-event-standard/component.js:28
+#: cards/multilang-job-standard/component.js:29
+#: cards/multilang-link-standard/component.js:26
+#: cards/multilang-menuitem-standard/component.js:34
+#: cards/multilang-product-prominentimage/component.js:29
+#: cards/multilang-product-standard/component.js:34
+#: cards/multilang-professional-location/component.js:36
+#: cards/multilang-professional-standard/component.js:34
+#: cards/multilang-standard/component.js:29
 msgid "Show less"
 msgstr "表示数を減らす"
 
-#: cards/multilang-event-standard/component.js:29
-#: cards/multilang-financial-professional-location/component.js:43
-#: cards/multilang-job-standard/component.js:30
-#: cards/multilang-link-standard/component.js:27
-#: cards/multilang-menuitem-standard/component.js:35
-#: cards/multilang-product-prominentimage/component.js:38
-#: cards/multilang-product-prominentvideo/component.js:33
-#: cards/multilang-product-standard/component.js:37
-#: cards/multilang-professional-location/component.js:43
-#: cards/multilang-professional-standard/component.js:35
-#: cards/multilang-standard/component.js:30
+#: cards/multilang-event-standard/component.js:27
+#: cards/multilang-job-standard/component.js:28
+#: cards/multilang-link-standard/component.js:25
+#: cards/multilang-menuitem-standard/component.js:33
+#: cards/multilang-product-prominentimage/component.js:28
+#: cards/multilang-product-standard/component.js:33
+#: cards/multilang-professional-location/component.js:35
+#: cards/multilang-professional-standard/component.js:33
+#: cards/multilang-standard/component.js:28
 msgid "Show more"
 msgstr "さらに表示"
 
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "代わりに<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">すべての[[currentVerticalLabel]]</em>を表示しています。"
+#: directanswercards/multilang-allfields-standard/component.js:177
+msgid "Thank you for your feedback!"
+msgstr "ご意見ありがとうございました!"
+
+#: directanswercards/multilang-allfields-standard/component.js:179
+msgid "This answered my question"
+msgstr "この内容で疑問が解決した"
+
+#: directanswercards/multilang-allfields-standard/component.js:180
+msgid "This did not answer my question"
+msgstr "この内容で疑問が解決しなかった"
+
+#: directanswercards/multilang-allfields-standard/component.js:163
+msgid "View Details"
+msgstr "詳細を表示"
+
+#: cards/multilang-menuitem-standard/component.js:48
+msgid "View Menu"
+msgstr "メニューの表示"
+
+#: directanswercards/multilang-allfields-standard/component.js:178
+msgid "Was this the answer you were looking for?"
+msgstr "これはあなたが探していた答えですか？"
+
+#: cards/multilang-location-standard/component.js:33
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "電話"
+
+#: cards/multilang-event-standard/component.js:32
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "RSVP"
+
+#: templates/universal-standard/script/universalresults.hbs:74
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "すべて表示"
+
+#: theme-components/collapsible-filters/filter-link/component.js:4
+msgid "clear search"
+msgstr "検索をクリア"
+
+#: theme-components/collapsible-filters/view-results-button/template.hbs:3
+msgid "No results found."
+msgstr "結果が見つかりませんでした。"
+
+#: theme-components/collapsible-filters/filter-link/component.js:3
+msgid "reset filters"
+msgstr "フィルタをリセット"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "並べ替えとフィルタ"
 
-#: directanswercards/multilang-allfields-standard/component.js:188
-msgid "Thank you for your feedback!"
-msgstr "ご意見ありがとうございました!"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>の結果が見つかりました。"
-
-#: directanswercards/multilang-allfields-standard/component.js:190
-msgid "This answered my question"
-msgstr "この内容で疑問が解決した"
-
-#: directanswercards/multilang-allfields-standard/component.js:191
-msgid "This did not answer my question"
-msgstr "この内容で疑問が解決しなかった"
-
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "[[resultsCount]]件の結果を表示"
+msgid_plural "View [[count]] Results"
+msgstr[0] "[[count]]件の結果を表示"
 
-#: directanswercards/multilang-allfields-standard/component.js:174
-msgid "View Details"
-msgstr "詳細を表示"
-
-#: cards/multilang-menuitem-standard/component.js:50
-msgid "View Menu"
-msgstr "メニューの表示"
-
-#: directanswercards/multilang-allfields-standard/component.js:189
-msgid "Was this the answer you were looking for?"
-msgstr "これはあなたが探していた答えですか？"
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "カードを閉じる"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -147,23 +131,6 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "このエリアを検索"
 
-#: cards/multilang-location-standard/component.js:40
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "電話"
-
-#: cards/multilang-financial-professional-location/template.hbs:198
-#: cards/multilang-location-standard/template.hbs:209
-#: cards/multilang-professional-location/template.hbs:195
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "カードを閉じる"
-
-#: cards/multilang-event-standard/component.js:34
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "RSVP"
-
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -174,7 +141,36 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "マップ"
 
-#: templates/universal-standard/script/universalresults.hbs:78
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "すべて表示"
+#: templates/vertical-interactive-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "主なロケーション検索"
+
+#: templates/vertical-interactive-map/page.html.hbs:64
+msgid "Map"
+msgstr "マップ"
+
+#: templates/vertical-interactive-map/page.html.hbs:59
+msgid "Map controls"
+msgstr "マップコントロール"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "[[currentVerticalLabel]] で<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">結果は見つかりませんでした</em>。"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "代わりに<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">すべての[[currentVerticalLabel]]</em>を表示しています。"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>の検索結果が見つかりました。"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "（[[resultsCount]]件の結果）"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "代わりに<a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">すべての検索カテゴリーの結果を表示することもできます</a>。"

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -2,124 +2,140 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: cards/multilang-menuitem-standard/component.js:27
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "（[[resultsCount]]件の結果）"
+
+#: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
 msgstr "[[calorieCount]]カロリー"
 
-#: cards/multilang-menuitem-standard/component.js:23
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
+msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr "[[currentVerticalLabel]] で<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">結果は見つかりませんでした</em>。"
+
+#: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
 msgstr "アレルゲン"
 
-#: cards/multilang-job-standard/component.js:33
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
+msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
+msgstr "代わりに<a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">すべての検索カテゴリーの結果を表示することもできます</a>。"
+
+#: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
 msgstr "今すぐ適用"
-
-#: cards/multilang-event-standard/component.js:42
-msgid "Directions"
-msgstr "ルート"
-
-#: cards/multilang-location-standard/component.js:41
-msgid "Get Directions"
-msgstr "ルート検索"
-
-#: cards/multilang-menuitem-standard/component.js:38
-msgid "Order Now"
-msgstr "今すぐ注文"
-
-#: cards/multilang-location-standard/template.hbs:136
-msgid "Services:"
-msgstr "サービス："
-
-#: cards/multilang-event-standard/component.js:28
-#: cards/multilang-job-standard/component.js:29
-#: cards/multilang-link-standard/component.js:26
-#: cards/multilang-menuitem-standard/component.js:34
-#: cards/multilang-product-prominentimage/component.js:29
-#: cards/multilang-product-standard/component.js:34
-#: cards/multilang-professional-location/component.js:36
-#: cards/multilang-professional-standard/component.js:34
-#: cards/multilang-standard/component.js:29
-msgid "Show less"
-msgstr "表示数を減らす"
-
-#: cards/multilang-event-standard/component.js:27
-#: cards/multilang-job-standard/component.js:28
-#: cards/multilang-link-standard/component.js:25
-#: cards/multilang-menuitem-standard/component.js:33
-#: cards/multilang-product-prominentimage/component.js:28
-#: cards/multilang-product-standard/component.js:33
-#: cards/multilang-professional-location/component.js:35
-#: cards/multilang-professional-standard/component.js:33
-#: cards/multilang-standard/component.js:28
-msgid "Show more"
-msgstr "さらに表示"
-
-#: directanswercards/multilang-allfields-standard/component.js:177
-msgid "Thank you for your feedback!"
-msgstr "ご意見ありがとうございました!"
-
-#: directanswercards/multilang-allfields-standard/component.js:179
-msgid "This answered my question"
-msgstr "この内容で疑問が解決した"
-
-#: directanswercards/multilang-allfields-standard/component.js:180
-msgid "This did not answer my question"
-msgstr "この内容で疑問が解決しなかった"
-
-#: directanswercards/multilang-allfields-standard/component.js:163
-msgid "View Details"
-msgstr "詳細を表示"
-
-#: cards/multilang-menuitem-standard/component.js:48
-msgid "View Menu"
-msgstr "メニューの表示"
-
-#: directanswercards/multilang-allfields-standard/component.js:178
-msgid "Was this the answer you were looking for?"
-msgstr "これはあなたが探していた答えですか？"
-
-#: cards/multilang-location-standard/component.js:33
-msgctxt "Call is a verb"
-msgid "Call"
-msgstr "電話"
-
-#: cards/multilang-event-standard/component.js:32
-msgctxt "RSVP is a verb"
-msgid "RSVP"
-msgstr "RSVP"
-
-#: templates/universal-standard/script/universalresults.hbs:74
-msgctxt "View is a verb"
-msgid "View All"
-msgstr "すべて表示"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
 msgstr "検索をクリア"
 
+#: cards/multilang-event-standard/component.js:44
+msgid "Directions"
+msgstr "ルート"
+
+#: cards/multilang-location-standard/component.js:49
+msgid "Get Directions"
+msgstr "ルート検索"
+
+#: templates/vertical-full-page-map/page.html.hbs:23
+msgid "Main location search"
+msgstr "主なロケーション検索"
+
+#: templates/vertical-full-page-map/page.html.hbs:67
+msgid "Map"
+msgstr "マップ"
+
+#: templates/vertical-full-page-map/page.html.hbs:62
+msgid "Map controls"
+msgstr "マップコントロール"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
 msgstr "結果が見つかりませんでした。"
+
+#: cards/multilang-menuitem-standard/component.js:40
+msgid "Order Now"
+msgstr "今すぐ注文"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
 msgstr "フィルタをリセット"
 
+#: cards/multilang-location-standard/template.hbs:140
+msgid "Services:"
+msgstr "サービス："
+
+#: cards/multilang-event-standard/component.js:30
+#: cards/multilang-financial-professional-location/component.js:44
+#: cards/multilang-job-standard/component.js:31
+#: cards/multilang-link-standard/component.js:28
+#: cards/multilang-menuitem-standard/component.js:36
+#: cards/multilang-product-prominentimage/component.js:39
+#: cards/multilang-product-prominentvideo/component.js:34
+#: cards/multilang-product-standard/component.js:38
+#: cards/multilang-professional-location/component.js:44
+#: cards/multilang-professional-standard/component.js:36
+#: cards/multilang-standard/component.js:31
+msgid "Show less"
+msgstr "表示数を減らす"
+
+#: cards/multilang-event-standard/component.js:29
+#: cards/multilang-financial-professional-location/component.js:43
+#: cards/multilang-job-standard/component.js:30
+#: cards/multilang-link-standard/component.js:27
+#: cards/multilang-menuitem-standard/component.js:35
+#: cards/multilang-product-prominentimage/component.js:38
+#: cards/multilang-product-prominentvideo/component.js:33
+#: cards/multilang-product-standard/component.js:37
+#: cards/multilang-professional-location/component.js:43
+#: cards/multilang-professional-standard/component.js:35
+#: cards/multilang-standard/component.js:30
+msgid "Show more"
+msgstr "さらに表示"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
+msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
+msgstr "代わりに<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">すべての[[currentVerticalLabel]]</em>を表示しています。"
+
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
 msgstr "並べ替えとフィルタ"
 
+#: directanswercards/multilang-allfields-standard/component.js:188
+msgid "Thank you for your feedback!"
+msgstr "ご意見ありがとうございました!"
+
+#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>の結果が見つかりました。"
+
+#: directanswercards/multilang-allfields-standard/component.js:190
+msgid "This answered my question"
+msgstr "この内容で疑問が解決した"
+
+#: directanswercards/multilang-allfields-standard/component.js:191
+msgid "This did not answer my question"
+msgstr "この内容で疑問が解決しなかった"
+
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
-msgid_plural "View [[count]] Results"
-msgstr[0] "[[count]]件の結果を表示"
+msgid_plural "View [[resultsCount]] Results"
+msgstr[0] "[[resultsCount]]件の結果を表示"
 
-#: cards/multilang-financial-professional-location/template.hbs:195
-#: cards/multilang-location-standard/template.hbs:206
-#: cards/multilang-professional-location/template.hbs:192
-msgctxt "Close is a verb"
-msgid "Close Card"
-msgstr "カードを閉じる"
+#: directanswercards/multilang-allfields-standard/component.js:174
+msgid "View Details"
+msgstr "詳細を表示"
+
+#: cards/multilang-menuitem-standard/component.js:50
+msgid "View Menu"
+msgstr "メニューの表示"
+
+#: directanswercards/multilang-allfields-standard/component.js:189
+msgid "Was this the answer you were looking for?"
+msgstr "これはあなたが探していた答えですか？"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
@@ -131,6 +147,23 @@ msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
 msgstr "このエリアを検索"
 
+#: cards/multilang-location-standard/component.js:40
+msgctxt "Call is a verb"
+msgid "Call"
+msgstr "電話"
+
+#: cards/multilang-financial-professional-location/template.hbs:198
+#: cards/multilang-location-standard/template.hbs:209
+#: cards/multilang-professional-location/template.hbs:195
+msgctxt "Close is a verb"
+msgid "Close Card"
+msgstr "カードを閉じる"
+
+#: cards/multilang-event-standard/component.js:34
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr "RSVP"
+
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
@@ -141,36 +174,7 @@ msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
 msgstr "マップ"
 
-#: templates/vertical-interactive-map/page.html.hbs:23
-msgid "Main location search"
-msgstr "主なロケーション検索"
-
-#: templates/vertical-interactive-map/page.html.hbs:64
-msgid "Map"
-msgstr "マップ"
-
-#: templates/vertical-interactive-map/page.html.hbs:59
-msgid "Map controls"
-msgstr "マップコントロール"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
-msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "[[currentVerticalLabel]] で<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">結果は見つかりませんでした</em>。"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
-msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "代わりに<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">すべての[[currentVerticalLabel]]</em>を表示しています。"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>の検索結果が見つかりました。"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:32
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "（[[resultsCount]]件の結果）"
-
-#: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:47
-msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "代わりに<a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">すべての検索カテゴリーの結果を表示することもできます</a>。"
+#: templates/universal-standard/script/universalresults.hbs:78
+msgctxt "View is a verb"
+msgid "View All"
+msgstr "すべて表示"

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -5,69 +5,67 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "(결과 [[resultsCount]]개)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]]칼로리"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "[[currentVerticalLabel]]에서 <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">결과를 찾을 수 없음</em>."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "알레르기 유발 물질"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "또는 <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">전체 검색 카테고리에서 결과를 조회할 수 있습니다</a>."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "지금 적용"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "검색 지우기"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "오시는 길"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "길 찾기"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "메인 위치 검색"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "지도"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "지도 제어"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "검색 결과가 없습니다."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "지금 주문"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "필터 재설정"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "서비스:"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +79,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "덜 보기"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +93,88 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "더 보기"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "대신 <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">전체 [[currentVerticalLabel]]</em> 표시."
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "정렬 및 필터"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "피드백을 주셔서 감사합니다!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "<span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>에 대한 결과가 나온 검색 카테고리:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "궁금한 점이 해소되었습니다"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "궁금한 점이 해소되지 않았습니다"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "결과 [[resultsCount]]개 보기"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "세부정보 보기"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "메뉴 보기"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "원하는 답변이 맞나요?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "지도 이동 시 검색"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "이 지역 검색"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "전화"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "카드 닫기"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "RSVP"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "목록"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "지도"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "전체 보기"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -5,69 +5,68 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] resultaat)"
+msgstr[1] "([[resultsCount]] resultaten)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] calorieën"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Geen resultaten gevonden</em> in [[currentVerticalLabel]]."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "Allergenen"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "U kunt ook <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> resultaten bekijken in alle zoekcategorieën</a>."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "Nu toepassen"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "wis zoekopdracht"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "Routebeschrijving"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "Routebeschrijving opvragen"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "Hoofdlocatie zoeken"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "Kaart"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "Bedieningselementen kaart"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "Geen resultaten gevonden."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "Nu bestellen"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "filters resetten"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "Services:"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +80,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "Minder weergeven"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +94,90 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "Meer tonen"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "Toon in plaats daarvan <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alle [[currentVerticalLabel]]</em>."
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "sorteren en filteren"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "Hartelijk dank voor uw feedback!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "De volgende zoekcategorie leverde resultaten op voor <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[1] "De volgende zoekcategorieën leverden resultaten op voor <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "Hiermee is mijn vraag beantwoord"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "Hiermee is mijn vraag niet beantwoord"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "Bekijk 1 resultaat"
+msgstr[1] "Bekijk [[resultsCount]] resultaten"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "Bekijk details"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "Menu bekijken"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "Was dit het antwoord waar u naar op zoek was?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "Zoeken wanneer kaart beweegt"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "Zoeken in dit gebied"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "Telefoongesprek"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "Kaart sluiten"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "RSVP"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "Lijst"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "Kaart"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "Alles bekijken"

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -5,69 +5,69 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] wynik)"
+msgstr[1] "([[resultsCount]] wyniki)"
+msgstr[2] "([[resultsCount]] wyników)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "Kalorie: [[calorieCount]]"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nie znaleziono wyników</em> w [[currentVerticalLabel]]."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "Alergeny"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "Możesz też <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">wyświetlić wyniki we wszystkich kategoriach wyszukiwania</a>."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "Zastosuj teraz"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "wyczyść wyszukiwanie"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "Wskazówki dojazdu"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "Uzyskaj wskazówki dojazdu"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "Główne wyszukiwanie lokalizacji"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "Mapa"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "Sterowanie mapą"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "Nie znaleziono wyników."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "Zamów teraz"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "resetuj filtry"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "Usługi:"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +81,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "Pokaż mniej"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +95,92 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "Pokaż więcej"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "Zamiast tego wyświetla <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">wszystkie [[currentVerticalLabel]].</em>"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "sortuje i filtruje"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "Dziękujemy za opinię!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "Poniższa kategoria wyszukiwania zwróciła wyniki zapytania <span class=\"yxt-AlternativeVerticals-details--query\">„[[query]]”</span>:"
+msgstr[1] "Poniższe kategorie wyszukiwania zwróciły wyniki zapytania <span class=\"yxt-AlternativeVerticals-details--query\">„[[query]]”</span>:"
+msgstr[2] "Poniższe kategorie wyszukiwania zwróciły wyniki zapytania <span class=\"yxt-AlternativeVerticals-details--query\">„[[query]]”</span>:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "To jest odpowiedź na moje pytanie"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "To nie jest odpowiedź na moje pytanie"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "Wyświetl 1 wynik"
+msgstr[1] "Wyświetl [[resultsCount]] wyniki"
+msgstr[2] "Wyświetl [[resultsCount]] wyników"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "Wyświetl szczegóły"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "Wyświetl menu"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "Czy była to poszukiwana odpowiedź?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "Wyszukaj przy poruszeniu mapy"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "Wyszukaj w tym obszarze"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "Zadzwoń"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "Zamknij kartę"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "RSVP"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "Lista"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "Mapa"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "Wyświetl wszystkie"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -5,69 +5,68 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] resultado)"
+msgstr[1] "([[resultsCount]] resultados)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] calorias"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Não foram encontrados resultados</em> na [[currentVerticalLabel]]."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "Alergénios"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "Em alternativa, pode <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> ver os resultados em todas as categorias de pesquisa</a>."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "Aplicar Agora"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "limpar pesquisa"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "Direções"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "Obter direções"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "Pesquisa de localização principal"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "Mapa"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "Controlos do mapa"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "Não foram encontrados resultados."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "Encomende Agora"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "repor filtros"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "Serviços:"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +80,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "Exibir menos"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +94,90 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "Mostrar mais"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "A mostrar <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">todas [[currentVerticalLabel]]</em> , em vez disso."
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "classificações e filtros"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "Obrigado pelo seu feedback!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "A seguinte categoria de pesquisa produziu resultados para <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[1] "As seguintes categorias de pesquisa produziram resultados para <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "Isto respondeu à minha pergunta"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "Isto não respondeu à minha pergunta"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "Ver 1 resultado"
+msgstr[1] "Ver [[resultsCount]] resultados"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "Ver detalhes"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "Ver o Menu"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "Era esta a resposta que estava à procura?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "Pesquisar quando o mapa se move"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "Pesquisar esta área"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "Chamada"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "Carta fechada"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "RSVP"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "Lista"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "Mapa"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "Ver tudo"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -5,69 +5,69 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] результат)"
+msgstr[1] "([[resultsCount]] результата)"
+msgstr[2] "([[resultsCount]] результатов)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] калорий"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Не найдены результаты</em> в [[currentVerticalLabel]]."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "Аллергены"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "Вы также можете <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">посмотреть результаты во всех категориях поиска</a>."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "Применить"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "очистить поиск"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "Маршрут"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "Проложить маршрут"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "Основной поиск местоположения"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "Карта"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "Управление картой"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "Результаты не найдены."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "Заказать"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "сбросить фильтры"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "Сервисы:"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +81,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "Показать меньше"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +95,92 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "Показать еще"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "Вместо этого показаны <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">все [[currentVerticalLabel]]</em>."
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "сортировка и фильтры"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "Спасибо за ваш отзыв!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "Следующая категория поиска содержит результаты по запросу <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[1] "Следующие категории поиска содержат результаты по запросу <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[2] "Следующие категории поиска содержат результаты по запросу <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "Ответ был полезен"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "Ответ не был полезен"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "Посмотреть 1 результат"
+msgstr[1] "Посмотреть [[resultsCount]] результата"
+msgstr[2] "Посмотреть [[resultsCount]] результатов"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "Подробнее"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "Смотреть меню"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "Этот ответ был вам полезен?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "Поиск при перемещении карты"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "Поиск в указанной области"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "Звонить"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "Закрыть карточку"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "Перезвоните мне"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "Список"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "Карта"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "Смотреть все"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -5,69 +5,68 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] resultat)"
+msgstr[1] "([[resultsCount]] resultat)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] kalorier"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Inga resultat hittades</em> i [[currentVerticalLabel]]."
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "Allergener"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "Alternativt kan du <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visa resultat från alla sökkategorier</a>."
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "Ansök nu"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "Rensa sökning"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "Vägbeskrivning"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "Få vägbeskrivningar"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "Huvudsaklig platssökning"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "Karta"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "Kartkontroller"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "Hittade inga resultat."
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "Beställ nu"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "återställ filter"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "Tjänster:"
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +80,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "Visa mindre"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +94,90 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "Visa mer"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "Visar <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">alla [[currentVerticalLabel]]</em> istället."
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "sorterar och filtrerar"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "Tack för din feedback!"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "Följande sökkategori gav svar för <span class=\"yxt-AlternativeVerticals-details--query\">”[[query]]”</span>:"
+msgstr[1] "Följande sökkategorier gav svar för <span class=\"yxt-AlternativeVerticals-details--query\">”[[query]]”</span>:"
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "Detta besvarade min fråga"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "Detta besvarade inte min fråga"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "Visa ett resultat"
+msgstr[1] "Visa [[resultsCount]] resultat"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "Se detaljer"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "Visa meny"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "Var det här det svar du letade efter?"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "Sök när kartan flyttas"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "Sök i området"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "Samtal"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "Stäng kort"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "RSVP"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "Lista"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "Karta"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "Visa alla"

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -5,69 +5,67 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "（[[resultsCount]] 项结果。"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] 卡路里"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "在[[currentVerticalLabel]]中<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">找不到任何结果</em>。"
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "过敏原"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "或者可以<a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">查看所有搜索类别的结果</a>。"
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "立即申请"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "清除搜索"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "路线"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "获取指示"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "主要位置搜索"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "地图"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "地图控件"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "未找到结果。"
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "立即订购"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "重置筛选条件"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "服务："
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +79,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "显示较少内容"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +93,88 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "显示更多"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "改为显示<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">所有[[currentVerticalLabel]]</em>。"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "排序和筛选"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "感谢你的反馈！"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "以下搜索类别产生了<span class=\"yxt-AlternativeVerticals-details--query\">“[[query]]”</span>的结果："
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "这回答了我的问题"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "这并未回答我的问题"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "查看 [[resultsCount]] 项结果"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "查看详细信息"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "查看菜单"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "这是你要找的答案吗？"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "当地图移动时进行搜索"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "搜索此区域"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "致电"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "关闭卡片"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "敬请回复"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "列表"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "地图"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "查看全部"

--- a/translations/zh_TW.po
+++ b/translations/zh_TW.po
@@ -5,69 +5,67 @@ msgstr ""
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:31
 msgid "([[resultsCount]] result)"
 msgid_plural "([[resultsCount]] results)"
-msgstr[0] "([[resultsCount]] risultato)"
-msgstr[1] "([[resultsCount]] risultati)"
+msgstr[0] "([[resultsCount]] 個結果)"
 
 #: cards/multilang-menuitem-standard/component.js:29
 msgid "[[calorieCount]] calories"
-msgstr "[[calorieCount]] calorie"
+msgstr "[[calorieCount]] 卡路里"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">Nessun risultato trovato</em> in [[currentVerticalLabel]]."
+msgstr "在 [[currentVerticalLabel]] 中<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">找不到結果</em>。"
 
 #: cards/multilang-menuitem-standard/component.js:25
 msgid "Allergens"
-msgstr "Allergeni"
+msgstr "過敏原"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:43
 msgid "Alternatively, you can <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\"> view results across all search categories</a>."
-msgstr "In alternativa, è possibile <a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">visualizzare i risultati in tutte le categorie"
-" di ricerca</a>."
+msgstr "或者，您可以<a class=\"yxt-AlternativeVerticals-universalLink\" href=\"[[universalUrl]]\">檢視所有搜尋類別的結果</a>。"
 
 #: cards/multilang-job-standard/component.js:35
 msgid "Apply Now"
-msgstr "Richiedi subito"
+msgstr "立即申請"
 
 #: theme-components/collapsible-filters/filter-link/component.js:4
 msgid "clear search"
-msgstr "Cancella ricerca"
+msgstr "清空搜尋"
 
 #: cards/multilang-event-standard/component.js:44
 msgid "Directions"
-msgstr "Indicazioni stradali"
+msgstr "路線"
 
 #: cards/multilang-location-standard/component.js:49
 msgid "Get Directions"
-msgstr "Ottieni indicazioni"
+msgstr "取得路線"
 
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
-msgstr "Ricerca posizione principale"
+msgstr "搜尋主要地點"
 
 #: templates/vertical-full-page-map/page.html.hbs:67
 msgid "Map"
-msgstr "Mappa"
+msgstr "地圖"
 
 #: templates/vertical-full-page-map/page.html.hbs:62
 msgid "Map controls"
-msgstr "Controlli mappa"
+msgstr "地圖控制"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:3
 msgid "No results found."
-msgstr "Nessun risultato trovato."
+msgstr "找不到結果。"
 
 #: cards/multilang-menuitem-standard/component.js:40
 msgid "Order Now"
-msgstr "Ordina ora"
+msgstr "立即訂購"
 
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
-msgstr "ripristina filtri"
+msgstr "重設篩選條件"
 
 #: cards/multilang-location-standard/template.hbs:140
 msgid "Services:"
-msgstr "Servizi:"
+msgstr "服務："
 
 #: cards/multilang-event-standard/component.js:30
 #: cards/multilang-financial-professional-location/component.js:44
@@ -81,7 +79,7 @@ msgstr "Servizi:"
 #: cards/multilang-professional-standard/component.js:36
 #: cards/multilang-standard/component.js:31
 msgid "Show less"
-msgstr "Mostra meno"
+msgstr "顯示較少"
 
 #: cards/multilang-event-standard/component.js:29
 #: cards/multilang-financial-professional-location/component.js:43
@@ -95,90 +93,88 @@ msgstr "Mostra meno"
 #: cards/multilang-professional-standard/component.js:35
 #: cards/multilang-standard/component.js:30
 msgid "Show more"
-msgstr "Mostra altro"
+msgstr "顯示更多"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:5
 msgid "Showing <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">all [[currentVerticalLabel]]</em> instead."
-msgstr "Visualizzazione di <em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">tutti i [[currentVerticalLabel]]</em>."
+msgstr "已改為顯示<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">所有 [[currentVerticalLabel]]</em>。"
 
 #: theme-components/collapsible-filters/filter-link/component.js:2
 msgid "sorts and filters"
-msgstr "ordinamenti e filtri"
+msgstr "排序和篩選條件"
 
 #: directanswercards/multilang-allfields-standard/component.js:188
 msgid "Thank you for your feedback!"
-msgstr "Grazie per il tuo feedback!"
+msgstr "感謝您的意見反應！"
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "La seguente categoria di ricerca ha prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
-msgstr[1] "Le seguenti categorie di ricerca hanno prodotto risultati per <span class=\"yxt-AlternativeVerticals-details--query\">&quot;[[query]]&quot;</span>:"
+msgstr[0] "以下搜尋類別為<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>產生了結果："
 
 #: directanswercards/multilang-allfields-standard/component.js:190
 msgid "This answered my question"
-msgstr "La risposta è stata esauriente"
+msgstr "這回答了我的問題"
 
 #: directanswercards/multilang-allfields-standard/component.js:191
 msgid "This did not answer my question"
-msgstr "La risposta non è stata esauriente"
+msgstr "這沒有回答我的問題"
 
 #: theme-components/collapsible-filters/view-results-button/template.hbs:5
 msgid "View 1 Result"
 msgid_plural "View [[resultsCount]] Results"
-msgstr[0] "Visualizza 1 risultato"
-msgstr[1] "Visualizza [[resultsCount]] risultati"
+msgstr[0] "檢視 [[resultsCount]] 個結果"
 
 #: directanswercards/multilang-allfields-standard/component.js:174
 msgid "View Details"
-msgstr "Visualizza dettagli"
+msgstr "檢視詳細資料"
 
 #: cards/multilang-menuitem-standard/component.js:50
 msgid "View Menu"
-msgstr "Visualizzare il menu"
+msgstr "檢視選單"
 
 #: directanswercards/multilang-allfields-standard/component.js:189
 msgid "Was this the answer you were looking for?"
-msgstr "È la risposta che ti aspettavi?"
+msgstr "這是您正在尋找的答案嗎？"
 
 #: templates/vertical-full-page-map/markup/searchthisareatoggle.hbs:10
 msgctxt "A button that conducts a search in the current map area"
 msgid "Search When Map Moves"
-msgstr "Cerca quando la mappa si sposta"
+msgstr "地圖移動時搜尋"
 
 #: templates/vertical-full-page-map/markup/searchthisareabutton.hbs:3
 msgctxt "A toggle for automatically searching when the map moves"
 msgid "Search This Area"
-msgstr "Cerca in questa area"
+msgstr "搜尋此區域"
 
 #: cards/multilang-location-standard/component.js:40
 msgctxt "Call is a verb"
 msgid "Call"
-msgstr "Chiama"
+msgstr "通話"
 
 #: cards/multilang-financial-professional-location/template.hbs:198
 #: cards/multilang-location-standard/template.hbs:209
 #: cards/multilang-professional-location/template.hbs:195
 msgctxt "Close is a verb"
 msgid "Close Card"
-msgstr "Chiudi scheda"
+msgstr "關閉卡片"
 
 #: cards/multilang-event-standard/component.js:34
 msgctxt "RSVP is a verb"
 msgid "RSVP"
-msgstr "Dare conferma"
+msgstr "敬請回覆"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:5
 msgctxt "The label of a toggle for displaying a list of results"
 msgid "List"
-msgstr "Elenco"
+msgstr "清單"
 
 #: templates/vertical-full-page-map/markup/mobilelisttoggles.hbs:9
 msgctxt "The label of a toggle for viewing a visual map"
 msgid "Map"
-msgstr "Mappa"
+msgstr "地圖"
 
 #: templates/universal-standard/script/universalresults.hbs:78
 msgctxt "View is a verb"
 msgid "View All"
-msgstr "Visualizza tutti"
+msgstr "檢視所有"


### PR DESCRIPTION
This PR adds a number of new language files to the Theme: Chinese (Traditional), Chinese (Simplified),
Russian, Polish, Portugese, Dutch, Arabic, Korean, Swedish, and Hindi. Exisitng language files were
also updated since there were some new strings needing translation.

J=SLAP-1461
TEST=none