### PR TITLE
Fix DA cards feedback analytics

### DIFF
--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -14,7 +14,9 @@
     {{> cta CTA linkTarget=linkTarget}}
   </div>
   {{/if}}
-  {{> footer }}
+  {{#if feedbackEnabled}}
+    {{> footer }}
+  {{/if}}
 </div>
 
 {{#*inline 'icon'}}

--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -26,6 +26,7 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
 
     return super.setState({
       ...cardData,
+      feedbackEnabled: ANSWERS.getAnalyticsOptIn(),
       feedbackSubmitted: data.feedbackSubmitted,
       isArray: Array.isArray(this.answer.value),
       cardName: `{{componentName}}`,

--- a/directanswercards/documentsearch-standard/template.hbs
+++ b/directanswercards/documentsearch-standard/template.hbs
@@ -9,7 +9,9 @@
       {{> cta CTA linkTarget=linkTarget}}
     </div>
   </div>
-  {{> footer}}
+  {{#if feedbackEnabled}}
+    {{> footer }}
+  {{/if}}
 </div>
 
 {{#*inline 'title'}}

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -14,7 +14,9 @@
     {{> cta CTA linkTarget=linkTarget}}
   </div>
   {{/if}}
-  {{> footer }}
+  {{#if feedbackEnabled}}
+    {{> footer }}
+  {{/if}}
 </div>
 
 {{#*inline 'icon'}}

--- a/global_config.json
+++ b/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "develop", // The version of the Answers SDK to use
+  "sdkVersion": "release/v1.11", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "develop", // The version of the Answers SDK to use
+  "sdkVersion": "release/v1.11", // The version of the Answers SDK to use
   "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system


### PR DESCRIPTION
Only show thumbs up/down feedback buttons on direct answer cards when user provides `businessId` and enables analytics.

J=SLAP-1175
TEST=manual

Smoke testing to check if feedback buttons only appear on DA cards when expected.