### PR TITLE
remove extra rtf analytics on results cards

### DIFF
--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -30,12 +30,6 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
         })
       );
     }
-    
-    const rtfElement = this._container.querySelector('.js-yxt-rtfValue');
-    if (rtfElement) {
-      const fieldName = rtfElement.dataset.fieldName;
-      rtfElement.addEventListener('click', e => this._handleRtfClickAnalytics(e, fieldName));
-    }
   }
 
   setState(data) {
@@ -92,38 +86,6 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
       },
       eventOptions
     );
-  }
-
-  /**
-   * A click handler for links in a Rich Text attriubte. When such a link is
-   * clicked, an {@link AnalyticsEvent} needs to be fired.
-   *
-   * @param {MouseEvent} event The click event.
-   * @param {string} fieldName The name of the Rich Text field used in the
-   *                           attriubte.
-   */
-   _handleRtfClickAnalytics (event, fieldName) {
-    const ctaType = event.target.dataset.ctaType;
-    if (!ctaType) {
-      return;
-    }
-
-    const analyticsOptions = {
-      directAnswer: false,
-      verticalKey: this.verticalKey,
-      searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
-      entityId: this.result.id,
-      url: event.target.href
-    };
-    if (!fieldName) {
-      console.warn('Field name not provided for RTF click analytics');
-    } else {
-      analyticsOptions.fieldName = fieldName;
-    }
-
-    const analyticsEvent = new ANSWERS.AnalyticsEvent(ctaType);
-    analyticsEvent.addOptions(analyticsOptions);
-    this.analyticsReporter.report(analyticsEvent);
   }
 
   static get type() {


### PR DESCRIPTION
Prior to this change, rtf click analytics on links would fire twice.
This is due to to the both SDK's and theme's base card components registering
click event handlers. The theme's base card exists as a child of the SDK's base card.

J=TECHOPS-2149
TEST=manual