### PR TITLE
set default cta linkType to URL

### DIFF
--- a/static/js/formatters/generate-cta-field-type-link.js
+++ b/static/js/formatters/generate-cta-field-type-link.js
@@ -10,7 +10,7 @@ export function generateCTAFieldTypeLink(cta) {
   }
   const normalizedCTA = {
     ...cta,
-    linkType: normalizeCtaLinkType(cta.linkType)
+    linkType: normalizeCtaLinkType(cta.linkType || 'URL')
   }
   return CtaFormatter.generateCTAFieldTypeLink(normalizedCTA);
 }

--- a/static/js/formatters/generate-cta-field-type-link.js
+++ b/static/js/formatters/generate-cta-field-type-link.js
@@ -1,6 +1,9 @@
 import CtaFormatter from '@yext/cta-formatter';
 
 /**
+ * By default, the linkType is assumed to be 'URL', which does not apply additional formatting, as opposed
+ * to the "Phone" and "Email" linkTypes.
+ * 
  * @param {{link: string, linkType: string}} cta the Calls To Action field object
  * @returns {string} The formatted url associated with the Call to Action object if the cta object exists, null otherwise
  */

--- a/tests/static/js/formatters-internal/generate-cta-field-type-link.js
+++ b/tests/static/js/formatters-internal/generate-cta-field-type-link.js
@@ -26,3 +26,10 @@ describe('generateCtaFieldTypeLinks can handle translated link types', () => {
     expect(generateCTAFieldTypeLink(cta)).toEqual('slap');
   });
 });
+
+it('works with no linkType set', () => {
+  const cta = {
+    link: 'slap'
+  }
+  expect(generateCTAFieldTypeLink(cta)).toEqual('slap');
+})


### PR DESCRIPTION
The API is allowed to send an undefined cta linkType. Setting
the default to URL effectively grabs the link with no extra
formatting.

J=SLAP-1655
TEST=auto