### PR TITLE
Update feedback text

### DIFF
--- a/cards/document-standard/component.js
+++ b/cards/document-standard/component.js
@@ -50,7 +50,7 @@ class document_standardCardComponent extends BaseCard['document-standard'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/event-standard/component.js
+++ b/cards/event-standard/component.js
@@ -50,7 +50,7 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -48,7 +48,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/financial-professional-location/component.js
+++ b/cards/financial-professional-location/component.js
@@ -66,7 +66,7 @@ class financial_professional_locationCardComponent extends BaseCard['financial-p
         // ariaLabel: ''
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/job-standard/component.js
+++ b/cards/job-standard/component.js
@@ -41,7 +41,7 @@ class job_standardCardComponent extends BaseCard['job-standard'] {
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/link-standard/component.js
+++ b/cards/link-standard/component.js
@@ -29,7 +29,7 @@ class link_standardCardComponent extends BaseCard['link-standard'] {
       // },
       details: profile.htmlSnippet, // The text in the body of the card
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -55,7 +55,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/menuitem-standard/component.js
+++ b/cards/menuitem-standard/component.js
@@ -56,7 +56,7 @@ class menuitem_standardCardComponent extends BaseCard['menuitem-standard'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-event-standard/component.js
+++ b/cards/multilang-event-standard/component.js
@@ -50,7 +50,7 @@ class multilang_event_standardCardComponent extends BaseCard['multilang-event-st
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-faq-accordion/component.js
+++ b/cards/multilang-faq-accordion/component.js
@@ -48,7 +48,7 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-financial-professional-location/component.js
+++ b/cards/multilang-financial-professional-location/component.js
@@ -66,7 +66,7 @@ class multilang_financial_professional_locationCardComponent extends BaseCard['m
         // ariaLabel: ''
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-job-standard/component.js
+++ b/cards/multilang-job-standard/component.js
@@ -41,7 +41,7 @@ class multilang_job_standardCardComponent extends BaseCard['multilang-job-standa
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-link-standard/component.js
+++ b/cards/multilang-link-standard/component.js
@@ -29,7 +29,7 @@ class multilang_link_standardCardComponent extends BaseCard['multilang-link-stan
       // },
       details: profile.htmlSnippet, // The text in the body of the card
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-location-standard/component.js
+++ b/cards/multilang-location-standard/component.js
@@ -55,7 +55,7 @@ class multilang_location_standardCardComponent extends BaseCard['multilang-locat
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-menuitem-standard/component.js
+++ b/cards/multilang-menuitem-standard/component.js
@@ -56,7 +56,7 @@ class multilang_menuitem_standardCardComponent extends BaseCard['multilang-menui
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-product-prominentimage-clickable/component.js
+++ b/cards/multilang-product-prominentimage-clickable/component.js
@@ -41,7 +41,7 @@ class multilang_product_prominentimage_clickableCardComponent
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card, Warning: cannot contain links
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-product-prominentimage/component.js
+++ b/cards/multilang-product-prominentimage/component.js
@@ -59,7 +59,7 @@ class multilang_product_prominentimageCardComponent extends BaseCard['multilang-
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-product-prominentvideo/component.js
+++ b/cards/multilang-product-prominentvideo/component.js
@@ -54,7 +54,7 @@ class multilang_product_prominentvideoCardComponent extends BaseCard['multilang-
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-product-standard/component.js
+++ b/cards/multilang-product-standard/component.js
@@ -58,7 +58,7 @@ class multilang_product_standardCardComponent extends BaseCard['multilang-produc
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-professional-location/component.js
+++ b/cards/multilang-professional-location/component.js
@@ -66,7 +66,7 @@ class multilang_professional_locationCardComponent extends BaseCard['multilang-p
         // ariaLabel: ''
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-professional-standard/component.js
+++ b/cards/multilang-professional-standard/component.js
@@ -56,7 +56,7 @@ class multilang_professional_standardCardComponent extends BaseCard['multilang-p
         // ariaLabel: ''
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/multilang-standard/component.js
+++ b/cards/multilang-standard/component.js
@@ -51,7 +51,7 @@ class multilang_standardCardComponent extends BaseCard['multilang-standard'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
       negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
     };

--- a/cards/product-prominentimage-clickable/component.js
+++ b/cards/product-prominentimage-clickable/component.js
@@ -40,7 +40,7 @@ class product_prominentimage_clickableCardComponent extends BaseCard['product-pr
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card, Warning: cannot contain links
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/product-prominentimage/component.js
+++ b/cards/product-prominentimage/component.js
@@ -59,7 +59,7 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/product-prominentvideo/component.js
+++ b/cards/product-prominentvideo/component.js
@@ -54,7 +54,7 @@ class product_prominentvideoCardComponent extends BaseCard['product-prominentvid
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -58,7 +58,7 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/professional-location/component.js
+++ b/cards/professional-location/component.js
@@ -66,7 +66,7 @@ class professional_locationCardComponent extends BaseCard['professional-location
         // ariaLabel: ''
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/professional-standard/component.js
+++ b/cards/professional-standard/component.js
@@ -56,7 +56,7 @@ class professional_standardCardComponent extends BaseCard['professional-standard
         // ariaLabel: ''
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/cards/standard/component.js
+++ b/cards/standard/component.js
@@ -51,7 +51,7 @@ class standardCardComponent extends BaseCard['standard'] {
         // ariaLabel: '',
       },
       feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
-      feedbackTextOnSubmission: 'Thank you for your feedback!', // Text to display after a thumbs up/down is clicked
+      feedbackTextOnSubmission: 'Thanks!', // Text to display after a thumbs up/down is clicked
       positiveFeedbackSrText: 'This answered my question', // Screen reader only text for thumbs-up
       negativeFeedbackSrText: 'This did not answer my question' // Screen reader only text for thumbs-down
     };

--- a/translations/ar.po
+++ b/translations/ar.po
@@ -112,6 +112,23 @@ msgstr "عمليات الفرز وعوامل التصفية"
 msgid "Thank you for your feedback!"
 msgstr "شكرًا على ملاحظاتك!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "شكرا!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/de.po
+++ b/translations/de.po
@@ -58,6 +58,23 @@ msgstr "Mehr anzeigen"
 msgid "Thank you for your feedback!"
 msgstr "Vielen Dank für Ihr Feedback!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Vielen Dank!"
+
 #: directanswercards/multilang-allfields-standard/component.js:179
 msgid "This answered my question"
 msgstr "Meine Frage wurde beantwortet"

--- a/translations/es.po
+++ b/translations/es.po
@@ -58,6 +58,23 @@ msgstr "Mostrar más"
 msgid "Thank you for your feedback!"
 msgstr "¡Gracias por tu comentario!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "¡Gracias!"
+
 #: directanswercards/multilang-allfields-standard/component.js:179
 msgid "This answered my question"
 msgstr "Esto ha respondido a mi pregunta"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -58,6 +58,23 @@ msgstr "Afficher plus"
 msgid "Thank you for your feedback!"
 msgstr "Merci pour vos commentaires !"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Merci!"
+
 #: directanswercards/multilang-allfields-standard/component.js:179
 msgid "This answered my question"
 msgstr "J'ai obtenu la réponse à ma question"

--- a/translations/hi.po
+++ b/translations/hi.po
@@ -108,6 +108,23 @@ msgstr "सॉर्ट और फ़िल्टर"
 msgid "Thank you for your feedback!"
 msgstr "आपके फ़ीडबैक के लिए आपका धन्यवाद!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "धन्यवाद!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/it.po
+++ b/translations/it.po
@@ -58,6 +58,23 @@ msgstr "Mostra altro"
 msgid "Thank you for your feedback!"
 msgstr "Grazie per il tuo feedback!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Grazie!"
+
 #: directanswercards/multilang-allfields-standard/component.js:179
 msgid "This answered my question"
 msgstr "La risposta è stata esauriente"

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -58,6 +58,23 @@ msgstr "さらに表示"
 msgid "Thank you for your feedback!"
 msgstr "ご意見ありがとうございました!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "ありがとう！"
+
 #: directanswercards/multilang-allfields-standard/component.js:179
 msgid "This answered my question"
 msgstr "この内容で疑問が解決した"

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -107,6 +107,23 @@ msgstr "정렬 및 필터"
 msgid "Thank you for your feedback!"
 msgstr "피드백을 주셔서 감사합니다!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "감사 해요!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -132,6 +132,10 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
+#: directanswercards/multilang-allfields-standard/component.js:188
+msgid "Thank you for your feedback!"
+msgstr ""
+
 #: cards/multilang-event-standard/component.js:53
 #: cards/multilang-faq-accordion/component.js:51
 #: cards/multilang-financial-professional-location/component.js:69
@@ -146,8 +150,7 @@ msgstr ""
 #: cards/multilang-professional-location/component.js:69
 #: cards/multilang-professional-standard/component.js:59
 #: cards/multilang-standard/component.js:54
-#: directanswercards/multilang-allfields-standard/component.js:188
-msgid "Thank you for your feedback!"
+msgid "Thanks!"
 msgstr ""
 
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -108,6 +108,23 @@ msgstr "sorteren en filteren"
 msgid "Thank you for your feedback!"
 msgstr "Hartelijk dank voor uw feedback!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Bedankt!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -109,6 +109,23 @@ msgstr "sortuje i filtruje"
 msgid "Thank you for your feedback!"
 msgstr "Dziękujemy za opinię!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Dziękuję!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -108,6 +108,23 @@ msgstr "classificações e filtros"
 msgid "Thank you for your feedback!"
 msgstr "Obrigado pelo seu feedback!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Obrigada!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -109,6 +109,23 @@ msgstr "сортировка и фильтры"
 msgid "Thank you for your feedback!"
 msgstr "Спасибо за ваш отзыв!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Спасибо!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -108,6 +108,23 @@ msgstr "sorterar och filtrerar"
 msgid "Thank you for your feedback!"
 msgstr "Tack för din feedback!"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "Tack!"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/zh-Hans.po
+++ b/translations/zh-Hans.po
@@ -107,6 +107,23 @@ msgstr "排序和筛选"
 msgid "Thank you for your feedback!"
 msgstr "感谢你的反馈！"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "谢谢！"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"

--- a/translations/zh-Hant.po
+++ b/translations/zh-Hant.po
@@ -107,6 +107,23 @@ msgstr "排序和篩選條件"
 msgid "Thank you for your feedback!"
 msgstr "感謝您的意見反應！"
 
+#: cards/multilang-event-standard/component.js:53
+#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-financial-professional-location/component.js:69
+#: cards/multilang-job-standard/component.js:44
+#: cards/multilang-link-standard/component.js:32
+#: cards/multilang-location-standard/component.js:58
+#: cards/multilang-menuitem-standard/component.js:59
+#: cards/multilang-product-prominentimage-clickable/component.js:44
+#: cards/multilang-product-prominentimage/component.js:62
+#: cards/multilang-product-prominentvideo/component.js:57
+#: cards/multilang-product-standard/component.js:61
+#: cards/multilang-professional-location/component.js:69
+#: cards/multilang-professional-standard/component.js:59
+#: cards/multilang-standard/component.js:54
+msgid "Thanks!"
+msgstr "謝謝！"
+
 #: theme-components/vertical-full-page-map-alternative-verticals/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"


### PR DESCRIPTION
Update the text of the feedback cards to "Thanks!"

Add translations as well. Note: the feedback text of the direct answer component stays the same. Since the "Thanks!" text is shorter, it fixes the long text shifting issue. If someone sets a custom text which is longer, then the text wrapping will appear, however that is the desired behavior according to product

J=SLAP-1698
TEST=manual

View the updated text in the theme test site in english and in Spanish