### PR TITLE
Revert 'Fix google maps InvalidValueError in theme'

### DIFF
--- a/templates/universal-standard/script/map-pin.hbs
+++ b/templates/universal-standard/script/map-pin.hbs
@@ -32,7 +32,7 @@
   if (mapProvider === 'google') {
     config.svg = svg;
     {{!-- Don't use the sdk's built-in label for GoogleMapProvider --}}
-    config.label = '';
+    config.label = {};
     config.scaledSize = {
       w: pinStyling.width,
       h: pinStyling.height,

--- a/templates/vertical-map/script/map-pin.hbs
+++ b/templates/vertical-map/script/map-pin.hbs
@@ -32,7 +32,7 @@
   if (mapProvider === 'google') {
     config.svg = svg;
     {{!-- Don't use the sdk's built-in label for GoogleMapProvider --}}
-    config.label = '';
+    config.label = {};
     config.scaledSize = {
       w: pinStyling.width,
       h: pinStyling.height,


### PR DESCRIPTION
Reverts  #955 because the necessary corresponding [PR in the SDK](https://github.com/yext/answers-search-ui/pull/1548) didn't make it into v1.11

J=none
TEST=manual

Build the test site with the new v1.11 SDK and see that the icons now look correct