### PR TITLE
Escape angle brackets in highlightField

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "answers-hitchhiker-theme",
       "version": "1.26.0",
+      "dependencies": {
+        "escape-html": "^1.0.3"
+      },
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.1",
         "@babel/core": "^7.9.6",
@@ -7509,8 +7512,7 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -23390,8 +23392,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
       "/wcag/",
       "/acceptance/"
     ]
+  },
+  "dependencies": {
+    "escape-html": "^1.0.3"
   }
 }

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -543,7 +543,7 @@ export function priceRange(defaultPriceRange, countryCode) {
 export function highlightField(fieldValue, matchedSubstrings = []) {
   let highlightedString = '';
 
-  // We must first sort the matchedSubstrings by decreasing offset. 
+  // We must first sort the matchedSubstrings by ascending offset. 
   const sortedMatches = matchedSubstrings.slice()
     .sort((match1, match2) => match1.offset - match2.offset);
   

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -540,7 +540,7 @@ export function priceRange(defaultPriceRange, countryCode) {
  *                                          highlight.
  */
 export function highlightField(fieldValue, matchedSubstrings = []) {
-  let highlightedString = fieldValue.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  let highlightedString = fieldValue;
 
   // We must first sort the matchedSubstrings by decreasing offset. 
   const sortedMatches = matchedSubstrings.slice()
@@ -554,6 +554,13 @@ export function highlightField(fieldValue, matchedSubstrings = []) {
       highlightedString.substr(offset + length);
   });
 
+  /**
+   * Use regex to match all tags that's not <mark> tag, and replaced angle brackets
+   * with '&lt;' and '&gt;' to properly display them. The regex pattern uses
+   * lookahead syntax to check if the angle bracket '<' is follow by 'mark' or '/mark'
+   * before closing it with '>'. If the tag is not a mark tag, replace the angle brackets.
+   */
+  highlightedString = highlightedString.replace(/(<)((?!\/?mark)[^>]*)(>)/g,'&lt;$2&gt;');
   return highlightedString;
 }
 

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -541,21 +541,20 @@ export function priceRange(defaultPriceRange, countryCode) {
  *                                          highlight.
  */
 export function highlightField(fieldValue, matchedSubstrings = []) {
-  let highlightedString = fieldValue;
+  let highlightedString = '';
 
   // We must first sort the matchedSubstrings by decreasing offset. 
   const sortedMatches = matchedSubstrings.slice()
     .sort((match1, match2) => match2.offset - match1.offset);
   
+  let processedFieldValueIndex = 0;
   sortedMatches.forEach(match => {
     const { offset, length } = match;
-    highlightedString = 
-      highlightedString.substr(0, offset) +
-      `|mark|${fieldValue.substr(offset, length)}|/mark|`+
-      highlightedString.substr(offset + length);
+    highlightedString += escape(fieldValue.substring(processedFieldValueIndex, offset))
+      + `<mark>${escape(fieldValue.substring(offset, offset + length))}</mark>`;
+      processedFieldValueIndex = offset + length;
   });
-
-  highlightedString = escape(highlightedString).replace(/\|mark\|/g, '<mark>').replace(/\|\/mark\|/g, '</mark>');
+  highlightedString += escape(fieldValue.substring(processedFieldValueIndex));
   return highlightedString;
 }
 

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -555,10 +555,9 @@ export function highlightField(fieldValue, matchedSubstrings = []) {
   });
 
   /**
-   * Use regex to match all tags that's not <mark> tag, and replaced angle brackets
-   * with '&lt;' and '&gt;' to properly display them. The regex pattern uses
-   * lookahead syntax to check if the angle bracket '<' is follow by 'mark' or '/mark'
-   * before closing it with '>'. If the tag is not a mark tag, replace the angle brackets.
+   * Use regex with uses lookahead syntax to match all tags that's not <mark> or </mark> tag,
+   * and replace angle brackets with '&lt;' and '&gt;' to properly display them as non-html code.
+   * If matched, preserve the content ($2) inside but replace the surrounding angle brackets.
    */
   highlightedString = highlightedString.replace(/(<)((?!\/?mark)[^>]*)(>)/g,'&lt;$2&gt;');
   return highlightedString;

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -11,6 +11,7 @@ import { isChrome } from './useragent.js';
 import LocaleCurrency from 'locale-currency'
 import getSymbolFromCurrency from 'currency-symbol-map'
 import { parseLocale } from './utils.js';
+import escape from 'escape-html';
 
 export function address(profile) {
   if (!profile.address) {
@@ -550,16 +551,11 @@ export function highlightField(fieldValue, matchedSubstrings = []) {
     const { offset, length } = match;
     highlightedString = 
       highlightedString.substr(0, offset) +
-      `<mark>${fieldValue.substr(offset, length)}</mark>`+
+      `|mark|${fieldValue.substr(offset, length)}|/mark|`+
       highlightedString.substr(offset + length);
   });
 
-  /**
-   * Use regex with lookahead syntax to match all tags that's not <mark> or </mark> tag,
-   * and replace angle brackets with '&lt;' and '&gt;' to properly display them as non-html code.
-   * If matched, preserve the content ($2) inside but replace the surrounding angle brackets.
-   */
-  highlightedString = highlightedString.replace(/(<)((?!\/?mark)[^>]*)(>)/g,'&lt;$2&gt;');
+  highlightedString = escape(highlightedString).replace(/\|mark\|/g, '<mark>').replace(/\|\/mark\|/g, '</mark>');
   return highlightedString;
 }
 

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -540,7 +540,7 @@ export function priceRange(defaultPriceRange, countryCode) {
  *                                          highlight.
  */
 export function highlightField(fieldValue, matchedSubstrings = []) {
-  let highlightedString = fieldValue;
+  let highlightedString = fieldValue.replace(/</g,'&lt;').replace(/>/g,'&gt;');
 
   // We must first sort the matchedSubstrings by decreasing offset. 
   const sortedMatches = matchedSubstrings.slice()

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -545,7 +545,7 @@ export function highlightField(fieldValue, matchedSubstrings = []) {
 
   // We must first sort the matchedSubstrings by decreasing offset. 
   const sortedMatches = matchedSubstrings.slice()
-    .sort((match1, match2) => match2.offset - match1.offset);
+    .sort((match1, match2) => match1.offset - match2.offset);
   
   let processedFieldValueIndex = 0;
   sortedMatches.forEach(match => {

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -552,7 +552,7 @@ export function highlightField(fieldValue, matchedSubstrings = []) {
     const { offset, length } = match;
     highlightedString += escape(fieldValue.substring(processedFieldValueIndex, offset))
       + `<mark>${escape(fieldValue.substring(offset, offset + length))}</mark>`;
-      processedFieldValueIndex = offset + length;
+    processedFieldValueIndex = offset + length;
   });
   highlightedString += escape(fieldValue.substring(processedFieldValueIndex));
   return highlightedString;

--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -555,7 +555,7 @@ export function highlightField(fieldValue, matchedSubstrings = []) {
   });
 
   /**
-   * Use regex with uses lookahead syntax to match all tags that's not <mark> or </mark> tag,
+   * Use regex with lookahead syntax to match all tags that's not <mark> or </mark> tag,
    * and replace angle brackets with '&lt;' and '&gt;' to properly display them as non-html code.
    * If matched, preserve the content ($2) inside but replace the surrounding angle brackets.
    */

--- a/tests/static/js/formatters-internal/highlightField.js
+++ b/tests/static/js/formatters-internal/highlightField.js
@@ -1,0 +1,31 @@
+import Formatters from '../../../../static/js/formatters';
+const { highlightField } = Formatters;
+
+describe('highlightField properly handle snippets', () => {
+  it('snippet with empty matched substrings', () => {
+    const fieldValue = 'morbi tristique senectus et netus et malesuada fames ac turpis egestas.';
+    const matchedSubstrings = [];
+    expect(highlightField(fieldValue, matchedSubstrings)).toEqual(fieldValue);
+  });
+
+  it('snippet with matched substrings at end of field value', () => {
+    const fieldValue = 'morbi tristique senectus et netus et malesuada fames ac turpis egestas.';
+    const matchedSubstrings = [{offset: 56, length: 15}];
+
+    const expectedString = 'morbi tristique senectus et netus et malesuada fames ac <mark>turpis egestas.</mark>';
+    expect(highlightField(fieldValue, matchedSubstrings)).toEqual(expectedString);
+  });
+
+  it('handle snippet with non-html brackets and multiple matched substrings', () => {
+    const fieldValue = '... script>  some stuff 2</script> Joe Exotic was born Joseph Allen Schreibvogel in Garden City, '
+    + 'Kansas, on March 5, 1963.[6][7][8], to parents Francis and Shirley Schreibvogel.[9] He grew up on a working farm '
+    + 'in Kansas. <script>  some ampersand stuff & & </script> He was Joseph Allen Schreibvogel in Garden City ...';
+    const matchedSubstrings = [{offset: 144, length: 32}, {offset: 84, length: 19}];
+
+    const expectedString = '... script&gt;  some stuff 2&lt;/script&gt; Joe Exotic was born Joseph Allen Schreibvogel in'
+    + ' <mark>Garden City, Kansas</mark>, on March 5, 1963.[6][7][8], to parents <mark>Francis and Shirley Schreibvogel'
+    + '</mark>.[9] He grew up on a working farm in Kansas. &lt;script&gt;  some ampersand stuff &amp; &amp; &lt;/script&gt;'
+    + ' He was Joseph Allen Schreibvogel in Garden City ...';
+    expect(highlightField(fieldValue, matchedSubstrings)).toEqual(expectedString);
+  });
+});

--- a/tests/static/js/formatters-internal/highlightField.js
+++ b/tests/static/js/formatters-internal/highlightField.js
@@ -8,9 +8,17 @@ describe('highlightField properly handle snippets', () => {
     expect(highlightField(fieldValue, matchedSubstrings)).toEqual(fieldValue);
   });
 
+  it('snippet with matched substrings at beginning of field value', () => {
+    const fieldValue = 'morbi tristique senectus et netus et malesuada fames ac turpis egestas.';
+    const matchedSubstrings = [{ offset: 0, length: 5 }];
+
+    const expectedString = '<mark>morbi</mark> tristique senectus et netus et malesuada fames ac turpis egestas.';
+    expect(highlightField(fieldValue, matchedSubstrings)).toEqual(expectedString);
+  });
+
   it('snippet with matched substrings at end of field value', () => {
     const fieldValue = 'morbi tristique senectus et netus et malesuada fames ac turpis egestas.';
-    const matchedSubstrings = [{offset: 56, length: 15}];
+    const matchedSubstrings = [{ offset: 56, length: 15 }];
 
     const expectedString = 'morbi tristique senectus et netus et malesuada fames ac <mark>turpis egestas.</mark>';
     expect(highlightField(fieldValue, matchedSubstrings)).toEqual(expectedString);
@@ -20,7 +28,7 @@ describe('highlightField properly handle snippets', () => {
     const fieldValue = '... script>  some stuff 2</script> Joe Exotic was born Joseph Allen Schreibvogel in Garden City, '
     + 'Kansas, on March 5, 1963.[6][7][8], to parents Francis and Shirley Schreibvogel.[9] He grew up on a working farm '
     + 'in Kansas. <script>  some ampersand stuff & & </script> He was Joseph Allen Schreibvogel in Garden City ...';
-    const matchedSubstrings = [{offset: 144, length: 32}, {offset: 84, length: 19}];
+    const matchedSubstrings = [{ offset: 144, length: 32 }, { offset: 84, length: 19 }];
 
     const expectedString = '... script&gt;  some stuff 2&lt;/script&gt; Joe Exotic was born Joseph Allen Schreibvogel in'
     + ' <mark>Garden City, Kansas</mark>, on March 5, 1963.[6][7][8], to parents <mark>Francis and Shirley Schreibvogel'


### PR DESCRIPTION
- perform full HTML escape on the constructed highlighted text (will transform ", ', &, <, and >)
- `substr` is deprecated, replaced with `substring`

J=SLAP-1703
TEST=manual & auto

update bryan's entity description to include script tags, search for 'where is joe exotic' and see that the script tags appear. (without the replacement, they do not appear)
see added jest tests passed