### PR TITLE
Distance formatter to include locale with region

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -82,15 +82,21 @@ export function toLocalizedDistance(profile, key = 'd_distance', displayUnits) {
   return this.toMiles(profile, undefined, undefined, locale);
 }
 
+
+
+export function _getJSFormattedLocale(locale) {
+  return locale && locale.replace(/_/g, '-');
+}
+
 export function _getDocumentLocale() {
-  return document.documentElement.lang.replace(/_/g, '-');
+  return _getJSFormattedLocale(document.documentElement.lang);
 }
 
 export function toKilometers(profile, key = 'd_distance', displayUnits = 'km', locale) {
   if (!profile[key]) {
     return '';
   }
-  locale = (locale && locale.replace(/_/g, '-')) || _getDocumentLocale()
+  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
   const distanceInKilometers = profile[key] / 1000; // Convert meters to kilometers
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1})
@@ -101,7 +107,7 @@ export function toMiles(profile, key = 'd_distance', displayUnits = 'mi', locale
   if (!profile[key]) {
     return '';
   }
-  locale = (locale && locale.replace(/_/g, '-')) || _getDocumentLocale()
+  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
   const distanceInMiles = profile[key] / 1609.344; // Convert meters to miles
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1 })
@@ -234,7 +240,7 @@ export function snakeToTitle(snake) {
  * @returns {string} The pretty printed value.
  */
 export function prettyPrintObject(obj, locale) {
-  locale = locale || _getDocumentLocale();
+  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
 
   switch (typeof obj) {
     case 'string':
@@ -459,7 +465,7 @@ export function openStatus(profile, key = 'hours', isTwentyFourHourClock, locale
   }
 
   const hoursLocalizer = new HoursStringsLocalizer(
-    locale || _getDocumentLocale(), isTwentyFourHourClock);
+    _getJSFormattedLocale(locale) || _getDocumentLocale(), isTwentyFourHourClock);
   return new OpenStatusMessageFactory(hoursLocalizer)
     .create(hours.openStatus);
 }
@@ -501,7 +507,7 @@ export function hoursList(profile, opts = {}, key = 'hours', locale) {
     };
 
     const hoursLocalizer = new HoursStringsLocalizer(
-      locale || _getDocumentLocale(), opts.isTwentyFourHourClock);
+      _getJSFormattedLocale(locale) || _getDocumentLocale(), opts.isTwentyFourHourClock);
     return new HoursTableBuilder(hoursLocalizer).build(hours, standardizedOpts);
 }
 
@@ -515,7 +521,7 @@ export { generateCTAFieldTypeLink };
  *                  returns the price value without formatting
  */
 export function price(fieldValue = {}, locale) {
-  const localeForFormatting = locale || _getDocumentLocale() || 'en';
+  const localeForFormatting = _getJSFormattedLocale(locale) || _getDocumentLocale() || 'en';
   const price = fieldValue.value && parseFloat(fieldValue.value);
   const currencyCode = fieldValue.currencyCode && fieldValue.currencyCode.split('-')[0];
   if (!price || isNaN(price) || !currencyCode) {

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -82,7 +82,9 @@ export function toLocalizedDistance(profile, key = 'd_distance', displayUnits) {
   return this.toMiles(profile, undefined, undefined, locale);
 }
 
-
+export function _getDefinedLocale(locale) {
+  return _getJSFormattedLocale(locale) || _getDocumentLocale() || 'en';
+}
 
 export function _getJSFormattedLocale(locale) {
   return locale && locale.replace(/_/g, '-');
@@ -96,7 +98,7 @@ export function toKilometers(profile, key = 'd_distance', displayUnits = 'km', l
   if (!profile[key]) {
     return '';
   }
-  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
+  locale = _getDefinedLocale(locale);
   const distanceInKilometers = profile[key] / 1000; // Convert meters to kilometers
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1})
@@ -107,7 +109,7 @@ export function toMiles(profile, key = 'd_distance', displayUnits = 'mi', locale
   if (!profile[key]) {
     return '';
   }
-  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
+  locale = _getDefinedLocale(locale);
   const distanceInMiles = profile[key] / 1609.344; // Convert meters to miles
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1 })
@@ -240,7 +242,7 @@ export function snakeToTitle(snake) {
  * @returns {string} The pretty printed value.
  */
 export function prettyPrintObject(obj, locale) {
-  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
+  locale = _getDefinedLocale(locale);
 
   switch (typeof obj) {
     case 'string':
@@ -465,7 +467,7 @@ export function openStatus(profile, key = 'hours', isTwentyFourHourClock, locale
   }
 
   const hoursLocalizer = new HoursStringsLocalizer(
-    _getJSFormattedLocale(locale) || _getDocumentLocale(), isTwentyFourHourClock);
+    _getDefinedLocale(locale), isTwentyFourHourClock);
   return new OpenStatusMessageFactory(hoursLocalizer)
     .create(hours.openStatus);
 }
@@ -507,7 +509,7 @@ export function hoursList(profile, opts = {}, key = 'hours', locale) {
     };
 
     const hoursLocalizer = new HoursStringsLocalizer(
-      _getJSFormattedLocale(locale) || _getDocumentLocale(), opts.isTwentyFourHourClock);
+      _getDefinedLocale(locale), opts.isTwentyFourHourClock);
     return new HoursTableBuilder(hoursLocalizer).build(hours, standardizedOpts);
 }
 
