### PR TITLE
add --pageNames arg to setup-test-site npm script

### DIFF
--- a/test-site/scripts/create-verticals.js
+++ b/test-site/scripts/create-verticals.js
@@ -3,6 +3,11 @@ const process = require('process');
 const path = require('path');
 const ConfigMerger = require('./config-merger');
 const PagePatcher = require('./page-patcher');
+const yargs = require('yargs')
+
+const argv = yargs
+  .option('pageNames', { type: 'array' })
+  .parse();
 
 const verticalConfiguration = {
   events: {
@@ -94,6 +99,9 @@ const testSiteDir = path.resolve(__dirname, '..');
 process.chdir(testSiteDir);
 
 Object.entries(verticalConfiguration).forEach(([pageName, config]) => {
+  if (argv.pageNames && !argv.pageNames.includes(pageName)) {
+    return;
+  }
   let verticalCommand =
     `npx jambo vertical --name ${pageName} --verticalKey ${config.verticalKey} --template ${config.template} --locales es ar`
   if (config.cardName) {

--- a/test-site/scripts/setup.sh
+++ b/test-site/scripts/setup.sh
@@ -29,4 +29,9 @@ copy_static_files_into_working_dir
 npm i
 cleanup_custom_cards
 create_custom_cards
-node scripts/create-verticals.js
+
+# Clear out preexisting pages/config
+find pages ! -name index.* -type f -delete
+find config ! \( -name index.* -o -name locale_config.json -o -name global_config.json \) -type f -delete
+
+node scripts/create-verticals.js $@


### PR DESCRIPTION
It can take a long time to build up the full test-site, so I added
"pageNames" arg that let you specify a subset of pages to build.
The pages and config dirs are also now cleared when you rerun the command.

J=SLAP-1677
TEST=manual

tested building a subset of pages with `npm run setup-test-site -- --pageNames people faqs`
tested an arg-less `npm run setup-test-site`