### PR TITLE
support sorting facets using optionsOrderList

### DIFF
--- a/static/js/transform-facets.js
+++ b/static/js/transform-facets.js
@@ -26,6 +26,7 @@ export default function transformFacets(facets, config) {
     const {
       fieldLabels,
       optionsOrder,
+      optionsOrderList,
       optionsFieldType = 'STRING',
       ...filterOptionsConfig
     } = config.fields[facet.fieldId];
@@ -41,7 +42,9 @@ export default function transformFacets(facets, config) {
       })
     }
 
-    if (optionsOrder) {
+    if (optionsOrderList) {
+      options = sortFacetOptionsCustom(options, optionsOrderList);
+    } else if (optionsOrder) {
       options = sortFacetOptions(options, optionsOrder, optionsFieldType, facet.fieldId);
     }
 
@@ -54,7 +57,7 @@ export default function transformFacets(facets, config) {
 }
 
 /**
- * Sorts the facet options in place.
+ * Sorts the facet options and returns a new array.
  * 
  * @param {{ displayName: string }[]} options The facet options to sort.
  * @param {'ASC' | 'DESC'} optionsOrder 
@@ -87,6 +90,26 @@ function sortFacetOptions(options, optionsOrder, optionsFieldType, fieldId) {
       return undefined;
     }
   }
-  
-  return options.sort(applyDirectionToComparator(getSortComparator()))
+
+  return [...options].sort(applyDirectionToComparator(getSortComparator()))
+}
+
+
+/**
+ * Sorts the facet options using the priority specified in
+ * the optionsOrderList and returns a new array.
+ * 
+ * @param {{ displayName: string }[]} options The facet options to sort.
+ * @param {string[] | number[]} optionsOrderList
+ * @returns {{ displayName: string }[]}
+ */
+function sortFacetOptionsCustom(options, optionsOrderList) {
+  const getPriority = displayName => {
+    const index = optionsOrderList.indexOf(displayName);
+    return index === -1 ? optionsOrderList.length : index;
+  }
+
+  return [...options].sort((a, b) => {
+    return getPriority(a.displayName) - getPriority(b.displayName);
+  });
 }

--- a/test-site/config-overrides/people.json
+++ b/test-site/config-overrides/people.json
@@ -19,6 +19,13 @@
             "Strategy": "STRATEGY !!!"
           },
           "optionsOrder": "DESC"
+        },
+        "languages": {
+          "optionsOrderList": [
+            "Italian",
+            "French",
+            "German"
+          ]
         }
       }
     },

--- a/tests/static/js/transform-facets.js
+++ b/tests/static/js/transform-facets.js
@@ -236,5 +236,30 @@ describe('optionsOrder', () => {
     expect(actualOptions[0].displayName).toEqual('100');
     expect(actualOptions[1].displayName).toEqual('3');
     expect(actualOptions[2].displayName).toEqual('2');
-  })
+  });
+});
+
+describe('sorting facets using optionsOrderList', () => {
+  const displayNames = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+  const facets = [
+    {
+      fieldId: 'c_mealType',
+      options: displayNames.map(d => ({ displayName: d }))
+    }
+  ];
+
+  function createFacetsConfig(optionsOrderList) {
+    return {
+      fields: {
+        c_mealType: {
+          optionsOrderList
+        }
+      }
+    }
+  };
+
+  it('will assign priority based on the optionsOrderList', () => {
+    const actualOptions = transformFacets(facets, createFacetsConfig(['e', 'g']))[0].options;
+    expect(actualOptions.map(o => o.displayName)).toEqual(['e', 'g', 'a', 'b', 'c', 'd', 'f'])
+  });
 });


### PR DESCRIPTION
I changed the sorting to not mutate the original array.
Originally I was worried about performance, but it should be very minor.

J=SLAP-1632
TEST=manual,auto

added optionsOrderList to the people page's config override for percy snapshots
manually built the page and saw the facets being sorted