### PR TITLE
Comment out vertical icons

### DIFF
--- a/templates/vertical-full-page-map/page-config.json
+++ b/templates/vertical-full-page-map/page-config.json
@@ -66,7 +66,7 @@
       // "verticalLimit": 15, // The result count limit for vertical search
       // "universalLimit": 5, // The result count limit for universal search
       "cardType": "location-standard", // The name of the card to use - e.g. accordion, location, customcard 
-      "icon": "pin", // The icon to use on the card for this vertical
+      // "icon": "pin", // The icon to use on the card for this vertical
       "mapConfig": {
         //"enablePinClustering": true, // Cluster pins on the map that are close together. Defaults false
         "mapProvider": "MapBox", // The name of the provider (e.g. Mapbox, Google)

--- a/templates/vertical-grid/page-config.json
+++ b/templates/vertical-grid/page-config.json
@@ -66,7 +66,7 @@
     "<REPLACE ME>": { // The vertical key from your search configuration
       // "label": "", // The name of the vertical in the section header and the navigation bar
       "cardType": "product-prominentimage", // The name of the card to use - e.g. accordion, location, customcard 
-      "icon": "star", // The icon to use on the card for this vertical
+      // "icon": "star", // The icon to use on the card for this vertical
       "universalSectionTemplate": "standard"
     }
   }

--- a/templates/vertical-map/page-config.json
+++ b/templates/vertical-map/page-config.json
@@ -68,7 +68,7 @@
       // "verticalLimit": 15, // The result count limit for vertical search
       // "universalLimit": 5, // The result count limit for universal search
       "cardType": "location-standard", // The name of the card to use - e.g. accordion, location, customcard 
-      "icon": "pin", // The icon to use on the card for this vertical
+      // "icon": "pin", // The icon to use on the card for this vertical
       "mapConfig": {
         "mapProvider": "MapBox", // The name of the provider (e.g. Mapbox, Google)
         "pin": {

--- a/templates/vertical-standard/page-config.json
+++ b/templates/vertical-standard/page-config.json
@@ -68,7 +68,7 @@
       // "verticalLimit": 15, // The result count limit for vertical search
       // "universalLimit": 5, // The result count limit for universal search
       "cardType": "standard", // The name of the card to use - e.g. accordion, location, customcard 
-      "icon": "star", // The icon to use on the card for this vertical
+      // "icon": "star", // The icon to use on the card for this vertical
       "universalSectionTemplate": "standard"
     }
   }


### PR DESCRIPTION
Comment out vertical icons per the HH's request

With this change, Icons will no longer appear next to the names of verticals on the universal page by default

J=SLAP-1619
TEST=manual, visual

Build the local test site and see that icons are no longer there except for where a custom icon url is supplied