### PR TITLE
Add feedback analytics

### DIFF
--- a/cards/common-partials/thumbsfeedback.hbs
+++ b/cards/common-partials/thumbsfeedback.hbs
@@ -1,5 +1,5 @@
 <div class="{{cardType}}-feedbackWrapper">
-  <div class="{{cardType}}-feedback">
+  <div class="{{cardType}}-feedbackContent">
     {{#if feedbackSubmitted}}
       <div class="{{cardType}}-feedbackText">
         {{feedbackTextOnSubmission}}
@@ -11,7 +11,13 @@
         </div>
       {{/if}}
       <div class="{{cardType}}-thumbsWrapper">
-        <form class="HitchhikerCard-thumbs js-HitchhikerCard-feedbackForm">
+        <form
+          {{#if directAnswer}}
+            class="HitchhikerCard-thumbs js-HitchhikerDirectAnswerCard-feedbackForm"
+          {{else}}
+            class="HitchhikerCard-thumbs js-HitchhikerCard-feedbackForm"
+          {{/if}}
+        >
           <fieldset class="HitchhikerCard-fieldset">
             <label class="HitchhikerCard-thumb">
               <span class="HitchhikerCard-thumbUpIcon">
@@ -20,7 +26,12 @@
               <input type="radio"
                 name="feedback"
                 value="true"
-                class="HitchhikerCard-feedback HitchhikerCard-thumbUpButton js-HitchhikerCard-thumbInput">
+                {{#if directAnswer}}
+                  class="HitchhikerCard-feedback HitchhikerCard-thumbUpButton js-HitchhikerDirectAnswerCard-thumbInput"
+                {{else}}
+                  class="HitchhikerCard-feedback HitchhikerCard-thumbUpButton js-HitchhikerCard-thumbInput"
+                {{/if}}
+              >
               <span class="sr-only">
                 {{positiveFeedbackSrText}}
               </span>
@@ -32,7 +43,12 @@
               <input type="radio"
                 name="feedback"
                 value="false"
-                class="HitchhikerCard-feedback HitchhikerCard-thumbDownButton js-HitchhikerCard-thumbInput">
+                {{#if directAnswer}}
+                  class="HitchhikerCard-feedback HitchhikerCard-thumbDownButton js-HitchhikerDirectAnswerCard-thumbInput"
+                {{else}}
+                  class="HitchhikerCard-feedback HitchhikerCard-thumbDownButton js-HitchhikerCard-thumbInput"
+                {{/if}}
+              >
               <span class="sr-only">
                 {{negativeFeedbackSrText}}
               </span>

--- a/cards/document-standard/template.hbs
+++ b/cards/document-standard/template.hbs
@@ -10,7 +10,7 @@
       <div class="HitchhikerDocumentStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerDocumentStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerDocumentStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -52,7 +52,7 @@
         </div>
         {{/if}}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerEventStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerEventStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -39,7 +39,7 @@
         </div>
       {{/if}}
       {{#if card.feedback}}
-        {{> thumbsfeedback card cardType="HitchhikerFaqAccordion"}}
+        {{> thumbsfeedback card cardType="HitchhikerFaqAccordion" feedbackSubmitted=feedbackSubmitted}}
       {{/if}}
     </div>
   </div>

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -22,7 +22,7 @@
       <div class="HitchhikerFinancialProfessionalLocation-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerFinancialProfessionalLocation"}}
+          {{> thumbsfeedback card cardType="HitchhikerFinancialProfessionalLocation" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -10,7 +10,7 @@
       <div class="HitchhikerJobStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerJobStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerJobStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -6,7 +6,7 @@
       {{> details }}
       <div class="HitchhikerLinkStandard-actions">
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerLinkStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerLinkStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -27,7 +27,7 @@
       <div class="HitchhikerLocationStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerLocationStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerLocationStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -20,7 +20,7 @@
         </div>
         {{/if}}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerMenuItemStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerMenuItemStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -52,7 +52,7 @@
           </div>
         {{/if}}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerEventStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerEventStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -39,7 +39,7 @@
         </div>
       {{/if}}
       {{#if card.feedback}}
-        {{> thumbsfeedback card cardType="HitchhikerFaqAccordion"}}
+        {{> thumbsfeedback card cardType="HitchhikerFaqAccordion" feedbackSubmitted=feedbackSubmitted}}
       {{/if}}
     </div>
   </div>

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -22,7 +22,7 @@
       <div class="HitchhikerFinancialProfessionalLocation-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerFinancialProfessionalLocation"}}
+          {{> thumbsfeedback card cardType="HitchhikerFinancialProfessionalLocation" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -10,7 +10,7 @@
       <div class="HitchhikerJobStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerJobStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerJobStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -6,7 +6,7 @@
       {{> details }}
       <div class="HitchhikerLinkStandard-actions">
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerLinkStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerLinkStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -27,7 +27,7 @@
       <div class="HitchhikerLocationStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerLocationStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerLocationStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -20,7 +20,7 @@
           </div>
         {{/if}}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerMenuItemStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerMenuItemStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-product-prominentimage-clickable/template.hbs
+++ b/cards/multilang-product-prominentimage-clickable/template.hbs
@@ -15,7 +15,7 @@
         {{> details }}
         <div class="HitchhikerProductProminentImage-actions">
           {{#if card.feedback}}
-            {{> thumbsfeedback card cardType="HitchhikerProductProminentImage"}}
+            {{> thumbsfeedback card cardType="HitchhikerProductProminentImage" feedbackSubmitted=feedbackSubmitted}}
           {{/if}}
         </div>
       </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -8,7 +8,7 @@
       <div class="HitchhikerProductProminentImage-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProductProminentImage"}}
+          {{> thumbsfeedback card cardType="HitchhikerProductProminentImage" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -7,7 +7,7 @@
   {{> content }}
   <div class="HitchhikerProductProminentVideo-actions">
     {{#if card.feedback}}
-      {{> thumbsfeedback card cardType="HitchhikerProductProminentVideo"}}
+      {{> thumbsfeedback card cardType="HitchhikerProductProminentVideo" feedbackSubmitted=feedbackSubmitted}}
     {{/if}}
   </div>
 </div>

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -17,7 +17,7 @@
           </div>
         {{/if}}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProductStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerProductStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -22,7 +22,7 @@
       <div class="HitchhikerProfessionalLocation-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProfessionalLocation"}}
+          {{> thumbsfeedback card cardType="HitchhikerProfessionalLocation" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -12,7 +12,7 @@
       <div class="HitchhikerProfessionalStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProfessionalStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerProfessionalStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -10,7 +10,7 @@
       <div class="HitchhikerStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/product-prominentimage-clickable/template.hbs
+++ b/cards/product-prominentimage-clickable/template.hbs
@@ -15,7 +15,7 @@
         {{> details }}
         <div class="HitchhikerProductProminentImageClickable-actions">
           {{#if card.feedback}}
-            {{> thumbsfeedback card cardType="HitchhikerProductProminentImageClickable"}}
+            {{> thumbsfeedback card cardType="HitchhikerProductProminentImageClickable" feedbackSubmitted=feedbackSubmitted}}
           {{/if}}
         </div>
       </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -8,7 +8,7 @@
       <div class="HitchhikerProductProminentImage-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProductProminentImage"}}
+          {{> thumbsfeedback card cardType="HitchhikerProductProminentImage" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -8,7 +8,7 @@
   <div class="HitchhikerProductProminentVideo-actions">
     {{> ctas }}
     {{#if card.feedback}}
-      {{> thumbsfeedback card cardType="HitchhikerProductProminentVideo"}}
+      {{> thumbsfeedback card cardType="HitchhikerProductProminentVideo" feedbackSubmitted=feedbackSubmitted}}
     {{/if}}
   </div>
 </div>

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -17,7 +17,7 @@
           </div>
         {{/if}}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProductStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerProductStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -22,7 +22,7 @@
       <div class="HitchhikerProfessionalLocation-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProfessionalLocation"}}
+          {{> thumbsfeedback card cardType="HitchhikerProfessionalLocation" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -12,7 +12,7 @@
       <div class="HitchhikerProfessionalStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerProfessionalStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerProfessionalStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -10,7 +10,7 @@
       <div class="HitchhikerStandard-actions">
         {{> ctas }}
         {{#if card.feedback}}
-          {{> thumbsfeedback card cardType="HitchhikerStandard"}}
+          {{> thumbsfeedback card cardType="HitchhikerStandard" feedbackSubmitted=feedbackSubmitted}}
         {{/if}}
       </div>
     </div>

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -14,7 +14,7 @@
     {{> cta CTA linkTarget=linkTarget}}
   </div>
   {{/if}}
-  {{> thumbsfeedback cardType="HitchhikerAllFieldsStandard"}}
+  {{> thumbsfeedback cardType="HitchhikerAllFieldsStandard" directAnswer=true}}
 </div>
 
 {{#*inline 'icon'}}

--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -5,17 +5,13 @@ BaseDirectAnswerCard = typeof (BaseDirectAnswerCard) !== 'undefined' ?
 BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
   constructor(config = {}, systemConfig = {}) {
     super(config, systemConfig);
-    let data = config.data || {};
+    const data = config.data || {};
     this.type = data.type || '';
     this.answer = data.answer || {};
     this.snippet = this.answer.snippet || {};
     this.relatedItem = data.relatedItem || {};
     this.associatedEntityId = data.relatedItem && data.relatedItem.data && data.relatedItem.data.id;
     this.verticalConfigId = data.relatedItem && data.relatedItem.verticalConfigId;
-    this.globalOptions = this.analyticsReporter && this.analyticsReporter._globalOptions;
-    this.experienceKey = this.globalOptions && this.globalOptions.experienceKey;
-    this.experienceVersion = this.globalOptions && this.globalOptions.experienceVersion;
-    this.queryId = this.globalOptions && this.globalOptions.queryId;
   }
 
   /**
@@ -44,15 +40,22 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
   }
 
   onMount() {
-    let feedbackFormSelector = '.js-HitchhikerCard-feedbackForm';
+    this.addFeedbackListeners();
+
+    const rtfElement = this._container.querySelector('.js-yxt-rtfValue');
+    rtfElement && rtfElement.addEventListener('click', e => this._handleRtfClickAnalytics(e));
+  }
+
+  addFeedbackListeners() {
+    const feedbackFormSelector = '.js-HitchhikerCard-feedbackForm';
     let feedbackFormEl = this._container.querySelector(feedbackFormSelector);
     if (feedbackFormEl) {
       // For WCAG compliance, the feedback should be a submittable form
       feedbackFormEl.addEventListener('submit', (e) => {
-        let formTargetEl = e.target;
-        let checkedValue = formTargetEl.querySelector('input:checked').value === 'true';
+        const formTargetEl = e.target;
+        const isGood = formTargetEl.querySelector('input:checked').value === 'true';
 
-        this.reportQuality(checkedValue);
+        this.reportQuality(isGood);
         this.updateState({
           feedbackSubmitted: true
         });
@@ -66,42 +69,11 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
             if (input) {
               input.checked = true;
             }
-            this._triggerCustomEvent(feedbackFormSelector, 'submit');
+            HitchhikerJS.DOM.triggerCustomEvent(this._container, feedbackFormSelector, 'submit');
           });
         });
       }
     }
-
-    const rtfElement = this._container.querySelector('.js-yxt-rtfValue');
-    rtfElement && rtfElement.addEventListener('click', e => this._handleRtfClickAnalytics(e));
-  }
-
-  /**
-   * Triggers the event passed in dispatched from the given selector
-   * @param {string} selector selector to dispatch event from
-   * @param {string} event event to fire
-   * @param {Object} settings additional settings
-   */
-  _triggerCustomEvent(selector, event, settings) {
-    let e = this._customEvent(event, settings);
-    this._container.querySelector(selector).dispatchEvent(e);
-  }
-
-  /**
-   * _customEvent is an event constructor polyfill
-   * @param {string} event event to fire
-   * @param {Object} settings additional settings
-   */
-  _customEvent(event, settings) {
-    const _settings = {
-      bubbles: true,
-      cancelable: true,
-      detail: null,
-      ...settings
-    };
-    const evt = document.createEvent('CustomEvent');
-    evt.initCustomEvent(event, _settings.bubbles, _settings.cancelable, _settings.detail);
-    return evt;
   }
 
   /**
@@ -123,9 +95,6 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
     const event = new ANSWERS.AnalyticsEvent(eventType)
       .addOptions({
         directAnswer: true,
-        experienceKey: this.experienceKey,
-        experienceVersion: this.experienceVersion,
-        queryId: this.queryId,
         verticalKey: this.verticalConfigId,
         searcher: 'UNIVERSAL',
         entityId: this.associatedEntityId

--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -12,6 +12,10 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
     this.relatedItem = data.relatedItem || {};
     this.associatedEntityId = data.relatedItem && data.relatedItem.data && data.relatedItem.data.id;
     this.verticalConfigId = data.relatedItem && data.relatedItem.verticalConfigId;
+    this.globalOptions = this.analyticsReporter && this.analyticsReporter._globalOptions;
+    this.experienceKey = this.globalOptions && this.globalOptions.experienceKey;
+    this.experienceVersion = this.globalOptions && this.globalOptions.experienceVersion;
+    this.queryId = this.globalOptions && this.globalOptions.queryId;
   }
 
   /**
@@ -40,7 +44,7 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
   }
 
   onMount() {
-    let feedbackFormSelector = '.js-HitchhikerDirectAnswerCard-feedbackForm';
+    let feedbackFormSelector = '.js-HitchhikerCard-feedbackForm';
     let feedbackFormEl = this._container.querySelector(feedbackFormSelector);
     if (feedbackFormEl) {
       // For WCAG compliance, the feedback should be a submittable form
@@ -50,11 +54,11 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
 
         this.reportQuality(checkedValue);
         this.updateState({
-          'feedbackSubmitted': true
+          feedbackSubmitted: true
         });
       });
 
-      let thumbSelectorEls = this._container.querySelectorAll('.js-HitchhikerDirectAnswerCard-thumbInput');
+      let thumbSelectorEls = this._container.querySelectorAll('.js-HitchhikerCard-thumbInput');
       if (thumbSelectorEls) {
         thumbSelectorEls.forEach(el => {
           el.addEventListener('click', (e) => {
@@ -118,7 +122,13 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
     const eventType = isGood === true ? EventTypes.THUMBS_UP : EventTypes.THUMBS_DOWN;
     const event = new ANSWERS.AnalyticsEvent(eventType)
       .addOptions({
-        'directAnswer': true
+        directAnswer: true,
+        experienceKey: this.experienceKey,
+        experienceVersion: this.experienceVersion,
+        queryId: this.queryId,
+        verticalKey: this.verticalConfigId,
+        searcher: 'UNIVERSAL',
+        entityId: this.associatedEntityId
       });
 
     this.analyticsReporter.report(event);

--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -47,7 +47,7 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
   }
 
   addFeedbackListeners() {
-    const feedbackFormSelector = '.js-HitchhikerCard-feedbackForm';
+    const feedbackFormSelector = '.js-HitchhikerDirectAnswerCard-feedbackForm';
     let feedbackFormEl = this._container.querySelector(feedbackFormSelector);
     if (feedbackFormEl) {
       // For WCAG compliance, the feedback should be a submittable form
@@ -61,7 +61,7 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
         });
       });
 
-      let thumbSelectorEls = this._container.querySelectorAll('.js-HitchhikerCard-thumbInput');
+      let thumbSelectorEls = this._container.querySelectorAll('.js-HitchhikerDirectAnswerCard-thumbInput');
       if (thumbSelectorEls) {
         thumbSelectorEls.forEach(el => {
           el.addEventListener('click', (e) => {

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -9,7 +9,7 @@
       {{> cta CTA linkTarget=linkTarget}}
     </div>
   </div>
-  {{> thumbsfeedback cardType="HitchhikerDocumentSearchStandard"}}
+  {{> thumbsfeedback cardType="HitchhikerDocumentSearchStandard" directAnswer=true}}
 </div>
 
 {{#*inline 'title'}}

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -14,7 +14,7 @@
     {{> cta CTA linkTarget=linkTarget}}
   </div>
   {{/if}}
-  {{> thumbsfeedback cardType="HitchhikerAllFieldsStandard"}}
+  {{> thumbsfeedback cardType="HitchhikerAllFieldsStandard" directAnswer=true}}
 </div>
 
 {{#*inline 'icon'}}

--- a/static/js/HitchhikerJS.js
+++ b/static/js/HitchhikerJS.js
@@ -41,3 +41,6 @@ import AnswersExperience from './answers-experience';
 window.AnswersExperience = new AnswersExperience(runtimeConfig);
 
 export * from './video-apis';
+
+import DOM from './dom';
+export { DOM };

--- a/static/js/dom.js
+++ b/static/js/dom.js
@@ -1,0 +1,30 @@
+export default class DOM {  
+  /**
+   * Triggers the event passed in dispatched from the given selector
+   * @param {HTMLElement} container container to select from
+   * @param {string} selector selector to dispatch event from
+   * @param {string} event event to fire
+   * @param {Object} settings additional settings
+   */
+   static triggerCustomEvent(container, selector, event, settings) {
+    const e = this.customEvent(event, settings);
+    container.querySelector(selector).dispatchEvent(e);
+  }
+
+  /**
+   * _customEvent is an event constructor polyfill
+   * @param {string} event event to fire
+   * @param {Object} settings additional settings
+   */
+  static customEvent(event, settings) {
+    const _settings = {
+      bubbles: true,
+      cancelable: true,
+      detail: null,
+      ...settings
+    };
+    const evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent(event, _settings.bubbles, _settings.cancelable, _settings.detail);
+    return evt;
+  }
+}

--- a/static/scss/answers/directanswercards/allfields-standard.scss
+++ b/static/scss/answers/directanswercards/allfields-standard.scss
@@ -97,12 +97,14 @@
 
   }
 
-  &-feedbackWrapper
+  &-feedbackWrapper,
+  &-footerWrapper
   {
     background-color: var(--yxt-direct-answer-footer-background-color);
   }
 
-  &-feedback
+  &-feedbackContent,
+  &-footer
   {
     display: flex;
     justify-content: flex-end;
@@ -113,7 +115,8 @@
     padding-bottom: 8px;
   }
 
-  &-feedbackText
+  &-feedbackText,
+  &-footerText
   {
     display: inline;
     margin-right: 8px;
@@ -128,6 +131,46 @@
   &-thumbsWrapper
   {
     display: flex;
+  }
+
+  &-thumbs
+  {
+    display: flex;
+    margin: 0;
+  }
+
+  &-thumbUpIcon
+  {
+    transform: rotate(180deg);
+  }
+
+  &-thumbUpIcon,
+  &-thumbDownIcon
+  {
+    display: inline-flex;
+    color: var(--yxt-color-text-secondary);
+  }
+
+  &-thumb
+  {
+    display: inline;
+    flex-shrink: 0;
+    cursor: pointer;
+    font-size: 18px;
+
+    & + &
+    {
+      margin-left: 8px;
+    }
+  }
+
+  &-fieldset
+  {
+    display: inline;
+    margin-inline-start: 2px;
+    margin-inline-end: 2px;
+    line-height: 0;
+    min-inline-size: min-content;
   }
 
   &-fieldValueLink
@@ -161,6 +204,15 @@
   {
     list-style-type: disc;
     list-style-position: inside;
+  }
+
+  &-feedback
+  {
+    @include Text(
+      $color: var(--yxt-color-text-neutral),
+    );
+    background-color: var(--yxt-color-background-highlight);
+    display: none;
   }
 
   &-viewMore

--- a/static/scss/answers/directanswercards/documentsearch-standard.scss
+++ b/static/scss/answers/directanswercards/documentsearch-standard.scss
@@ -91,7 +91,8 @@
     background-color: var(--yxt-direct-answer-footer-background-color);
   }
 
-  &-feedback
+  &-feedbackContent,
+  &-footer
   {
     display: flex;
     justify-content: flex-end;
@@ -102,7 +103,8 @@
     padding-bottom: 8px;
   }
 
-  &-feedbackText
+  &-feedbackText,
+  &-footerText
   {
     display: inline;
     margin-right: 8px;
@@ -117,6 +119,55 @@
   &-thumbsWrapper
   {
     display: flex;
+  }
+
+  &-thumbs
+  {
+    display: flex;
+    margin: 0;
+  }
+
+  &-thumbUpIcon
+  {
+    transform: rotate(180deg);
+  }
+
+  &-thumbUpIcon,
+  &-thumbDownIcon
+  {
+    display: inline-flex;
+    color: var(--yxt-color-text-secondary);
+  }
+
+  &-thumb
+  {
+    display: inline;
+    flex-shrink: 0;
+    cursor: pointer;
+    font-size: 18px;
+
+    & + &
+    {
+      margin-left: 8px;
+    }
+  }
+
+  &-fieldset
+  {
+    display: inline;
+    margin-inline-start: 2px;
+    margin-inline-end: 2px;
+    line-height: 0;
+    min-inline-size: min-content;
+  }
+
+  &-feedback
+  {
+    @include Text(
+      $color: var(--yxt-color-text-neutral),
+    );
+    background-color: var(--yxt-color-background-highlight);
+    display: none;
   }
 
   &-viewMore


### PR DESCRIPTION
Add analytics for the thumbs up/down feedback buttons on cards. Update the analytics on direct answer cards to include additional event attributes that are consistent with those for results cards.

J=SLAP-1545
TEST=manual

Smoke testing to see if clicking feedback buttons on each card sent the correct analytics event and displayed the feedback submission message