### PR TITLE
fix custom search icon size

### DIFF
--- a/static/scss/answers/legacy-aeb/lanswers-overrides.scss
+++ b/static/scss/answers/legacy-aeb/lanswers-overrides.scss
@@ -1,14 +1,6 @@
 .yxt-SearchBar
 {
   margin-bottom: 0;
-
-  &-buttonImage
-  {
-    svg
-    {
-      font-size: 24px;
-    }
-  }
 }
 
 .yxt-NoResults

--- a/test-site/config-overrides/faqs.json
+++ b/test-site/config-overrides/faqs.json
@@ -1,6 +1,9 @@
 {
   "pageTitle": "FAQ Search",
   "componentSettings": {
+    "SearchBar": {
+      "submitIcon": "magnifying_glass"
+    },
     "QASubmission": {
       "entityId": "12345",
       "privacyPolicyUrl": ""

--- a/test-site/config-overrides/people.ar.json
+++ b/test-site/config-overrides/people.ar.json
@@ -1,7 +1,18 @@
 {
   "componentSettings": {
     "SearchBar": {
-      "customIconUrl": "../static/assets/ayaya.png"
+      "customIconUrl": "../static/assets/ayaya.png",
+      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
+      "loadingIndicator": {
+        "display": true //Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+      },
+      "voiceSearch": {
+        "enabled": false // Whether or not voice search is enabled
+        // "customMicIconUrl": "", // Path to override the voice start icon
+        // "customListeningIconUrl": "" // Path to override the voice stop icon
+      }
     },
     "Facets": {
       "expand": false,

--- a/test-site/config-overrides/people.ar.json
+++ b/test-site/config-overrides/people.ar.json
@@ -2,7 +2,7 @@
   "componentSettings": {
     "SearchBar": {
       "customIconUrl": "../static/assets/ayaya.png",
-      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "placeholderText": "بحث", // The placeholder text in the answers search bar
       "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
       "loadingIndicator": {
         "display": true //Optional, whether to include a loading indicator on seachbar

--- a/test-site/config-overrides/people.ar.json
+++ b/test-site/config-overrides/people.ar.json
@@ -22,15 +22,6 @@
         "displayAllResults": true
       },
       "hideResultsHeader": true
-    },
-  },
-  "verticalsToConfig": {
-    "people": { // The vertical key from your search configuration
-      // "label": "", // The name of the vertical in the section header and the navigation bar
-      "cardType": "multilang-standard", // The name of the card to use - e.g. accordion, location, customcard
-      "icon": "star", // The icon to use on the card for this vertical
-      "universalSectionTemplate": "standard",
-      "label": "Personas"
     }
   }
 }

--- a/test-site/config-overrides/people.es.json
+++ b/test-site/config-overrides/people.es.json
@@ -1,7 +1,18 @@
 {
   "componentSettings": {
     "SearchBar": {
-      "customIconUrl": "../static/assets/ayaya.png"
+      "customIconUrl": "../static/assets/ayaya.png",
+      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
+      "loadingIndicator": {
+        "display": true //Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+      },
+      "voiceSearch": {
+        "enabled": false // Whether or not voice search is enabled
+        // "customMicIconUrl": "", // Path to override the voice start icon
+        // "customListeningIconUrl": "" // Path to override the voice stop icon
+      }
     },
     "Facets": {
       "expand": false,

--- a/test-site/config-overrides/people.es.json
+++ b/test-site/config-overrides/people.es.json
@@ -2,7 +2,7 @@
   "componentSettings": {
     "SearchBar": {
       "customIconUrl": "../static/assets/ayaya.png",
-      "placeholderText": "Search", // The placeholder text in the answers search bar
+      "placeholderText": "Buscar", // The placeholder text in the answers search bar
       "allowEmptySearch": true, // Allows users to submit an empty search in the searchbar
       "loadingIndicator": {
         "display": true //Optional, whether to include a loading indicator on seachbar

--- a/test-site/config-overrides/people.es.json
+++ b/test-site/config-overrides/people.es.json
@@ -1,4 +1,29 @@
 {
+  "componentSettings": {
+    "SearchBar": {
+      "customIconUrl": "../static/assets/ayaya.png"
+    },
+    "Facets": {
+      "expand": false,
+      "showMore": false,
+      "searchOnChange": true
+    },
+    "SortOptions": {
+      "options": [{
+        "type": "RELEVANCE",
+        "label": "Relevance"
+      }]
+    },
+    "AppliedFilters": {
+      "removable": true
+    },
+    "VerticalResults": {
+      "noResults": {
+        "displayAllResults": true // Optional, whether to display all results in the vertical when no results are found.
+      },
+      "hideResultsHeader": true
+    },
+  },
   "verticalsToConfig": {
     "people": { // The vertical key from your search configuration
       // "label": "", // The name of the vertical in the section header and the navigation bar

--- a/test-site/config-overrides/people.json
+++ b/test-site/config-overrides/people.json
@@ -1,6 +1,9 @@
 {
   "pageTitle": "People",
   "componentSettings": {
+    "SearchBar": {
+      "customIconUrl": "static/assets/ayaya.png"
+    },
     "Facets": {
       "expand": false,
       "showMore": false,

--- a/test-site/scripts/create-verticals.js
+++ b/test-site/scripts/create-verticals.js
@@ -104,4 +104,6 @@ Object.entries(verticalConfiguration).forEach(([pageName, config]) => {
   pagePatcher.applyPatchToPage(pageName);
   configMerger.mergeConfigForPage(pageName + '.es');
   pagePatcher.applyPatchToPage(pageName + '.es');
+  configMerger.mergeConfigForPage(pageName + '.ar');
+  pagePatcher.applyPatchToPage(pageName + '.ar');
 });


### PR DESCRIPTION
fix custom search icon size

Removes custom aeb styling that was causing search icons to be too large.

J=SLAP-1654
TEST=manual,auto

tweaked the snapshot config to test these
saw no issues with a custom submitIcon or customIconUrl
loading indicator worked as expected