### PR TITLE
Fix double query on load from within iframe integrations

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -157,6 +157,11 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
      * @type {Object}
      */
     this.alternativeVerticalsConfig = config.alternativeVerticalsConfig;
+
+    /**
+     * Indicates whether or not the map has moved from its initial position
+     */
+    this.hasMapMoved = false;
   }
 
   onCreate () {
@@ -373,6 +378,15 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
    * Search the area or show the search the area button according to configurable logic
    */
   handleMapCenterChange () {
+    const isIframe = 'parentIFrame' in window;
+    const hasMapMoved = this.hasMapMoved;
+    this.hasMapMoved = true;
+    // Ignore the first map move within an iframe because it is triggered by the iframe
+    // resizer and not by the user
+    if (!hasMapMoved && isIframe) {
+      return;
+    }
+
     if (!this.searchOnMapMove) {
       this._container.classList.add('VerticalFullPageMap--showSearchThisArea');
       return;

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -159,9 +159,9 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     this.alternativeVerticalsConfig = config.alternativeVerticalsConfig;
 
     /**
-     * Indicates whether or not the map has moved from its initial position
+     * Indicates whether or not the handleMapCenterChangefunction has been invoked
      */
-    this.hasMapMoved = false;
+    this.isFirstMapCenterChangeInvocation = true;
   }
 
   onCreate () {
@@ -379,11 +379,11 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
    */
   handleMapCenterChange () {
     const isIframe = 'parentIFrame' in window;
-    const hasMapMoved = this.hasMapMoved;
-    this.hasMapMoved = true;
-    // Ignore the first map move within an iframe because it is triggered by the iframe
+    const isFirstMapCenterChangeInvocation = this.isFirstMapCenterChangeInvocation;
+    this.isFirstMapCenterChangeInvocation = false;
+    // Ignore the first invocation of this function within an iframe because it is triggered by the iframe
     // resizer and not by the user
-    if (!hasMapMoved && isIframe) {
+    if (isFirstMapCenterChangeInvocation && isIframe) {
       return;
     }
 


### PR DESCRIPTION
Fix double query on load from iframe integrations

When the full-page-map loads within an iframed experience, the iframe resizer resizes the page which leads to an additional query being fired on map load because it triggers the searchOnMapMove. Disabling `searchOnMapMove` would prevent the double query from firing, however it would cause the 'Search this area' button to appear which isn't supposed to happen until the map is moved by the user. 

By ignoring the first map change invocation from within iframe experiences, we can eliminate the issues described above.

J=SLAP-1633
TEST=manual

Load the vertical full page map from within an iframe and confirm from the network tab that only a single query is fired on page load. Test that when `disableSearchOnMapMove` is true, the 'Search This Area' button doesn't pop up until the user moves the map. Also test the pages with standard non-iframe integrations and check that the functionality is the same.