### PR TITLE
Use window.iframeLoaded promise

### DIFF
--- a/script/core.hbs
+++ b/script/core.hbs
@@ -38,12 +38,12 @@
       ...token && { apiKey: token },
       querySource: window.isOverlay ? 'OVERLAY' : 'STANDARD',
       onStateChange: (objParams, stringParams, replaceHistory) => {
-        if ('parentIFrame' in window) {
+        window.iframeLoaded.then(() => {
           parentIFrame.sendMessage(JSON.stringify({
             params: iframeGetSearchParams(),
             replaceHistory: replaceHistory
           }));
-        }
+        });
       },
       ...{{> script/additional-answers-config }},
       onReady: () => {

--- a/static/js/overlay/answers-frame/controllers/messagedirector.js
+++ b/static/js/overlay/answers-frame/controllers/messagedirector.js
@@ -73,6 +73,8 @@ export default class MessageDirector {
    * @param {IFrameMessage} message
    */
   _notifyParentFrame(message) {
-    window.parentIFrame && window.parentIFrame.sendMessage(message.toObject());
+    window.iframeLoaded.then(() => {
+      window.parentIFrame.sendMessage(message.toObject());
+    });
   }
 }

--- a/static/js/overlay/answers-frame/controllers/messagedirector.js
+++ b/static/js/overlay/answers-frame/controllers/messagedirector.js
@@ -73,8 +73,6 @@ export default class MessageDirector {
    * @param {IFrameMessage} message
    */
   _notifyParentFrame(message) {
-    window.iframeLoaded.then(() => {
-      window.parentIFrame.sendMessage(message.toObject());
-    });
+    window.parentIFrame && window.parentIFrame.sendMessage(message.toObject());
   }
 }

--- a/templates/common-partials/script/pagination.hbs
+++ b/templates/common-partials/script/pagination.hbs
@@ -1,14 +1,12 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0; // Safari
+
     window.iframeLoaded.then(() => {
-      if (window.parentIFrame) {
-        const paginateMessage = { action: 'paginate' };
-        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-      } else {
-        document.documentElement.scrollTop = 0;
-        document.body.scrollTop = 0; // Safari
-      }
+      const paginateMessage = { action: 'paginate' };
+      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
     });
   },
   {{#if verticalKey}}

--- a/templates/common-partials/script/pagination.hbs
+++ b/templates/common-partials/script/pagination.hbs
@@ -1,13 +1,15 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
-    if (window.parentIFrame) {
-      const paginateMessage = { action: 'paginate' };
-      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-    } else {
-      document.documentElement.scrollTop = 0;
-      document.body.scrollTop = 0; // Safari
-    }
+    window.iframeLoaded.then(() => {
+      if (window.parentIFrame) {
+        const paginateMessage = { action: 'paginate' };
+        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
+      } else {
+        document.documentElement.scrollTop = 0;
+        document.body.scrollTop = 0; // Safari
+      }
+    });
   },
   {{#if verticalKey}}
     verticalKey: "{{{verticalKey}}}",

--- a/templates/vertical-full-page-map/script/pagination.hbs
+++ b/templates/vertical-full-page-map/script/pagination.hbs
@@ -1,15 +1,14 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0; // Safari
+
     window.iframeLoaded.then(() => {
-      if (window.parentIFrame) {
-        const paginateMessage = { action: 'paginate' };
-        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-      } else {
-        document.documentElement.scrollTop = 0;
-        document.body.scrollTop = 0; // Safari
-      }
+      const paginateMessage = { action: 'paginate' };
+      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
     });
+
     const resultsColumn = document.querySelector(".js-locator-resultsWrapper");
     if (resultsColumn) {
       resultsColumn.scrollTop = 0;

--- a/templates/vertical-full-page-map/script/pagination.hbs
+++ b/templates/vertical-full-page-map/script/pagination.hbs
@@ -1,13 +1,15 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
-    if (window.parentIFrame) {
-      const paginateMessage = { action: 'paginate' };
-      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-    } else {
-      document.documentElement.scrollTop = 0;
-      document.body.scrollTop = 0; // Safari
-    }
+    window.iframeLoaded.then(() => {
+      if (window.parentIFrame) {
+        const paginateMessage = { action: 'paginate' };
+        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
+      } else {
+        document.documentElement.scrollTop = 0;
+        document.body.scrollTop = 0; // Safari
+      }
+    });
     const resultsColumn = document.querySelector(".js-locator-resultsWrapper");
     if (resultsColumn) {
       resultsColumn.scrollTop = 0;

--- a/templates/vertical-map/script/pagination.hbs
+++ b/templates/vertical-map/script/pagination.hbs
@@ -1,13 +1,15 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
-    if (window.parentIFrame) {
-      const paginateMessage = { action: 'paginate' };
-      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-    } else {
-      document.documentElement.scrollTop = 0;
-      document.body.scrollTop = 0; // Safari
-    }
+    window.iframeLoaded.then(() => {
+      if (window.parentIFrame) {
+        const paginateMessage = { action: 'paginate' };
+        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
+      } else {
+        document.documentElement.scrollTop = 0;
+        document.body.scrollTop = 0; // Safari
+      }
+    });
     const resultsColumn = document.querySelector(".Answers-resultsColumn");
     resultsColumn.scrollTop = 0;
   },

--- a/templates/vertical-map/script/pagination.hbs
+++ b/templates/vertical-map/script/pagination.hbs
@@ -1,15 +1,14 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0; // Safari
+
     window.iframeLoaded.then(() => {
-      if (window.parentIFrame) {
-        const paginateMessage = { action: 'paginate' };
-        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-      } else {
-        document.documentElement.scrollTop = 0;
-        document.body.scrollTop = 0; // Safari
-      }
+      const paginateMessage = { action: 'paginate' };
+      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
     });
+    
     const resultsColumn = document.querySelector(".Answers-resultsColumn");
     resultsColumn.scrollTop = 0;
   },

--- a/tests/templates/script/fixtures/pagination.hbs.js
+++ b/tests/templates/script/fixtures/pagination.hbs.js
@@ -1,14 +1,12 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0; // Safari
+
     window.iframeLoaded.then(() => {
-      if (window.parentIFrame) {
-        const paginateMessage = { action: 'paginate' };
-        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-      } else {
-        document.documentElement.scrollTop = 0;
-        document.body.scrollTop = 0; // Safari
-      }
+      const paginateMessage = { action: 'paginate' };
+      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
     });
   },
     verticalKey: "testKey",

--- a/tests/templates/script/fixtures/pagination.hbs.js
+++ b/tests/templates/script/fixtures/pagination.hbs.js
@@ -1,13 +1,15 @@
 ANSWERS.addComponent("Pagination", Object.assign({}, {
   container: "#js-answersPagination",
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {
-    if (window.parentIFrame) {
-      const paginateMessage = { action: 'paginate' };
-      window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
-    } else {
-      document.documentElement.scrollTop = 0;
-      document.body.scrollTop = 0; // Safari
-    }
+    window.iframeLoaded.then(() => {
+      if (window.parentIFrame) {
+        const paginateMessage = { action: 'paginate' };
+        window.parentIFrame.sendMessage(JSON.stringify(paginateMessage));
+      } else {
+        document.documentElement.scrollTop = 0;
+        document.body.scrollTop = 0; // Safari
+      }
+    });
   },
     verticalKey: "testKey",
 }, {}));


### PR DESCRIPTION
Update iframe checks to use window.iframeLoaded promise. This is to avoid possible race conditions with the iframe (e.g. if the SDK adds the pagination component before iframe-resizer is spun up).

J=SLAP-1102
TEST=manual

Check default and iframe pages in test-site to make sure pagination scrolling works as expected for vertical map templates.