### PR TITLE
error with getUrlWithTextHighlight

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -599,7 +599,7 @@ export function getYoutubeUrl(videos = []) {
  * @returns a URL with text fragment URI component attached
  */
 export function getUrlWithTextHighlight(snippet, baseUrl) {
-  if (!isChrome() || snippet.matchedSubstrings.length === 0) {
+  if (!isChrome() || !snippet || snippet.matchedSubstrings.length === 0) {
     return baseUrl;
   }
   //Find the surrounding sentence of the snippet

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -599,7 +599,7 @@ export function getYoutubeUrl(videos = []) {
  * @returns a URL with text fragment URI component attached
  */
 export function getUrlWithTextHighlight(snippet, baseUrl) {
-  if (!isChrome()) {
+  if (!isChrome() || snippet.matchedSubstrings.length === 0) {
     return baseUrl;
   }
   //Find the surrounding sentence of the snippet

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -192,6 +192,15 @@ describe('Formatters', () => {
     const isChrome = jest.spyOn(useragent, 'isChrome');
     isChrome.mockReturnValue(true);
 
+    it('Behaves correctly when there is no matchedSubstring', () => {
+      const snippet = {
+        value: 'this is a sentence, for testing purposes.',
+        matchedSubstrings: []
+      };
+      const actual = Formatters.getUrlWithTextHighlight(snippet, link);
+      expect(actual).toEqual(link);
+    });
+
     it('Behaves correctly when there is a matchedSubstring with a surrounding sentence', () => {
       const snippet = {
         value: 'this is a sentence, for testing purposes.',


### PR DESCRIPTION
direct answer may return a snippet with no matchSubstring, add a check for that before constructing url with text highlighting

TEST=manual&auto
- test a query that return a Direct answer without any matched substrings, see that no error occur and url is still working
- add jest test