### PR TITLE
Move video to top of video cards

### DIFF
--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -1,10 +1,10 @@
 <div class="HitchhikerProductProminentVideo {{cardName}}">
-  <div class="HitchhikerProductProminentVideo-header">
+  {{> video }}
+  <div class="HitchhikerProductProminentVideo-body">
     {{> title }}
     {{> subtitle }}
+    {{> content }}
   </div>
-  {{> video }}
-  {{> content }}
 </div>
 
 {{#*inline 'title'}}

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -1,10 +1,10 @@
 <div class="HitchhikerProductProminentVideo {{cardName}}">
-  <div class="HitchhikerProductProminentVideo-header">
+  {{> video }}
+  <div class="HitchhikerProductProminentVideo-body">
     {{> title }}
     {{> subtitle }}
+    {{> content }}
   </div>
-  {{> video }}
-  {{> content }}
 </div>
 
 {{#*inline 'title'}}

--- a/static/scss/answers/cards/product-prominentvideo.scss
+++ b/static/scss/answers/cards/product-prominentvideo.scss
@@ -8,11 +8,15 @@
   width: 100%;
   height: 100%;
 
+  &-body
+  {
+    padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
+  }
+
   &-header
   {
     display: flex;
     flex-direction: column;
-    padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
   }
 
   &-contentWrapper
@@ -20,7 +24,6 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
   }
 
   &-title
@@ -64,6 +67,11 @@
   &-detailsText
   {
     @include rich_text_formatting;
+  }
+
+  &-cardDetails
+  {
+    margin-top: calc(var(--yxt-base-spacing) / 2);
   }
 
   &-ctasWrapper

--- a/static/scss/answers/cards/product-prominentvideo.scss
+++ b/static/scss/answers/cards/product-prominentvideo.scss
@@ -13,12 +13,6 @@
     padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
   }
 
-  &-header
-  {
-    display: flex;
-    flex-direction: column;
-  }
-
   &-contentWrapper
   {
     display: flex;


### PR DESCRIPTION
Move the videos in the video cards to the top so that the videos are aligned

By moving the videos to the top of the card, we match the layout of the product image cards. The original video card spec has the video below the title, however this causes alignment issues when the card title overflows onto the next line since the videos are now out of alignment. CSS Subgrid is the proper way to align content across cards, (https://www.smashingmagazine.com/2018/07/css-grid-2/) however currently it's only supported on firefox so we can't go that route yet. For now, we simply move the video to the top of the cards.

J=none
TEST=manual

Test the card locally and confirm the layout looks the same as the product image cards. Add CTAs and subtitles locally and confirm they look good as well