### PR TITLE
add vertical command: handle page and template names with spaces

### DIFF
--- a/commands/addvertical.js
+++ b/commands/addvertical.js
@@ -185,6 +185,13 @@ class VerticalAdder {
    * @param {Object} args The command parameters.
    */
   _validateArgs(args) {
+    function throwIfQuotesFound(argName) {
+      if (args[argName].includes(`'`) || args[argName].includes(`"`)) {
+        throw new UserError(`Quotes are not allowed for the "${argName}" argument.`);
+      }
+    }
+    throwIfQuotesFound('name');
+    throwIfQuotesFound('verticalKey');
     if (args.template === 'universal-standard') {
       throw new UserError('A vertical cannot be initialized with the universal template');
     }
@@ -256,7 +263,7 @@ class VerticalAdder {
    * @param {Array<string>} locales The additional locales to generate the page for.
    */
   _createVerticalPage(name, template, locales) {
-    const args = ['--name', name, '--template', template];
+    const args = ['--name', `'${name}'`, '--template', `'${template}'`];
 
     if (locales.length) {
       args.push('--locales', locales.join(' '));


### PR DESCRIPTION
When calling spawn sync, in order for an argument with a space in it to be
recognized as a single argument, it must be wrapped in quotes. Otherwise, the
later parts of the argument will be considered unknown arguments.
For example, if I run

`npx jambo [COMMAND] --name Blog Article`

the "Article" part of Blog Article will be considered a separate argument from
--name=Blog. Instead, it needs to be

`npx jambo [COMMAND] --name 'Blog Article'`

(double quotes also work, and our case doesn't care about the nuances between them)
I also added an error message if a user tries to use a verticalKey or page name that contains
a quote. This was not working previously, I wouldn't want it to be ambiguous as to whether this was
ever supported.

J=TECHOPS-2502
TEST=manual

test adding a vertical, with and without a space
verify that the arguments passed to the add vertical command in CBD through the SGS UI is
the same as the way I tested locally
test the error message