### PR TITLE
avoid results render on locator map view

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "1.10", // The version of the Answers SDK to use
+  "sdkVersion": "develop", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -189,14 +189,14 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       this.searchThisArea();
     });
 
-    this.setupCssForBreakpoints();
+    this.setupMobileBreakpointListener();
     this.addMapComponent();
   }
 
   /**
    * Properly set CSS classes for mobile and desktop
    */
-  setupCssForBreakpoints () {
+   setupMobileBreakpointListener () {
     if (!this.isMobile()) {
       this.updateCssForDesktop();
     }

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -20,6 +20,13 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     super(config, systemConfig);
 
     /**
+     * Name of a location card type
+     * 
+     * @type {string}
+     */
+    this.cardType = config.cardType;
+
+    /**
      * The container in the DOM for the interactive map
      * @type {HTMLElement}
      */
@@ -198,6 +205,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       if (this.isMobile()) {
         this.updateCssForMobile();
       } else {
+        this.core.storage.set('DISABLE_RENDER_RESULTS', false);
         this.updateCssForDesktop();
       }
     };
@@ -466,22 +474,29 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
    */
   pinFocusListener (index, cardId) {
     this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, cardId);
-    const selector = `.yxt-Card[data-opts='{ "_index": ${index - 1} }']`;
-    const card = document.querySelector(selector);
-
     document.querySelectorAll('.yxt-Card--pinFocused').forEach((el) => {
       el.classList.remove('yxt-Card--pinFocused');
     });
-
-    card.classList.add('yxt-Card--pinFocused');
 
     if (this.isMobile()) {
       document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').forEach((el) => removeElement(el));
       const isDetailCardOpened = document.querySelectorAll('.yxt-Card--isVisibleOnMobileMap').length;
 
-      this._detailCard = card.cloneNode(true);
+      const entityId = cardId.replace('js-yl-', '');
+      const verticalResults = this.core.storage.get(StorageKeys.VERTICAL_RESULTS).results;
+      const entityData = verticalResults.find(entity => entity.id.toString() === entityId);
+      const opts = {
+        parentContainer: this._container, 
+        container: `.yxt-Card-${entityId}`,
+        data: {
+          result: entityData,
+          verticalKey: this.verticalKey
+        }
+      };
+      ANSWERS.addComponent(this.cardType, opts);
+      this._detailCard = this._container.querySelector(`.yxt-Card-${entityId}`);
       this._detailCard.classList.add('yxt-Card--isVisibleOnMobileMap');
-      this._container.appendChild(this._detailCard);
+      this._detailCard.classList.add('yxt-Card--pinFocused');
 
       if (!isDetailCardOpened) {
         window.requestAnimationFrame(() => {
@@ -502,6 +517,9 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
       this.addCssClassesForState(MobileStates.DETAIL_SHOWN);
     } else {
+      const selector = `.yxt-Card[data-opts='{ "_index": ${index - 1} }']`;
+      const card = document.querySelector(selector);
+      card.classList.add('yxt-Card--pinFocused');
       this.scrollToResult(card);
     }
   }
@@ -532,8 +550,10 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
           this.deselectAllResults();
           window.scrollTo(0, 0);
           if (this._mobileView === MobileStates.LIST_VIEW) {
+            this.core.storage.set('DISABLE_RENDER_RESULTS', true);
             this.setMobileMapView();
           } else {
+            this.core.storage.set('DISABLE_RENDER_RESULTS', false);
             this.setMobileListView();
           }
         });

--- a/templates/vertical-full-page-map/script/verticalresults.hbs
+++ b/templates/vertical-full-page-map/script/verticalresults.hbs
@@ -1,5 +1,15 @@
 ANSWERS.addComponent("VerticalResults", Object.assign({}, {
   container: "#js-answersVerticalResults",
+  onCreate: function() { 
+    this.core.storage.registerListener({
+      storageKey: 'DISABLE_RENDER_RESULTS',
+      eventType: 'update',
+      callback: () => { this.setState(this.getState()) }
+    });
+  },
+  beforeMountOverride: function(data) { 
+    return !this.core.storage.get('DISABLE_RENDER_RESULTS');
+  },
   {{#if verticalKey}}
     verticalKey: "{{{verticalKey}}}",
     modifier: "{{{verticalKey}}}",

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "1.10", // The version of the Answers SDK to use
+  "sdkVersion": "develop", // The version of the Answers SDK to use
   "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/theme-components/vertical-full-page-map/script.js
+++ b/theme-components/vertical-full-page-map/script.js
@@ -22,6 +22,9 @@ ANSWERS.addComponent('VerticalFullPageMapOrchestrator', Object.assign({},
   },
   locale: "{{global_config.locale}}",
   verticalKey: "{{{verticalKey}}}",
+  {{#with (lookup verticalsToConfig verticalKey)}}
+    {{#if cardType}}cardType: "{{{cardType}}}",{{/if}}
+  {{/with}}
   verticalPages: [
     {{#each verticalConfigs}}
       {{#if verticalKey}}


### PR DESCRIPTION
Improve performance for map pages on mobile by only render result cards on list view

- VerticalFullPageMapOrchestrator use a field in core storage `DISABLE_RENDER_RESULTS` to communicate with VerticalResults component whether it should render the results on page.
- VerticalResults component's config pass in a beforeMountOverride function to avoid mount() being call in the component lifecycle and render if `DISABLE_RENDER_RESULTS` is true.
- VerticalResults component's config also pass in a onCreate function to add a listener on any changes `DISABLE_RENDER_RESULTS`, to potentially trigger render update for the rsults if user switch from map view to list view, or screen resize between mobile and desktop view
- Since VerticalResults now will not render any location cards on map view, VerticalFullPageOrchestrator can no longer copy the card and display that when a pin is clicked. So,cardType is passed into the config for VerticalFullPageOrchestrator. When a pin is click, the cardId is used to pull the corresponding entity data from results in storage, and construct a card component based on cardType to append to the top level map container.

Note: require update to SDK's component.js file for beforeMountOverride to work

J=SLAP-1302
TEST=manual & auto

smoke test from theme's locations_full_page_map vertical page:
- resize screen from mobile to desktop and vice versa, see that results and focused pins are still loaded properly.
- toggle between map and list view, see that the results are only render on list view in elemnt inspection (except for the first time when search is trigger from searchbar)
- in map view, drag across the map a few times and see that pins are loaded correctly but results are not render on the page.
- see that detail card is displayed correctly when click on pin from map view, before and after dragging acrross the map

recorded performance metric on browser inspector, see that the tasks to re-render the components shrink to around ~≤27ms compare to previous time depending on result count (~≥100ms for 2000+ results) (got rid of most of the 'long tasks' - where the main UI thread is busy for 50 ms or longer)

no changes in map related snapshots from percy