### PR TITLE
remove usage of jambo's internal global.parseJamboConfig()

### DIFF
--- a/commands/helpers/utils/jamboconfigutils.js
+++ b/commands/helpers/utils/jamboconfigutils.js
@@ -41,7 +41,7 @@ exports.parseJamboConfig = function () {
  * @param {string} partialsPath The local path to the set of partials. 
  */
 exports.addToPartials = function (partialsPath) {
-  const jamboConfig = parseJamboConfig();
+  const jamboConfig = exports.parseJamboConfig();
   const existingPartials = jamboConfig.dirs.partials;
 
   const shouldAddNewPartialsPath =


### PR DESCRIPTION
Unfortunately a number of jambo's internal helpers are defined
on the global namespace. https://github.com/yext/jambo/pull/19/files
Then, when custom commands were added to the theme, a number of these helpers
were copy pasted from jambo. However, they were slightly modifier to NOT
reassign the helpers that were on the global namespace, while still using
the global parseJamboConfig() inside addToPartials().

i.e., when you write javascript like the below, WITHOUT using a declaration like let or const
```js
myFunction = function() {} // GLOBAL variable

// Other examples
const myFunction = function() {} //scoped
let myFunction = function() {} //scoped
var myFunction = function //global
```

what you are doing is creating a GLOBAL variable. Using the var declaration also does this.
This bug was found when trying to migrate to typescript, which does not allow for this syntax.

J=SLAP-1493
TEST=manual

ran the custom card command
saw it add to the jambo.json partials list
and create a custom card

console.logged the global namespace in the custom command, checked that none of the other global commands logged out were being used anywhere