### PR TITLE
Update styling for items in More tab

### DIFF
--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -67,14 +67,17 @@
         padding-left: var(--yxt-base-spacing);
         padding-right: var(--yxt-base-spacing);
         padding-bottom: calc(var(--yxt-base-spacing) * 0.2);
-        padding-top: calc(var(--yxt-base-spacing) * 0.5);
-        line-height: var(--yxt-base-spacing);
-        word-break: break-word;
         letter-spacing: 1.1px;
       }
 
       .yxt-Nav-item.is-active {
         border-bottom-width: .185rem;
+      }
+
+      .yxt-Nav-modal .yxt-Nav-item {
+        padding-top: calc(var(--yxt-base-spacing) * 0.5);
+        line-height: var(--yxt-base-spacing);
+        word-break: break-word;
       }
     }
   }

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -75,9 +75,12 @@
       }
 
       .yxt-Nav-modal .yxt-Nav-item {
-        padding-top: calc(var(--yxt-base-spacing) * 0.5);
         line-height: var(--yxt-base-spacing);
         word-break: break-word;
+      }
+
+      .yxt-Nav-modal li + li .yxt-Nav-item{
+        padding-top: calc(var(--yxt-base-spacing) * 0.5);
       }
     }
   }

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -67,6 +67,9 @@
         padding-left: var(--yxt-base-spacing);
         padding-right: var(--yxt-base-spacing);
         padding-bottom: calc(var(--yxt-base-spacing) * 0.2);
+        padding-top: calc(var(--yxt-base-spacing) * .5);
+        line-height: var(--yxt-base-spacing);
+        word-break: break-word;
         letter-spacing: 1.1px;
       }
 

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -67,7 +67,7 @@
         padding-left: var(--yxt-base-spacing);
         padding-right: var(--yxt-base-spacing);
         padding-bottom: calc(var(--yxt-base-spacing) * 0.2);
-        padding-top: calc(var(--yxt-base-spacing) * .5);
+        padding-top: calc(var(--yxt-base-spacing) * 0.5);
         line-height: var(--yxt-base-spacing);
         word-break: break-word;
         letter-spacing: 1.1px;


### PR DESCRIPTION
Update padding, line-height, and word break of navigation items in the 'More' tab. The padding should not apply to the first item in the list.

J=SLAP-1662
TEST=manual

Check that styling changes are present and the break occurs correctly with multiple word items.