### PR TITLE
dont hide ANSWERS.onReady errors

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -106,6 +106,7 @@
         });
       }
     }).catch(err => {
+      console.error(err);
       window.AnswersExperience.AnswersInitializedPromise.reject('Answers failed to initialized.');
     });
     {{> script/after-init}}


### PR DESCRIPTION
Prior to this change, all errors that occurred during ANSWERS.onReady
were being swallowed up by the .catch(). This could lead to very
frustrating debugging experiences, and also hide critical errors like
a null pointer error.

J=SLAP-1616
TEST=manual

see that errors are no longer hidden