@@ -521,7 +523,7 @@ export { generateCTAFieldTypeLink };
  *                  returns the price value without formatting
  */
 export function price(fieldValue = {}, locale) {
-  const localeForFormatting = _getJSFormattedLocale(locale) || _getDocumentLocale() || 'en';
+  const localeForFormatting = _getDefinedLocale(locale);
   const price = fieldValue.value && parseFloat(fieldValue.value);
   const currencyCode = fieldValue.currencyCode && fieldValue.currencyCode.split('-')[0];
   if (!price || isNaN(price) || !currencyCode) {

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -82,10 +82,6 @@ export function toLocalizedDistance(profile, key = 'd_distance', displayUnits) {
   return this.toMiles(profile, undefined, undefined, locale);
 }
 
-export function _getDefinedLocale(locale) {
-  return _getJSFormattedLocale(locale) || _getDocumentLocale() || 'en';
-}
-
 export function _getJSFormattedLocale(locale) {
   return locale && locale.replace(/_/g, '-');
 }
@@ -98,7 +94,7 @@ export function toKilometers(profile, key = 'd_distance', displayUnits = 'km', l
   if (!profile[key]) {
     return '';
   }
-  locale = _getDefinedLocale(locale);
+  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
   const distanceInKilometers = profile[key] / 1000; // Convert meters to kilometers
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1})
@@ -109,7 +105,7 @@ export function toMiles(profile, key = 'd_distance', displayUnits = 'mi', locale
   if (!profile[key]) {
     return '';
   }
-  locale = _getDefinedLocale(locale);
+  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
   const distanceInMiles = profile[key] / 1609.344; // Convert meters to miles
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1 })
@@ -242,7 +238,7 @@ export function snakeToTitle(snake) {
  * @returns {string} The pretty printed value.
  */
 export function prettyPrintObject(obj, locale) {
-  locale = _getDefinedLocale(locale);
+  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
 
   switch (typeof obj) {
     case 'string':
@@ -467,7 +463,7 @@ export function openStatus(profile, key = 'hours', isTwentyFourHourClock, locale
   }
 
   const hoursLocalizer = new HoursStringsLocalizer(
-    _getDefinedLocale(locale), isTwentyFourHourClock);
+    _getJSFormattedLocale(locale) || _getDocumentLocale(), isTwentyFourHourClock);
   return new OpenStatusMessageFactory(hoursLocalizer)
     .create(hours.openStatus);
 }
@@ -509,7 +505,7 @@ export function hoursList(profile, opts = {}, key = 'hours', locale) {
     };
 
     const hoursLocalizer = new HoursStringsLocalizer(
-      _getDefinedLocale(locale), opts.isTwentyFourHourClock);
+      _getJSFormattedLocale(locale) || _getDocumentLocale(), opts.isTwentyFourHourClock);
     return new HoursTableBuilder(hoursLocalizer).build(hours, standardizedOpts);
 }
 
