### PR TITLE
Fix Thumbs Up/Down Background color when active

### DIFF
--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -46,7 +46,6 @@
   {
     display: flex;
     flex-grow: 1;
-    background-color: var(--yxt-color-background-highlight);
     min-width: 55px;
     @include bpgte(sm)
     {


### PR DESCRIPTION
Fix the color surrounding the thumbs up/down buttons when the card is active (e.g. on a location page)

J=SLAP-1699
TEST=manual

Confirm the issue is fixed on the cards with active states (the location cards including location-standard, professional-location, and financial-professional-location)