### PR TITLE
Add null check for url formatter

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -611,7 +611,7 @@ export function getYoutubeUrl(videos = []) {
  * @returns a URL with text fragment URI component attached
  */
 export function getUrlWithTextHighlight(snippet, baseUrl) {
-  if (!isChrome() || !snippet || snippet.matchedSubstrings.length === 0) {
+  if (!isChrome() || !snippet || snippet.matchedSubstrings.length === 0 || !baseUrl) {
     return baseUrl;
   }
   //Find the surrounding sentence of the snippet

--- a/tests/static/js/formatters.js
+++ b/tests/static/js/formatters.js
@@ -232,6 +232,20 @@ describe('Formatters', () => {
     const isChrome = jest.spyOn(useragent, 'isChrome');
     isChrome.mockReturnValue(true);
 
+    it('Behaves correctly when baseUrl is not defined', () => {
+      const snippet = {
+        value: 'this is a sentence, for testing purposes.',
+        matchedSubstrings: [
+          {
+            offset: 5, 
+            length: 10 
+          }
+        ]
+      };
+      const actual = Formatters.getUrlWithTextHighlight(snippet, undefined);
+      expect(actual).toBeUndefined();
+    });
+    
     it('Behaves correctly when there is no matchedSubstring', () => {
       const snippet = {
         value: 'this is a sentence, for testing purposes.',


### PR DESCRIPTION
Add a check for a null `baseUrl` passed to the `getUrlWithTextHighlight` formatter. Without this check, document search direct answer cards would display links that didn't exist.

J=SLAP-1667
TEST=auto, manual

Check that jest tests pass and that there is no 'read more' link shown at the bottom of document search cards if the baseUrl is null or undefined.