@@ -523,7 +519,7 @@ export { generateCTAFieldTypeLink };
  *                  returns the price value without formatting
  */
 export function price(fieldValue = {}, locale) {
-  const localeForFormatting = _getDefinedLocale(locale);
+  const localeForFormatting =  _getJSFormattedLocale(locale) || _getDocumentLocale() || 'en';
   const price = fieldValue.value && parseFloat(fieldValue.value);
   const currencyCode = fieldValue.currencyCode && fieldValue.currencyCode.split('-')[0];
   if (!price || isNaN(price) || !currencyCode) {

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -83,14 +83,14 @@ export function toLocalizedDistance(profile, key = 'd_distance', displayUnits) {
 }
 
 export function _getDocumentLocale() {
-  return document.documentElement.lang.replace('_', '-');
+  return document.documentElement.lang.replace(/_/g, '-');
 }
 
 export function toKilometers(profile, key = 'd_distance', displayUnits = 'km', locale) {
   if (!profile[key]) {
     return '';
   }
-  locale = locale || _getDocumentLocale()
+  locale = (locale && locale.replace(/_/g, '-')) || _getDocumentLocale()
   const distanceInKilometers = profile[key] / 1000; // Convert meters to kilometers
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1})
@@ -101,7 +101,7 @@ export function toMiles(profile, key = 'd_distance', displayUnits = 'mi', locale
   if (!profile[key]) {
     return '';
   }
-  locale = locale || _getDocumentLocale()
+  locale = (locale && locale.replace(/_/g, '-')) || _getDocumentLocale()
   const distanceInMiles = profile[key] / 1609.344; // Convert meters to miles
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1 })

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -82,19 +82,19 @@ export function toLocalizedDistance(profile, key = 'd_distance', displayUnits) {
   return this.toMiles(profile, undefined, undefined, locale);
 }
 
-export function _getJSFormattedLocale(locale) {
+export function _getLocaleWithDashes(locale) {
   return locale && locale.replace(/_/g, '-');
 }
 
 export function _getDocumentLocale() {
-  return _getJSFormattedLocale(document.documentElement.lang);
+  return _getLocaleWithDashes(document.documentElement.lang);
 }
 
 export function toKilometers(profile, key = 'd_distance', displayUnits = 'km', locale) {
   if (!profile[key]) {
     return '';
   }
-  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
+  locale = _getLocaleWithDashes(locale) || _getDocumentLocale();
   const distanceInKilometers = profile[key] / 1000; // Convert meters to kilometers
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1})
@@ -105,7 +105,7 @@ export function toMiles(profile, key = 'd_distance', displayUnits = 'mi', locale
   if (!profile[key]) {
     return '';
   }
-  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
+  locale = _getLocaleWithDashes(locale) || _getDocumentLocale();
   const distanceInMiles = profile[key] / 1609.344; // Convert meters to miles
   return new Intl.NumberFormat(locale,
     { style: 'decimal', maximumFractionDigits: 1, minimumFractionDigits: 1 })
@@ -238,7 +238,7 @@ export function snakeToTitle(snake) {
  * @returns {string} The pretty printed value.
  */
 export function prettyPrintObject(obj, locale) {
-  locale = _getJSFormattedLocale(locale) || _getDocumentLocale();
+  locale = _getLocaleWithDashes(locale) || _getDocumentLocale();
 
   switch (typeof obj) {
     case 'string':
@@ -463,7 +463,7 @@ export function openStatus(profile, key = 'hours', isTwentyFourHourClock, locale
   }
 
   const hoursLocalizer = new HoursStringsLocalizer(
-    _getJSFormattedLocale(locale) || _getDocumentLocale(), isTwentyFourHourClock);
+    _getLocaleWithDashes(locale) || _getDocumentLocale(), isTwentyFourHourClock);
   return new OpenStatusMessageFactory(hoursLocalizer)
     .create(hours.openStatus);
 }
@@ -505,7 +505,7 @@ export function hoursList(profile, opts = {}, key = 'hours', locale) {
     };
 
     const hoursLocalizer = new HoursStringsLocalizer(
-      _getJSFormattedLocale(locale) || _getDocumentLocale(), opts.isTwentyFourHourClock);
+      _getLocaleWithDashes(locale) || _getDocumentLocale(), opts.isTwentyFourHourClock);
     return new HoursTableBuilder(hoursLocalizer).build(hours, standardizedOpts);
 }
 
