### PR TITLE
Fix google maps InvalidValueError in theme

### DIFF
--- a/templates/universal-standard/script/map-pin.hbs
+++ b/templates/universal-standard/script/map-pin.hbs
@@ -32,7 +32,7 @@
   if (mapProvider === 'google') {
     config.svg = svg;
     {{!-- Don't use the sdk's built-in label for GoogleMapProvider --}}
-    config.label = {};
+    config.label = '';
     config.scaledSize = {
       w: pinStyling.width,
       h: pinStyling.height,

--- a/templates/vertical-map/script/map-pin.hbs
+++ b/templates/vertical-map/script/map-pin.hbs
@@ -32,7 +32,7 @@
   if (mapProvider === 'google') {
     config.svg = svg;
     {{!-- Don't use the sdk's built-in label for GoogleMapProvider --}}
-    config.label = {};
+    config.label = '';
     config.scaledSize = {
       w: pinStyling.width,
       h: pinStyling.height,


### PR DESCRIPTION
- SDK GoogleMapMarkerConfig expects label to be of type string

J=SLAP-655
TEST=manual

see that map is working properly and error is gone in browser inspector