### PR TITLE
Update image formatter to use dynamic thumbnailer

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -313,8 +313,8 @@ export function image(simpleOrComplexImage = {}, desiredSize = '200x', atLeastAs
   let desiredWidth, desiredHeight;
   let desiredDims = desiredSize.split('x');
 
-  const [urlWithoutExtension, extension] = _splitUrlOnIndex(image.url, image.url.lastIndexOf('.'));
-  const [urlBeforeDimensions, dimensions] = _splitUrlOnIndex(urlWithoutExtension, urlWithoutExtension.lastIndexOf('/') + 1);
+  const [urlWithoutExtension, extension] = _splitStringOnIndex(image.url, image.url.lastIndexOf('.'));
+  const [urlBeforeDimensions, dimensions] = _splitStringOnIndex(urlWithoutExtension, urlWithoutExtension.lastIndexOf('/') + 1);
   const fullSizeDims = dimensions.split('x');
 
   if (desiredDims[0] !== '') {
@@ -351,14 +351,14 @@ export function image(simpleOrComplexImage = {}, desiredSize = '200x', atLeastAs
 }
 
 /**
- * Splits a url into two parts at the specified index.
+ * Splits a string into two parts at the specified index.
  * 
- * @param {string} url The url to be split
- * @param {number} index The index at which to split the url
- * @returns {Array<string>} The two parts of the url after splitting
+ * @param {string} str The string to be split
+ * @param {number} index The index at which to split the string
+ * @returns {Array<string>} The two parts of the string after splitting
  */
-function _splitUrlOnIndex(url, index) {
-  return [url.slice(0, index), url.slice(index)];
+function _splitStringOnIndex(str, index) {
+  return [str.slice(0, index), str.slice(index)];
 }
 
 /**

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -284,9 +284,19 @@ export function joinList(list, separator) {
 /**
  * Given an image object with a url, changes the url to use dynamic thumbnailer and https.
  * 
+ * Note: A dynamic thumbnailer url generated with atLeastAsLarge = true returns an image that is
+ * at least as large in one dimension of the desired size. In other words, the returned image will
+ * be at least as large, and as close as possible to, the largest image that is contained within a
+ * box of the desired size dimensions.
+ * 
+ * If atLeastAsLarge = false, the dynamic thumbnailer url will give the largest image that is
+ * smaller than the desired size in both dimensions.
+ * 
  * @param {Object} simpleOrComplexImage An image object with a url
  * @param {string} desiredSize The desired size of the image ('<width>x<height>')
- * @param {boolean} atLeastAsLarge Whether the image should be larger than the desired size or smaller
+ * @param {boolean} atLeastAsLarge Whether the image should be at least as large as the desired
+ *                                 size in one dimension or smaller than the desired size in both
+ *                                 dimensions.
  * @returns {Object} An object with a url for dynamic thumbnailer
  */
 export function image(simpleOrComplexImage = {}, desiredSize = '200x', atLeastAsLarge = true) {

--- a/tests/static/js/formatters-internal/image.js
+++ b/tests/static/js/formatters-internal/image.js
@@ -2,99 +2,55 @@ import Formatters from 'static/js/formatters.js';
 
 describe('image formatter', () => {
   const img = {
-    url: 'https://a.mktgcdn.com/p/1024x768.jpg',
-    width: 1024,
-    height: 768,
-    thumbnails: [
-      {
-        url: 'https://a.mktgcdn.com/p/619x348.jpg',
-        width: 619,
-        height: 348
-      },
-      {
-        url: 'https://a.mktgcdn.com/p/600x337.jpg',
-        width: 600,
-        height: 337
-      },
-      {
-        url: 'https://a.mktgcdn.com/p/196x110.jpg',
-        width: 196,
-        height: 110
-      }
-    ]
+    url: 'https://a.mktgcdn.com/p/1024x768.jpg'
   }
 
   describe('when choosing the smallest image over threshold', () => {
     it('By default chooses the smallest image with width >= 200', () => {
       const imageUrl = Formatters.image(img).url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/600x337.jpg');
+      expect(imageUrl).toEqual('https://dynl.mktgcdn.com/p/200x1.jpg');
     });
 
     it('Can restrict the dimensions by width', () => {
       const imageUrl = Formatters.image(img, '601x').url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/619x348.jpg');
-    });
-
-    it('Can restrict by width when both dimensions specified', () => {
-      const imageUrl = Formatters.image(img, '601x1').url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/619x348.jpg');
+      expect(imageUrl).toEqual('https://dynl.mktgcdn.com/p/601x1.jpg');
     });
 
     it('Can restrict the dimensions by height', () => {
       const imageUrl = Formatters.image(img, 'x338').url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/619x348.jpg');
+      expect(imageUrl).toEqual('https://dynl.mktgcdn.com/p/1x338.jpg');
     });
 
-    it('Can restrict by height when both dimensions specified', () => {
-      const imageUrl = Formatters.image(img, '1x338').url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/619x348.jpg');
-    });
-
-    it('Can restrict by width when both dimensions specified', () => {
-      const imageUrl = Formatters.image(img, '601x0').url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/619x348.jpg');
-    });
-
-    it('return the largest image when no image is over threshold', () => {
-      const imageUrl = Formatters.image(img, '99999x99999').url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/1024x768.jpg');
+    it('Can restrict by both dimensions', () => {
+      const imageUrl = Formatters.image(img, '601x338').url;
+      expect(imageUrl).toEqual('https://dynl.mktgcdn.com/p/601x338.jpg');
     });
 
     it('returns the smallest image when no dimensions given', () => {
       const imageUrl = Formatters.image(img, 'x').url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/196x110.jpg');
+      expect(imageUrl).toEqual('https://dynl.mktgcdn.com/p/1x1.jpg');
     });
   });
 
   describe('when choosing the biggest image under threshold', () => {
     it('Can restrict the dimensions by width', () => {
       const imageUrl = Formatters.image(img, '601x', false).url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/600x337.jpg');
-    });
-
-    it('Can restrict by width when both dimensions specified', () => {
-      const imageUrl = Formatters.image(img, '601x9999', false).url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/600x337.jpg');
+      expect(imageUrl).toEqual('https://dynm.mktgcdn.com/p/601x768.jpg');
     });
 
     it('Can restrict the dimensions by height', () => {
       const imageUrl = Formatters.image(img, 'x338', false).url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/600x337.jpg');
+      expect(imageUrl).toEqual('https://dynm.mktgcdn.com/p/1024x338.jpg');
     });
 
-    it('Can restrict by height when both dimensions specified', () => {
-      const imageUrl = Formatters.image(img, '9999x338', false).url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/600x337.jpg');
-    });
-
-    it('returns the smallest image when no image is under threshold', () => {
-      const imageUrl = Formatters.image(img, '-1x-1', false).url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/196x110.jpg');
+    it('Can restrict by both dimensions', () => {
+      const imageUrl = Formatters.image(img, '999x338', false).url;
+      expect(imageUrl).toEqual('https://dynm.mktgcdn.com/p/999x338.jpg');
     });
 
     it('return the largest image when no dimensions given', () => {
       const imageUrl = Formatters.image(img, 'x', false).url;
-      expect(imageUrl).toEqual('https://a.mktgcdn.com/p/1024x768.jpg');
+      expect(imageUrl).toEqual('https://dynm.mktgcdn.com/p/1024x768.jpg');
     });
   });
 });


### PR DESCRIPTION
Change the image formatter to use dynamic thumbnailer instead of expecting an array of thumbnails. A thumbnail array will no longer be provided after the streams migration. Dynamic thumbnailer uses the host `dynl` for images at least as large as the specified size (the smallest image with at least one dimension greater than or equal to the specified values). The host `dynm` gives the largest image that is smaller than the specified values in both dimensions.

Note: for `dynl`, desired size values of 1 or smaller are a special case which indicates that dimension should be ignored and the returned thumbnail should be larger than the other dimension.

J=SLAP-1670
TEST=auto, manual

Check that the current profile images still appear as before and those in the streams test account now appear as well.