@@ -519,7 +519,7 @@ export { generateCTAFieldTypeLink };
  *                  returns the price value without formatting
  */
 export function price(fieldValue = {}, locale) {
-  const localeForFormatting =  _getJSFormattedLocale(locale) || _getDocumentLocale() || 'en';
+  const localeForFormatting =  _getLocaleWithDashes(locale) || _getDocumentLocale() || 'en';
   const price = fieldValue.value && parseFloat(fieldValue.value);
   const currencyCode = fieldValue.currencyCode && fieldValue.currencyCode.split('-')[0];
   if (!price || isNaN(price) || !currencyCode) {

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -6,7 +6,7 @@ describe('Formatters', () => {
     const profile = { d_distance: 10000000 }; // Distance in meters
     const distanceKey = 'd_distance';
     
-    beforeEach(function() {
+    beforeEach(() => {
       document.documentElement.lang = '';
     });
 
@@ -74,7 +74,7 @@ describe('Formatters', () => {
       currencyCode: 'USD-US Dollar'
     };
 
-    beforeEach(function() {
+    beforeEach(() => {
       document.documentElement.lang = '';
     });
 

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -51,6 +51,15 @@ describe('Formatters', () => {
       const distance = Formatters.toLocalizedDistance(profile);
       expect(distance).toEqual('10,000.0 km');
     });
+
+    it('Correctly formats distance for Chinese display', () => {
+      document.documentElement.lang = 'zh-CN';
+      let distance = Formatters.toLocalizedDistance(profile);
+      expect(distance).toEqual('10,000.0 km');
+      document.documentElement.lang = 'zh-Hant_TW';
+      distance = Formatters.toLocalizedDistance(profile);
+      expect(distance).toEqual('10,000.0 km');
+    });
   })
 
   describe('price', () => {
@@ -62,10 +71,13 @@ describe('Formatters', () => {
       const price = Formatters.price(priceField, 'en');
       expect(price).toEqual('$100.99');
     });
+
     it('Formats a price in USD with no provided locale', () => {
+      document.documentElement.lang = 'en';
       const price = Formatters.price(priceField);
       expect(price).toEqual('$100.99');
     });
+
     it('Formats a price in USD with a non-en locale', () => {
       const price = Formatters.price(priceField, 'fr');
       expect(price).toEqual('100,99 $US');
@@ -76,6 +88,7 @@ describe('Formatters', () => {
       const price = Formatters.price(priceField);
       expect(price).toEqual('€100.99');
     });
+
     it('Formats a price in EUR with a non-en locale', () => {
       priceField.currencyCode = 'EUR-Euro';
       const price = Formatters.price(priceField, 'fr');

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -5,19 +5,25 @@ describe('Formatters', () => {
   describe('toLocalizedDistance', () => {
     const profile = { d_distance: 10000000 }; // Distance in meters
     const distanceKey = 'd_distance';
-    document.documentElement.lang = 'en';
+    
+    beforeEach(function() {
+      document.documentElement.lang = '';
+    });
 
     it('Formats a distance in kilometers', () => {
+      document.documentElement.lang = 'en';
       const distance = Formatters.toLocalizedDistance(profile, distanceKey, 'km');
       expect(distance).toEqual('10,000.0 km');
     });
 
     it('Formats a distance in miles', () => {
+      document.documentElement.lang = 'en';
       const distance = Formatters.toLocalizedDistance(profile, distanceKey, 'mi');
       expect(distance).toEqual('6,213.7 mi');
     });
 
     it('Fallbacks to miles', () => {
+      document.documentElement.lang = 'en';
       const distance = Formatters.toLocalizedDistance(profile, distanceKey, 'unknown-unit');
       expect(distance).toEqual('6,213.7 mi');
     });
@@ -67,6 +73,11 @@ describe('Formatters', () => {
       value: '100.99',
       currencyCode: 'USD-US Dollar'
     };
+
+    beforeEach(function() {
+      document.documentElement.lang = '';
+    });
+
     it('Formats a price in USD', () => {
       const price = Formatters.price(priceField, 'en');
       expect(price).toEqual('$100.99');


### PR DESCRIPTION
Int.FormatNumber and toLocaleString would fail on locale with underscore, such as chinese locale like 'zh-Hant_CN'. Update function to replace underscore with dash for locale

TEST=auto

pass updated jest test