### PR TITLE
Use color-text-primary for card body text

### DIFF
--- a/static/scss/answers/cards/document-standard.scss
+++ b/static/scss/answers/cards/document-standard.scss
@@ -64,6 +64,7 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-ctasWrapper

--- a/static/scss/answers/cards/event-standard.scss
+++ b/static/scss/answers/cards/event-standard.scss
@@ -79,6 +79,7 @@
   &-detailsText
   {
     margin-top: calc(var(--yxt-base-spacing) / 2);
+    color: var(--yxt-color-text-primary);
   }
 
   &-content

--- a/static/scss/answers/cards/faq-accordion.scss
+++ b/static/scss/answers/cards/faq-accordion.scss
@@ -90,8 +90,12 @@
 
     margin: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
     font-size: var(--yxt-font-size-md);
-    color: var(--yxt-color-text-primary);
     line-height: var(--yxt-line-height-md);
+  }
+
+  &-detailsText
+  {
+    color: var(--yxt-color-text-primary);
   }
 
   &-details-toggle

--- a/static/scss/answers/cards/financial-professional-location.scss
+++ b/static/scss/answers/cards/financial-professional-location.scss
@@ -97,13 +97,23 @@ $financial-professional-location-ordinal-dimensions: 18px !default;
 
   &-distance
   {
+    color: var(--yxt-color-text-primary);
+  }
+
+  &-distance
+  {
     font-style: italic;
     white-space: nowrap;
     margin-left: auto;
     margin-right: 0;
   }
 
-  &-address,
+  &-address
+  {
+    margin-top: calc(var(--hh-financial-professional-location-spacing) / 2);
+    color: var(--yxt-color-text-primary);
+  }
+
   &-cardDetails
   {
     margin-top: calc(var(--hh-financial-professional-location-spacing) / 2);
@@ -112,6 +122,7 @@ $financial-professional-location-ordinal-dimensions: 18px !default;
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-listTitle
@@ -127,9 +138,15 @@ $financial-professional-location-ordinal-dimensions: 18px !default;
     padding-left: calc(var(--hh-financial-professional-location-spacing) / 2);
   }
 
+  &-listWrapper
+  {
+    color: var(--yxt-color-text-primary);
+  }
+
   &-phone
   {
     margin-top: calc(var(--hh-financial-professional-location-spacing) / 2);
+    color: var(--yxt-color-text-primary);
   }
 
   &-phone--desktop {

--- a/static/scss/answers/cards/job-standard.scss
+++ b/static/scss/answers/cards/job-standard.scss
@@ -67,6 +67,7 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-ctasWrapper

--- a/static/scss/answers/cards/link-standard.scss
+++ b/static/scss/answers/cards/link-standard.scss
@@ -62,6 +62,7 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
 
     br {
       display: none; // TODO (agrow) figure out a less hacky way to do this

--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -123,6 +123,7 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
     font-style: italic;
     white-space: nowrap;
     padding-left: 4px;
+    color: var(--yxt-color-text-primary);
   }
 
   &-subtitle
@@ -205,13 +206,16 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
 
   &-address
   {
+    color: var(--yxt-color-text-primary);
+
     .c-AddressRow:last-child {
       display: none;
     }
   }
 
   &-phone
-  {
+  { 
+    color: var(--yxt-color-text-primary);
     display: flex;
     font-weight: var(--yxt-font-weight-semibold);
     margin-top: calc(var(--hh-location-standard-base-spacing) / 4);
@@ -242,8 +246,14 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
     margin-top: calc(var(--hh-location-standard-base-spacing) / 2);
   }
 
+  &-detailsText
+  {
+    color: var(--yxt-color-text-primary);
+  }
+
   &-hoursText
   {
+    color: var(--yxt-color-text-primary);
     margin-top: calc(var(--hh-location-standard-base-spacing) / 2);
   }
 
@@ -254,6 +264,7 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
 
   &-services
   {
+    color: var(--yxt-color-text-primary);
     flex-basis: 100%;
     margin-top: calc(var(--hh-location-standard-base-spacing) / 2);
   }

--- a/static/scss/answers/cards/menuitem-standard.scss
+++ b/static/scss/answers/cards/menuitem-standard.scss
@@ -61,6 +61,11 @@
     padding-bottom: calc(var(--yxt-base-spacing) / 2);
   }
 
+  &-listWrapper
+  {
+    color: var(--yxt-color-text-primary);
+  }
+
   &-content
   {
     margin-top: calc(var(--yxt-base-spacing) / 2);
@@ -69,6 +74,7 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-contentCtasWrapper

--- a/static/scss/answers/cards/product-prominentimage-clickable.scss
+++ b/static/scss/answers/cards/product-prominentimage-clickable.scss
@@ -113,5 +113,6 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 }

--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -95,6 +95,7 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-ctasWrapper

--- a/static/scss/answers/cards/product-prominentvideo.scss
+++ b/static/scss/answers/cards/product-prominentvideo.scss
@@ -61,6 +61,7 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-cardDetails

--- a/static/scss/answers/cards/product-standard.scss
+++ b/static/scss/answers/cards/product-standard.scss
@@ -66,7 +66,8 @@
 
   &-detailsText
   {
-    @include rich_text_formatting;
+    @include rich_text_formatting; 
+    color: var(--yxt-color-text-primary);
   }
 
   &-ctasWrapper

--- a/static/scss/answers/cards/professional-location.scss
+++ b/static/scss/answers/cards/professional-location.scss
@@ -103,7 +103,12 @@ $professional-location-ordinal-dimensions: 18px !default;
     margin-right: 0;
   }
 
