### PR TITLE
bump esbuild-loader to 2.15.1

### DIFF
--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -2599,23 +2599,23 @@
       }
     },
     "esbuild": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
-      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz",
+      "integrity": "sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==",
       "dev": true
     },
     "esbuild-loader": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-2.13.1.tgz",
-      "integrity": "sha512-Tzc5nB5tVUmigXz6m4j1OYozJCjdix7E9vtd5RaE54fqz2Rz34Is9S8FbAf8uqR4xvQUBAXIi6Jkn1OeMxw2aQ==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-2.15.1.tgz",
+      "integrity": "sha512-JRBL6uTeWplMbylNBt9gxLKMjD8wKnqGq786QV/cm/nPBSNA9/kC7/vNwCXTDPfYqHoWsjyfH7ub9ekN0kdAYQ==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.11.19",
+        "esbuild": "^0.12.21",
         "joycon": "^3.0.1",
         "json5": "^2.2.0",
         "loader-utils": "^2.0.0",
         "tapable": "^2.2.0",
-        "type-fest": "^1.0.1",
+        "type-fest": "^1.4.0",
         "webpack-sources": "^2.2.0"
       },
       "dependencies": {
@@ -2646,9 +2646,9 @@
           "dev": true
         },
         "webpack-sources": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.0.tgz",
-          "integrity": "sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
+          "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
           "dev": true,
           "requires": {
             "source-list-map": "^2.0.1",
@@ -6434,9 +6434,9 @@
       }
     },
     "type-fest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.0.tgz",
-      "integrity": "sha512-++0N6KyAj0t2webXst0PE0xuXb4Dv3z1Z+4SGzK+j/epeWBZCfkQbkW/ezscZwpinmBQ5wu/l4TqagKSVcAGCA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true
     },
     "typescript": {

--- a/static/package.json
+++ b/static/package.json
@@ -22,7 +22,7 @@
     "babel-loader": "^8.1.0",
     "comment-json": "^4.1.1",
     "css-loader": "^3.4.2",
-    "esbuild-loader": "^2.13.1",
+    "esbuild-loader": "^2.15.1",
     "file-system": "^2.2.2",
     "fs-extra": "^9.0.1",
     "grunt": "^1.3.0",


### PR DESCRIPTION
this bumps the version of esbuild used internally by esbuild-loader from 0.11.19 to 0.12.19