### PR TITLE
Allow for custom label color in map pins

### DIFF
--- a/static/js/theme-map/PinImages.js
+++ b/static/js/theme-map/PinImages.js
@@ -43,7 +43,7 @@ class PinImages {
               font-family="Arial-BoldMT,Arial"
               font-size="12"
               font-weight="bold">
-          <tspan x="50%" y="15" text-anchor="middle">${index}</tspan>
+          <tspan x="50%" y="15" fill="${labelColor}" text-anchor="middle">${index}</tspan>
         </text>
         </g>
       </svg>`;


### PR DESCRIPTION
update pin svg to use labelColor from config

J=SLAP-1521
TEST=manual

change colors in map page config and see that the pin's number color is updated on the page.