### PR TITLE
Card layout updates

### DIFF
--- a/cards/document-standard/template.hbs
+++ b/cards/document-standard/template.hbs
@@ -9,9 +9,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/document-standard/template.hbs
+++ b/cards/document-standard/template.hbs
@@ -7,9 +7,7 @@
       <div class="HitchhikerDocumentStandard-info">
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -34,26 +34,26 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
-        <div class="HitchhikerEventStandard-ctasWrapper">
-          {{#if (all card.CTA1.url card.CTA1.label)}}
-          <div class="HitchhikerEventStandard-primaryCTA">
-            {{#with card.CTA1}}
-              {{> CTA }}
-            {{/with}}
+          <div class="HitchhikerEventStandard-ctasWrapper">
+            {{#if (all card.CTA1.url card.CTA1.label)}}
+            <div class="HitchhikerEventStandard-primaryCTA">
+              {{#with card.CTA1}}
+                {{> CTA }}
+              {{/with}}
+            </div>
+            {{/if}}
+            {{#if (all card.CTA2.url card.CTA2.label)}}
+            <div class="HitchhikerEventStandard-secondaryCTA">
+              {{#with card.CTA2}}
+                {{> CTA }}
+              {{/with}}
+            </div>
+            {{/if}}
           </div>
-          {{/if}}
-          {{#if (all card.CTA2.url card.CTA2.label)}}
-          <div class="HitchhikerEventStandard-secondaryCTA">
-            {{#with card.CTA2}}
-              {{> CTA }}
-            {{/with}}
-          </div>
-          {{/if}}
-        </div>
         {{/if}}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -32,26 +32,24 @@
         {{/if}}
         {{> 'details'}}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
-          <div class="HitchhikerEventStandard-ctasWrapper">
-            {{#if (all card.CTA1.url card.CTA1.label)}}
-            <div class="HitchhikerEventStandard-primaryCTA">
-              {{#with card.CTA1}}
-                {{> CTA }}
-              {{/with}}
-            </div>
-            {{/if}}
-            {{#if (all card.CTA2.url card.CTA2.label)}}
-            <div class="HitchhikerEventStandard-secondaryCTA">
-              {{#with card.CTA2}}
-                {{> CTA }}
-              {{/with}}
-            </div>
-            {{/if}}
+      {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
+        <div class="HitchhikerEventStandard-ctasWrapper">
+          {{#if (all card.CTA1.url card.CTA1.label)}}
+          <div class="HitchhikerEventStandard-primaryCTA">
+            {{#with card.CTA1}}
+              {{> CTA }}
+            {{/with}}
           </div>
-        {{/if}}
-      </div>
+          {{/if}}
+          {{#if (all card.CTA2.url card.CTA2.label)}}
+          <div class="HitchhikerEventStandard-secondaryCTA">
+            {{#with card.CTA2}}
+              {{> CTA }}
+            {{/with}}
+          </div>
+          {{/if}}
+        </div>
+      {{/if}}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -19,26 +19,24 @@
       </div>
     {{/if}}
     {{> 'details'}}
-    <div class="HitchhikerCard-actions">
-      {{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
-        <div class="HitchhikerFaqAccordion-ctasWrapper">
-          {{#if card.CTA1.url}}
-          <div class="HitchhikerFaqAccordion-primaryCTA">
-            {{#with card.CTA1}}
-              {{> CTA }}
-            {{/with}}
-          </div>
-          {{/if}}
-          {{#if card.CTA2.url}}
-          <div class="HitchhikerFaqAccordion-secondaryCTA">
-            {{#with card.CTA2}}
-              {{> CTA }}
-            {{/with}}
-          </div>
-          {{/if}}
+    {{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
+      <div class="HitchhikerFaqAccordion-ctasWrapper">
+        {{#if card.CTA1.url}}
+        <div class="HitchhikerFaqAccordion-primaryCTA">
+          {{#with card.CTA1}}
+            {{> CTA }}
+          {{/with}}
         </div>
-      {{/if}}
-    </div>
+        {{/if}}
+        {{#if card.CTA2.url}}
+        <div class="HitchhikerFaqAccordion-secondaryCTA">
+          {{#with card.CTA2}}
+            {{> CTA }}
+          {{/with}}
+        </div>
+        {{/if}}
+      </div>
+    {{/if}}
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -38,8 +38,8 @@
           {{/if}}
         </div>
       {{/if}}
-      {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -19,9 +19,7 @@
         {{> list }}
         {{> phone }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -21,9 +21,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -9,9 +9,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -7,9 +7,7 @@
       <div class="HitchhikerJobStandard-info">
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -4,10 +4,8 @@
     {{> subtitle }}
     <div class="HitchhikerLinkStandard-contentWrapper">
       {{> details }}
-      <div class="HitchhikerCard-actions">
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
-      </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -24,9 +24,7 @@
         {{> contactInfo }}
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -26,9 +26,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 </div>

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -10,18 +10,18 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
-        <div class="HitchhikerMenuItemStandard-ctasWrapper">
-          {{#with card.CTA1}}
-          {{> CTA ctaName="primaryCTA" }}
-          {{/with}}
-          {{#with card.CTA2}}
-          {{> CTA ctaName="secondaryCTA" }}
-          {{/with}}
-        </div>
+          <div class="HitchhikerMenuItemStandard-ctasWrapper">
+            {{#with card.CTA1}}
+            {{> CTA ctaName="primaryCTA" }}
+            {{/with}}
+            {{#with card.CTA2}}
+            {{> CTA ctaName="secondaryCTA" }}
+            {{/with}}
+          </div>
         {{/if}}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -8,18 +8,16 @@
         {{> list }}
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
-          <div class="HitchhikerMenuItemStandard-ctasWrapper">
-            {{#with card.CTA1}}
-            {{> CTA ctaName="primaryCTA" }}
-            {{/with}}
-            {{#with card.CTA2}}
-            {{> CTA ctaName="secondaryCTA" }}
-            {{/with}}
-          </div>
-        {{/if}}
-      </div>
+      {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
+        <div class="HitchhikerMenuItemStandard-ctasWrapper">
+          {{#with card.CTA1}}
+          {{> CTA ctaName="primaryCTA" }}
+          {{/with}}
+          {{#with card.CTA2}}
+          {{> CTA ctaName="secondaryCTA" }}
+          {{/with}}
+        </div>
+      {{/if}}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -32,26 +32,24 @@
         {{/if}}
         {{> 'details'}}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
-          <div class="HitchhikerEventStandard-ctasWrapper">
-            {{#if (all card.CTA1.url card.CTA1.label)}}
-            <div class="HitchhikerEventStandard-primaryCTA">
-              {{#with card.CTA1}}
-                {{> CTA }}
-              {{/with}}
-            </div>
-            {{/if}}
-            {{#if (all card.CTA2.url card.CTA2.label)}}
-            <div class="HitchhikerEventStandard-secondaryCTA">
-              {{#with card.CTA2}}
-                {{> CTA }}
-              {{/with}}
-            </div>
-            {{/if}}
+      {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
+        <div class="HitchhikerEventStandard-ctasWrapper">
+          {{#if (all card.CTA1.url card.CTA1.label)}}
+          <div class="HitchhikerEventStandard-primaryCTA">
+            {{#with card.CTA1}}
+              {{> CTA }}
+            {{/with}}
           </div>
-        {{/if}}
-      </div>
+          {{/if}}
+          {{#if (all card.CTA2.url card.CTA2.label)}}
+          <div class="HitchhikerEventStandard-secondaryCTA">
+            {{#with card.CTA2}}
+              {{> CTA }}
+            {{/with}}
+          </div>
+          {{/if}}
+        </div>
+      {{/if}}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -51,9 +51,9 @@
             {{/if}}
           </div>
         {{/if}}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -19,26 +19,24 @@
       </div>
     {{/if}}
     {{> 'details'}}
-    <div class="HitchhikerCard-actions">
-      {{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
-        <div class="HitchhikerFaqAccordion-ctasWrapper">
-          {{#if card.CTA1.url}}
-          <div class="HitchhikerFaqAccordion-primaryCTA">
-            {{#with card.CTA1}}
-              {{> CTA }}
-            {{/with}}
-          </div>
-          {{/if}}
-          {{#if card.CTA2.url}}
-          <div class="HitchhikerFaqAccordion-secondaryCTA">
-            {{#with card.CTA2}}
-              {{> CTA }}
-            {{/with}}
-          </div>
-          {{/if}}
+    {{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
+      <div class="HitchhikerFaqAccordion-ctasWrapper">
+        {{#if card.CTA1.url}}
+        <div class="HitchhikerFaqAccordion-primaryCTA">
+          {{#with card.CTA1}}
+            {{> CTA }}
+          {{/with}}
         </div>
-      {{/if}}
-    </div>
+        {{/if}}
+        {{#if card.CTA2.url}}
+        <div class="HitchhikerFaqAccordion-secondaryCTA">
+          {{#with card.CTA2}}
+            {{> CTA }}
+          {{/with}}
+        </div>
+        {{/if}}
+      </div>
+    {{/if}}
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -38,8 +38,8 @@
           {{/if}}
         </div>
       {{/if}}
-      {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -19,9 +19,7 @@
         {{> list }}
         {{> phone }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -21,9 +21,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -9,9 +9,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -7,9 +7,7 @@
       <div class="HitchhikerJobStandard-info">
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -4,10 +4,8 @@
     {{> subtitle }}
     <div class="HitchhikerLinkStandard-contentWrapper">
       {{> details }}
-      <div class="HitchhikerCard-actions">
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
-      </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -24,9 +24,7 @@
         {{> contactInfo }}
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -26,9 +26,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 </div>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -8,7 +8,6 @@
         {{> list }}
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
         {{#if (any (all card.CTA1 card.CTA1.url) (all card.CTA2 card.CTA2.url))}}
           <div class="HitchhikerMenuItemStandard-ctasWrapper">
             {{#with card.CTA1}}
@@ -19,7 +18,6 @@
             {{/with}}
           </div>
         {{/if}}
-      </div>
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -19,9 +19,9 @@
             {{/with}}
           </div>
         {{/if}}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-product-prominentimage-clickable/template.hbs
+++ b/cards/multilang-product-prominentimage-clickable/template.hbs
@@ -13,10 +13,8 @@
       {{> subtitle }}
       <div class="HitchhikerProductProminentImage-contentWrapper">
         {{> details }}
-        <div class="HitchhikerCard-actions">
-          {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
-        </div>
       </div>
+      {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
     </div>
   {{#if card.url}}</a>{{/if}}
 </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -5,9 +5,7 @@
     {{> subtitle }}
     <div class="HitchhikerProductProminentImage-contentWrapper">
       {{> details }}
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -7,9 +7,9 @@
       {{> details }}
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -50,7 +50,7 @@
 {{/inline}}
 
 {{#*inline 'content'}}
-{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label) card.feedbackEnabled)}}
+{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
   <div class="HitchhikerProductProminentVideo-contentWrapper">
     {{> details }}
     {{> ctas }}

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -53,9 +53,7 @@
 {{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label) card.feedbackEnabled)}}
   <div class="HitchhikerProductProminentVideo-contentWrapper">
     {{> details }}
-    <div class="HitchhikerCard-actions">
-      {{> ctas }}
-    </div>
+    {{> ctas }}
   </div>
 {{/if}}
 {{/inline}}

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -4,6 +4,7 @@
     {{> title }}
     {{> subtitle }}
     {{> content }}
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 
@@ -54,7 +55,6 @@
     {{> details }}
     <div class="HitchhikerCard-actions">
       {{> ctas }}
-      {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
     </div>
   </div>
 {{/if}}

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -5,18 +5,16 @@
     {{> subtitle }}
     <div class="HitchhikerProductStandard-contentWrapper">
       {{> details }}
-      <div class="HitchhikerCard-actions">
-        {{#if (any (all card.CTA1 card.CTA1.label card.CTA1.url) (all card.CTA2 card.CTA2.label card.CTA2.url))}}
-          <div class="HitchhikerProductStandard-ctasWrapper">
-            {{#with card.CTA1}}
-            {{> CTA ctaName="primaryCTA" }}
-            {{/with}}
-            {{#with card.CTA2}}
-            {{> CTA ctaName="secondaryCTA" }}
-            {{/with}}
-          </div>
-        {{/if}}
-      </div>
+      {{#if (any (all card.CTA1 card.CTA1.label card.CTA1.url) (all card.CTA2 card.CTA2.label card.CTA2.url))}}
+        <div class="HitchhikerProductStandard-ctasWrapper">
+          {{#with card.CTA1}}
+          {{> CTA ctaName="primaryCTA" }}
+          {{/with}}
+          {{#with card.CTA2}}
+          {{> CTA ctaName="secondaryCTA" }}
+          {{/with}}
+        </div>
+      {{/if}}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -16,9 +16,9 @@
             {{/with}}
           </div>
         {{/if}}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -19,9 +19,7 @@
         {{> list }}
         {{> phone }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -21,9 +21,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -9,9 +9,7 @@
         {{> list }}
         {{> phone }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -11,9 +11,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -9,9 +9,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -7,9 +7,7 @@
       <div class="HitchhikerStandard-info">
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/product-prominentimage-clickable/template.hbs
+++ b/cards/product-prominentimage-clickable/template.hbs
@@ -13,10 +13,8 @@
       {{> subtitle }}
       <div class="HitchhikerProductProminentImageClickable-contentWrapper">
         {{> details }}
-        <div class="HitchhikerCard-actions">
-          {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
-        </div>
       </div>
+      {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
     </div>
   {{#if card.url}}</a>{{/if}}
 </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -5,9 +5,7 @@
     {{> subtitle }}
     <div class="HitchhikerProductProminentImage-contentWrapper">
       {{> details }}
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -7,9 +7,9 @@
       {{> details }}
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -50,7 +50,7 @@
 {{/inline}}
 
 {{#*inline 'content'}}
-{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label) card.feedbackEnabled)}}
+{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
   <div class="HitchhikerProductProminentVideo-contentWrapper">
     {{> details }}
     {{> ctas }}

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -53,9 +53,7 @@
 {{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label) card.feedbackEnabled)}}
   <div class="HitchhikerProductProminentVideo-contentWrapper">
     {{> details }}
-    <div class="HitchhikerCard-actions">
-      {{> ctas }}
-    </div>
+    {{> ctas }}
   </div>
 {{/if}}
 {{/inline}}

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -4,6 +4,7 @@
     {{> title }}
     {{> subtitle }}
     {{> content }}
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 
@@ -54,7 +55,6 @@
     {{> details }}
     <div class="HitchhikerCard-actions">
       {{> ctas }}
-      {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
     </div>
   </div>
 {{/if}}

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -5,18 +5,16 @@
     {{> subtitle }}
     <div class="HitchhikerProductStandard-contentWrapper">
       {{> details }}
-      <div class="HitchhikerCard-actions">
-        {{#if (any (all card.CTA1 card.CTA1.label card.CTA1.url) (all card.CTA2 card.CTA2.label card.CTA2.url))}}
-          <div class="HitchhikerProductStandard-ctasWrapper">
-            {{#with card.CTA1}}
-            {{> CTA ctaName="primaryCTA" }}
-            {{/with}}
-            {{#with card.CTA2}}
-            {{> CTA ctaName="secondaryCTA" }}
-            {{/with}}
-          </div>
-        {{/if}}
-      </div>
+      {{#if (any (all card.CTA1 card.CTA1.label card.CTA1.url) (all card.CTA2 card.CTA2.label card.CTA2.url))}}
+        <div class="HitchhikerProductStandard-ctasWrapper">
+          {{#with card.CTA1}}
+          {{> CTA ctaName="primaryCTA" }}
+          {{/with}}
+          {{#with card.CTA2}}
+          {{> CTA ctaName="secondaryCTA" }}
+          {{/with}}
+        </div>
+      {{/if}}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -16,9 +16,9 @@
             {{/with}}
           </div>
         {{/if}}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -19,9 +19,7 @@
         {{> list }}
         {{> phone }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -21,9 +21,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -9,9 +9,7 @@
         {{> list }}
         {{> phone }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -11,9 +11,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -9,9 +9,9 @@
       </div>
       <div class="HitchhikerCard-actions">
         {{> ctas }}
-        {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
       </div>
     </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>
 </div>
 

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -7,9 +7,7 @@
       <div class="HitchhikerStandard-info">
         {{> details }}
       </div>
-      <div class="HitchhikerCard-actions">
-        {{> ctas }}
-      </div>
+      {{> ctas }}
     </div>
     {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
   </div>

--- a/static/scss/answers/cards/document-standard.scss
+++ b/static/scss/answers/cards/document-standard.scss
@@ -92,12 +92,4 @@
   {
     display: none;
   }
-
-  .HitchhikerCard-feedbackWrapper
-  {
-    @include bpgte(sm)
-    {
-      margin-right: calc(var(--yxt-base-spacing) / 2);
-    }
-  }
 }

--- a/static/scss/answers/cards/event-standard.scss
+++ b/static/scss/answers/cards/event-standard.scss
@@ -3,6 +3,7 @@
   background-color: var(--yxt-color-brand-white);
   padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
   display: flex;
+  flex-direction: column;
   font-size: .875rem;
   width: 100%;
   height: 100%;
@@ -109,13 +110,5 @@
   .js-hidden
   {
     display: none;
-  }
-
-  .HitchhikerCard-feedbackWrapper
-  {
-    @include bpgte(sm)
-    {
-      margin-left: 1.5rem;
-    }
   }
 }

--- a/static/scss/answers/cards/faq-accordion.scss
+++ b/static/scss/answers/cards/faq-accordion.scss
@@ -149,11 +149,6 @@
 
   .HitchhikerCard
   {
-    &-actions
-    {
-      flex-direction: row;
-    }
-
     &-feedbackWrapper
     {
       margin-top: 0;

--- a/static/scss/answers/cards/faq-accordion.scss
+++ b/static/scss/answers/cards/faq-accordion.scss
@@ -156,8 +156,10 @@
 
     &-feedbackWrapper
     {
-      margin: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
-      padding-bottom: calc(var(--yxt-base-spacing) / 2);
+      margin-top: 0;
+      margin-left: calc(var(--yxt-base-spacing));
+      margin-right: calc(var(--yxt-base-spacing));
+      margin-bottom: calc(var(--yxt-base-spacing) * 0.75);
     }
 
     &-feedbackContent

--- a/static/scss/answers/cards/job-standard.scss
+++ b/static/scss/answers/cards/job-standard.scss
@@ -10,6 +10,8 @@
   &-body
   {
     width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   &-contentWrapper

--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -62,16 +62,6 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
         flex-direction: column;
       }
     }
-
-    &-feedbackWrapper
-    {
-      margin-left: 0;
-
-      @include bpgte(lg)
-      {
-        margin-left: calc(var(--hh-location-standard-base-spacing) / 2);
-      }
-    }
   }
 }
 

--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -50,19 +50,6 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
       }
     }
   }
-
-  .HitchhikerCard
-  {
-    &-actions
-    {
-      flex-direction: row;
-
-      @include bpgte(lg)
-      {
-        flex-direction: column;
-      }
-    }
-  }
 }
 
 .HitchhikerLocationStandard

--- a/static/scss/answers/cards/menuitem-standard.scss
+++ b/static/scss/answers/cards/menuitem-standard.scss
@@ -11,6 +11,8 @@
   &-body
   {
     width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   &-imgWrapper

--- a/static/scss/answers/cards/product-prominentimage-clickable.scss
+++ b/static/scss/answers/cards/product-prominentimage-clickable.scss
@@ -121,11 +121,6 @@
 
   .HitchhikerCard
   {
-    &-actions
-    {
-      flex-direction: row;
-    }
-  
     &-feedbackContent
     {
       margin-top: calc(var(--yxt-base-spacing) / 2);

--- a/static/scss/answers/cards/product-prominentimage-clickable.scss
+++ b/static/scss/answers/cards/product-prominentimage-clickable.scss
@@ -40,6 +40,9 @@
   {
     width: 100%;
     padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
   }
 
   &-contentWrapper
@@ -121,11 +124,6 @@
     &-actions
     {
       flex-direction: row;
-    }
-  
-    &-feedbackWrapper
-    {
-      margin-left: 0;
     }
   
     &-feedbackContent

--- a/static/scss/answers/cards/product-prominentimage-clickable.scss
+++ b/static/scss/answers/cards/product-prominentimage-clickable.scss
@@ -42,7 +42,7 @@
     padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
     display: flex;
     flex-direction: column;
-    height: 100%;
+    flex-grow: 1;
   }
 
   &-contentWrapper

--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -124,11 +124,6 @@
       flex-direction: row;
     }
   
-    &-feedbackWrapper
-    {
-      margin-left: 0;
-    }
-  
     &-feedbackContent
     {
       margin-top: calc(var(--yxt-base-spacing) / 2);

--- a/static/scss/answers/cards/product-prominentimage.scss
+++ b/static/scss/answers/cards/product-prominentimage.scss
@@ -119,11 +119,6 @@
 
   .HitchhikerCard
   {
-    &-actions
-    {
-      flex-direction: row;
-    }
-  
     &-feedbackContent
     {
       margin-top: calc(var(--yxt-base-spacing) / 2);

--- a/static/scss/answers/cards/product-prominentvideo.scss
+++ b/static/scss/answers/cards/product-prominentvideo.scss
@@ -11,7 +11,7 @@
   &-body
   {
     padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
-    height: 100%;
+    flex-grow: 1;
     display: flex;
     flex-direction: column;
   }

--- a/static/scss/answers/cards/product-prominentvideo.scss
+++ b/static/scss/answers/cards/product-prominentvideo.scss
@@ -93,11 +93,6 @@
 
   .HitchhikerCard
   {
-    &-actions
-    {
-      flex-direction: row;
-    }
-  
     &-feedbackContent
     {
       margin-top: 0;

--- a/static/scss/answers/cards/product-prominentvideo.scss
+++ b/static/scss/answers/cards/product-prominentvideo.scss
@@ -100,7 +100,7 @@
   
     &-feedbackContent
     {
-      margin-top: calc(var(--yxt-base-spacing) / 2);
+      margin-top: 0;
     }
   }
 }

--- a/static/scss/answers/cards/product-prominentvideo.scss
+++ b/static/scss/answers/cards/product-prominentvideo.scss
@@ -11,6 +11,9 @@
   &-body
   {
     padding: calc(var(--yxt-base-spacing) * 3/4) var(--yxt-base-spacing);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   &-contentWrapper
@@ -93,11 +96,6 @@
     &-actions
     {
       flex-direction: row;
-    }
-  
-    &-feedbackWrapper
-    {
-      margin-left: 0;
     }
   
     &-feedbackContent

--- a/static/scss/answers/cards/product-standard.scss
+++ b/static/scss/answers/cards/product-standard.scss
@@ -11,6 +11,8 @@
   &-body
   {
     width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   &-imgWrapper

--- a/static/scss/answers/cards/professional-standard.scss
+++ b/static/scss/answers/cards/professional-standard.scss
@@ -15,6 +15,8 @@ $professional-standard-spacing: var(--yxt-base-spacing) !default;
   &-body
   {
     width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   &-contentWrapper

--- a/static/scss/answers/cards/standard.scss
+++ b/static/scss/answers/cards/standard.scss
@@ -11,6 +11,8 @@
   &-body
   {
     width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   &-contentWrapper
@@ -91,13 +93,5 @@
   .js-hidden
   {
     display: none;
-  }
-
-  .HitchhikerCard-feedbackWrapper
-  {
-    @include bpgte(sm)
-    {
-      margin-right: calc(var(--yxt-base-spacing) / 2);
-    }
   }
 }

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -596,10 +596,6 @@
       font-weight: bold;
       justify-content: flex-end;
     }
-
-    .HitchhikerCard-feedbackWrapper {
-      margin-left: 0;
-    }
   }
 
   .yxt-Card--isVisibleOnMobileMap {

--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -551,10 +551,6 @@
     &-ctasWrapper {
       margin-top: calc(var(--yxt-base-spacing) / 2);
     }
-
-    .HitchhikerCard-actions {
-      flex-direction: row;
-    }
   }
 
   .HitchhikerLocationCard {

--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -56,6 +56,9 @@
     align-items: flex-end;
     flex-grow: 1;
     margin-top: calc(var(--yxt-base-spacing) / 2);
+    // Use 22px height to match the height of the feedback text so that the card doesn't shift 
+    // when a feedback button is clicked
+    height: 22px;
   }
 
   &-feedbackText

--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -45,7 +45,6 @@
     align-items: flex-end;
     flex-grow: 1;
     margin-top: calc(var(--yxt-base-spacing) / 2);
-    height: auto;
   }
 
   &-feedbackText

--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -31,17 +31,6 @@
       @include TextButton($padding: 0);
   }
 
-  &-actions
-  {
-    display: flex;
-    align-items: flex-end;
-
-    @include bpgte(sm)
-    {
-      flex-direction: column;
-    }
-  }
-
   &-feedbackWrapper
   {
     display: flex;

--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -56,9 +56,7 @@
     align-items: flex-end;
     flex-grow: 1;
     margin-top: calc(var(--yxt-base-spacing) / 2);
-    // Use 22px height to match the height of the feedback text so that the card doesn't shift 
-    // when a feedback button is clicked
-    height: 22px;
+    height: auto;
   }
 
   &-feedbackText
@@ -71,6 +69,13 @@
       $color: var(--yxt-color-text-secondary)
     );
     text-align: right;
+  }
+
+  &-thumbsWrapper
+  {
+    // Use 22px height to match the height of the feedback text so that the card doesn't shift 
+    // when a feedback button is clicked
+    height: 22px;
   }
 
   &-thumbs

--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -46,7 +46,6 @@
   {
     display: flex;
     flex-grow: 1;
-    background-color: var(--yxt-color-background-highlight);
     min-width: 55px;
     @include bpgte(sm)
     {

--- a/static/scss/answers/module.scss
+++ b/static/scss/answers/module.scss
@@ -47,10 +47,6 @@
     display: flex;
     flex-grow: 1;
     min-width: 55px;
-    @include bpgte(sm)
-    {
-      margin-left: calc(var(--yxt-base-spacing) / 2);
-    }
   }
 
   &-feedbackContent
@@ -59,10 +55,7 @@
     justify-content: flex-end;
     align-items: flex-end;
     flex-grow: 1;
-    @include bpgte(sm)
-    {
-      margin-top: calc(var(--yxt-base-spacing) / 2);
-    }
+    margin-top: calc(var(--yxt-base-spacing) / 2);
   }
 
   &-feedbackText

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -88,7 +88,7 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: cards/multilang-location-standard/template.hbs:143
+#: cards/multilang-location-standard/template.hbs:141
 msgid "Services:"
 msgstr ""
 
@@ -244,9 +244,9 @@ msgctxt "Call is a verb"
 msgid "Call"
 msgstr ""
 
-#: cards/multilang-financial-professional-location/template.hbs:201
-#: cards/multilang-location-standard/template.hbs:212
-#: cards/multilang-professional-location/template.hbs:198
+#: cards/multilang-financial-professional-location/template.hbs:199
+#: cards/multilang-location-standard/template.hbs:210
+#: cards/multilang-professional-location/template.hbs:196
 msgctxt "Close is a verb"
 msgid "Close Card"
 msgstr ""


### PR DESCRIPTION
Update the layout of the card feedback buttons so that they are located in their own row underneath the CTAs and the card content

This change was in response to feedback from Product/UX. This PR moves the feedback buttons out from the `HitchhikerCard-actions` div into the card body. We also remove the `HichhikerCard-actions` div since that was only there so that the buttons could be next to the CTAs. This allows the card content to be full width when CTAs are not present. It adds some extra height to most cards since there's an entire row dedicated to the feedback buttons, however UX was happy with this decision. As part of this change, I removed some styling which is no longer relevant.

This PR also ensures that the feedback buttons are in the bottom right on grid layout. (Previously the buttons could appear just below the card content in grid layout just below the CTAs)

Also set a fixed feedbackContent height so that the cards don't shift when the buttons are pressed.

J=SLAP-1702
TEST=manual

Visual inspect all cards with feedback buttons enabled and also check mobile layouts. Test the product cards on the grid layout and confirm the feedback buttons are in the bottom right. Test clicking the feedback buttons and observing that the cards do not shift

