### PR TITLE
QA item: use site locale for price range as default

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -537,15 +537,15 @@ export function priceRange(defaultPriceRange, countryCode) {
     console.warn(`No price range or country code given.`);
     return '';
   }
-  if(countryCode) {
+  if (countryCode) {
     const currencySymbol = getSymbolFromCurrency(LocaleCurrency.getCurrency(countryCode));
-    if(currencySymbol) {
+    if (currencySymbol) {
       return defaultPriceRange.replace(/\$/g, currencySymbol); 
     }
   }
   const locale = _getDocumentLocale();
   const currencySymbol = getSymbolFromCurrency(LocaleCurrency.getCurrency(locale));
-  if(currencySymbol) {
+  if (currencySymbol) {
     return defaultPriceRange.replace(/\$/g, currencySymbol); 
   }
   console.warn(`Unable to determine currency symbol from ISO country code "${countryCode}" or locale "${locale}".`);

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -534,7 +534,7 @@ export function price(fieldValue = {}, locale) {
  */
 export function priceRange(defaultPriceRange, countryCode) {
   if (!defaultPriceRange) {
-    console.warn(`No price range or country code given.`);
+    console.warn(`Price range is not provided.`);
     return '';
   }
   if (countryCode) {

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -10,6 +10,7 @@ import { generateCTAFieldTypeLink } from './formatters/generate-cta-field-type-l
 import { isChrome } from './useragent.js';
 import LocaleCurrency from 'locale-currency'
 import getSymbolFromCurrency from 'currency-symbol-map'
+import { parseLocale } from './utils.js';
 
 export function address(profile) {
   if (!profile.address) {
@@ -543,12 +544,13 @@ export function priceRange(defaultPriceRange, countryCode) {
       return defaultPriceRange.replace(/\$/g, currencySymbol); 
     }
   }
-  const locale = _getDocumentLocale();
-  const currencySymbol = getSymbolFromCurrency(LocaleCurrency.getCurrency(locale));
+  const { region, language } = parseLocale(_getDocumentLocale());
+  const currencySymbol = getSymbolFromCurrency(LocaleCurrency.getCurrency(region || language));
   if (currencySymbol) {
     return defaultPriceRange.replace(/\$/g, currencySymbol); 
   }
-  console.warn(`Unable to determine currency symbol from ISO country code "${countryCode}" or locale "${locale}".`);
+  console.warn('Unable to determine currency symbol from '
+    + `ISO country code "${countryCode}" or locale "${_getDocumentLocale()}".`);
   return defaultPriceRange;
 }
 

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -525,24 +525,30 @@ export function price(fieldValue = {}, locale) {
 }
 
 /**
- * Returns a localized price range string for the given price range ($-$$$$) and country code (ISO format)
+ * Returns a localized price range string for the given price range ($-$$$$) and country code (ISO format).
+ * If country code is invalid or undefined, use locale of the site to determine the currency symbol.
+ * If all else fails, use the default priceRange with dollar sign.
  * @param {string} defaultPriceRange The price range from LiveAPI entity
  * @param {string} countrycode The country code from LiveAPI entity (e.g. profile.address.countryCode)
  * @return {string} The price range with correct currency symbol formatting according to country code
  */
 export function priceRange(defaultPriceRange, countryCode) {
-  if (!defaultPriceRange || !countryCode) {
+  if (!defaultPriceRange) {
     console.warn(`No price range or country code given.`);
     return '';
   }
-  const currencyCode = LocaleCurrency.getCurrency(countryCode);
-  if (currencyCode) {
-    const currencySymbol = getSymbolFromCurrency(currencyCode);
-    if (currencySymbol) {
+  if(countryCode) {
+    const currencySymbol = getSymbolFromCurrency(LocaleCurrency.getCurrency(countryCode));
+    if(currencySymbol) {
       return defaultPriceRange.replace(/\$/g, currencySymbol); 
     }
   }
-  console.warn(`Unable to determine currency symbol from ISO country code ${countryCode}.`);
+  const locale = _getDocumentLocale();
+  const currencySymbol = getSymbolFromCurrency(LocaleCurrency.getCurrency(locale));
+  if(currencySymbol) {
+    return defaultPriceRange.replace(/\$/g, currencySymbol); 
+  }
+  console.warn(`Unable to determine currency symbol from ISO country code "${countryCode}" or locale "${locale}".`);
   return defaultPriceRange;
 }
 

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -135,7 +135,20 @@ describe('Formatters', () => {
       expect(price).toEqual('£');
     });
 
-    it('Formats a price range in invalid input', () => {
+    it('Formats a price range in invalid country code, use page\'s locale', () => {
+      document.documentElement.lang = 'jp'
+      const price = Formatters.priceRange('$$$', 'IDK');
+      expect(price).toEqual('¥¥¥');
+    });
+
+    it('Formats a price range in undefined country code, use page\'s locale', () => {
+      document.documentElement.lang = 'jp'
+      const price = Formatters.priceRange('$$$', undefined);
+      expect(price).toEqual('¥¥¥');
+    });
+
+    it('Formats a price range in invalid country code and invalid page\'s locale', () => {
+      document.documentElement.lang = 'IDKK'
       const price = Formatters.priceRange('$', 'IDK');
       expect(price).toEqual('$');
     });

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -142,9 +142,12 @@ describe('Formatters', () => {
     });
 
     it('Formats a price range in undefined country code, use page\'s locale', () => {
-      document.documentElement.lang = 'jp'
-      const price = Formatters.priceRange('$$$', undefined);
+      document.documentElement.lang = 'zh-CN'
+      let price = Formatters.priceRange('$$$', undefined);
       expect(price).toEqual('¥¥¥');
+      document.documentElement.lang = 'zh-Hant_TW'
+      price = Formatters.priceRange('$$$', undefined);
+      expect(price).toEqual('NT$NT$NT$');
     });
 
     it('Formats a price range in invalid country code and invalid page\'s locale', () => {


### PR DESCRIPTION
- update priceRange formatter function to determined the price range string in following order:
	- use provided country code to determine the currency symbol
	- if country code is invalid or undefined, use site locale to determine the currency symbol
	- if all else fails, return the default price range, which is in $

TEST=auto

add more cases in jest test, all passed