### PR TITLE
remove optionsFieldType

### DIFF
--- a/static/js/transform-facets.js
+++ b/static/js/transform-facets.js
@@ -27,7 +27,6 @@ export default function transformFacets(facets, config) {
       fieldLabels,
       optionsOrder,
       optionsOrderList,
-      optionsFieldType = 'STRING',
       ...filterOptionsConfig
     } = config.fields[facet.fieldId];
 
@@ -45,7 +44,7 @@ export default function transformFacets(facets, config) {
     if (optionsOrderList) {
       options = sortFacetOptionsCustom(options, optionsOrderList);
     } else if (optionsOrder) {
-      options = sortFacetOptions(options, optionsOrder, optionsFieldType, facet.fieldId);
+      options = sortFacetOptions(options, optionsOrder, facet.fieldId);
     }
 
     return {
@@ -61,37 +60,21 @@ export default function transformFacets(facets, config) {
  * 
  * @param {{ displayName: string }[]} options The facet options to sort.
  * @param {'ASC' | 'DESC'} optionsOrder 
- * @param {'STRING' | 'INT'} optionsFieldType 
  * @param {string} fieldId 
  * @returns {{ displayName: string }[]}
  */
-function sortFacetOptions(options, optionsOrder, optionsFieldType, fieldId) {
+function sortFacetOptions(options, optionsOrder, fieldId) {
   const getSortComparator = () => {
-    if (optionsFieldType === 'STRING') {
-      return (a, b) => a.displayName.localeCompare(b.displayName);
-    } else if (optionsFieldType === 'INT') {
-      return (a, b) => parseInt(a.displayName) - parseInt(b.displayName);
-    } else {
-      console.error(`Unknown facet optionsFieldType "${optionsFieldType}" for the "${fieldId}" facet.`);
-      return undefined;
-    }
-  }
-  const applyDirectionToComparator = (comparator) => {
-    if (!comparator) {
-      return undefined;
-    }
-
     if (optionsOrder === 'ASC') {
-      return comparator;
+      return (a, b) => a.displayName.localeCompare(b.displayName);
     } else if (optionsOrder === 'DESC') {
-      return (a, b) => -1 * comparator(a, b)
+      return (a, b) => b.displayName.localeCompare(a.displayName);
     } else {
       console.error(`Unknown facet optionsOrder "${optionsOrder}" for the "${fieldId}" facet.`);
       return undefined;
     }
   }
-
-  return [...options].sort(applyDirectionToComparator(getSortComparator()))
+  return [...options].sort(getSortComparator())
 }
 
 

--- a/tests/static/js/transform-facets.js
+++ b/tests/static/js/transform-facets.js
@@ -146,7 +146,7 @@ describe('optionsOrder', () => {
     }
   ];
 
-  function createFacetsConfig(optionsOrder, optionsFieldType, fieldLabels) {
+  function createFacetsConfig(optionsOrder, fieldLabels) {
     return {
       fields: {
         c_mealType: {
@@ -155,7 +155,6 @@ describe('optionsOrder', () => {
             Lunch: 'a lunch',
             Dinner: 'duh dinner'
           },
-          optionsFieldType: optionsFieldType || 'STRING',
           optionsOrder
         }
       }
@@ -167,14 +166,14 @@ describe('optionsOrder', () => {
     expect(actualOptions[0].displayName).toEqual('a lunch');
     expect(actualOptions[1].displayName).toEqual('duh dinner');
     expect(actualOptions[2].displayName).toEqual('ze breakfast');
-  })
+  });
 
   it('works for DESC order', () => {
     const actualOptions = transformFacets(facets, createFacetsConfig('DESC'))[0].options;
     expect(actualOptions[0].displayName).toEqual('ze breakfast');
     expect(actualOptions[1].displayName).toEqual('duh dinner');
     expect(actualOptions[2].displayName).toEqual('a lunch');
-  })
+  });
 
   it('logs an error if you use an unknown optionsOrder', () => {
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -183,59 +182,6 @@ describe('optionsOrder', () => {
     expect(consoleError).toHaveBeenCalledWith(
       'Unknown facet optionsOrder "PACER" for the "c_mealType" facet.');
     consoleError.mockRestore();
-  })
-
-  it('logs an error if you use an unknown optionsFieldType, and does not try to sort', () => {
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-    expect(consoleError).toHaveBeenCalledTimes(0);
-    transformFacets(facets, createFacetsConfig('ASC', 'FAKEINT'))[0].options;
-    expect(consoleError).toHaveBeenCalledWith(
-      'Unknown facet optionsFieldType "FAKEINT" for the "c_mealType" facet.');
-    consoleError.mockRestore();
-  })
-
-  it('works with ASC number display names', () => {
-    const actualOptions = transformFacets(facets, createFacetsConfig('ASC', 'INT', {
-      Breakfast: 3,
-      Lunch: 2,
-      Dinner: 100
-    }))[0].options;
-    expect(actualOptions[0].displayName).toEqual(2);
-    expect(actualOptions[1].displayName).toEqual(3);
-    expect(actualOptions[2].displayName).toEqual(100);
-  })
-
-  it('works with DESC number display names', () => {
-    const actualOptions = transformFacets(facets, createFacetsConfig('DESC', 'INT', {
-      Breakfast: 2,
-      Lunch: 3,
-      Dinner: 100
-    }))[0].options;
-    expect(actualOptions[0].displayName).toEqual(100);
-    expect(actualOptions[1].displayName).toEqual(3);
-    expect(actualOptions[2].displayName).toEqual(2);
-  })
-
-  it('works with ASC number display names that need to be parsed', () => {
-    const actualOptions = transformFacets(facets, createFacetsConfig('ASC', 'INT', {
-      Breakfast: '3',
-      Lunch: '2',
-      Dinner: '100'
-    }))[0].options;
-    expect(actualOptions[0].displayName).toEqual('2');
-    expect(actualOptions[1].displayName).toEqual('3');
-    expect(actualOptions[2].displayName).toEqual('100');
-  })
-
-  it('works with DESC number display names that need to be parsed', () => {
-    const actualOptions = transformFacets(facets, createFacetsConfig('DESC', 'INT', {
-      Breakfast: '2',
-      Lunch: '3',
-      Dinner: '100'
-    }))[0].options;
-    expect(actualOptions[0].displayName).toEqual('100');
-    expect(actualOptions[1].displayName).toEqual('3');
-    expect(actualOptions[2].displayName).toEqual('2');
   });
 });
 


### PR DESCRIPTION
The backend does not natively support facets on number fields.
This PR removes support for interpreting string fields as numbers.

J=SLAP-1631
TEST=manual

rebuilt page and checked optionsOrder and optionsOrderList facets