### PR TITLE
Always have feedback buttons on product-prominentvideo cards

### DIFF
--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -49,7 +49,7 @@
 {{/inline}}
 
 {{#*inline 'content'}}
-{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
+{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label) card.feedbackEnabled)}}
   <div class="HitchhikerProductProminentVideo-contentWrapper">
     {{> details }}
     <div class="HitchhikerCard-actions">

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -49,7 +49,7 @@
 {{/inline}}
 
 {{#*inline 'content'}}
-{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
+{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label) card.feedbackEnabled)}}
   <div class="HitchhikerProductProminentVideo-contentWrapper">
     {{> details }}
     <div class="HitchhikerCard-actions">


### PR DESCRIPTION
Display thumbs up/down feedback buttons on product-prominentvideo cards whenever feedback is enabled, even if there are no details or CTAs.

J=SLAP-1701
TEST=manual

Check that test-site has thumbs up/down buttons appearing accordingly on product-prominentvideo cards