### PR TITLE
return correct formatted time for given locale

### DIFF
--- a/static/js/hours/stringslocalizer.js
+++ b/static/js/hours/stringslocalizer.js
@@ -42,7 +42,7 @@ export default class HoursStringsLocalizer {
     time.setHours(Math.floor(yextTime / 100));
     time.setMinutes(yextTime % 100);
 
-    return time.toLocaleString(this.locale, {
+    return time.toLocaleString(this._locale, {
       hour: 'numeric',
       minute: 'numeric',
       ...this._isTwentyFourHourClock && { hourCycle: this._isTwentyFourHourClock ? 'h24' : 'h12' }


### PR DESCRIPTION
use the defined field `this._locale` instead of `this.locale`. This will cause some changes in percy snapshots

test=manual
launched test site and see that es pages use h24 format and en use h12 format