-  &-address,
+  &-address
+  {
+    margin-top: calc(var(--hh-professional-location-spacing) / 2);
+    color: var(--yxt-color-text-primary);
+  }
+
   &-cardDetails
   {
     margin-top: calc(var(--hh-professional-location-spacing) / 2);
@@ -112,6 +117,7 @@ $professional-location-ordinal-dimensions: 18px !default;
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-listTitle
@@ -127,9 +133,15 @@ $professional-location-ordinal-dimensions: 18px !default;
     padding-left: calc(var(--hh-professional-location-spacing) / 2);
   }
 
+  &-listWrapper
+  {
+    color: var(--yxt-color-text-primary);
+  }
+
   &-phone
   {
     margin-top: calc(var(--hh-professional-location-spacing) / 2);
+    color: var(--yxt-color-text-primary);
   }
 
   &-phone--desktop {

--- a/static/scss/answers/cards/professional-standard.scss
+++ b/static/scss/answers/cards/professional-standard.scss
@@ -71,6 +71,7 @@ $professional-standard-spacing: var(--yxt-base-spacing) !default;
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-listTitle
@@ -86,9 +87,15 @@ $professional-standard-spacing: var(--yxt-base-spacing) !default;
     padding-left: calc(var(--hh-professional-standard-spacing) / 2);
   }
 
+  &-listWrapper
+  {
+    color: var(--yxt-color-text-primary);
+  }
+
   &-phone
   {
     margin-top: calc(var(--hh-professional-standard-spacing) / 2);
+    color: var(--yxt-color-text-primary);
   }
 
   &-phone--desktop {

--- a/static/scss/answers/cards/standard.scss
+++ b/static/scss/answers/cards/standard.scss
@@ -64,6 +64,7 @@
   &-detailsText
   {
     @include rich_text_formatting;
+    color: var(--yxt-color-text-primary);
   }
 
   &-ctasWrapper


### PR DESCRIPTION
Use the color-text-primary variable for the color of text on the body of cards

This change makes most text slightly lighter because the value of --yxt-color-text-primary is `#212121;`. Previously the cards were falling back to the default of the browser which is black.

J=SLAP-1617
TEST=manual

For testing purposes, set the text to red and view all of the cards of the test site. See that the color of the body of text is red as expected.