### PR TITLE
Remove scrollbars from filters

### DIFF
--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -51,7 +51,7 @@ $container-width: 1000px;
   --yxt-searchbar-button-text-color-hover: var(--yxt-color-brand-primary);
   --yxt-filter-options-options-max-height: none;
   --yxt-filters-and-sorts-font-size: var(--yxt-font-size-md);
-  --yxt-filters-and-sorts-line-height: 20px;
+  --yxt-filters-option-label-line-height: 20px;
   --yxt-alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-semibold);
   --yxt-text-snippet-highlight-color: #eef3fb;
   --yxt-text-snippet-font-color: var(--yxt-color-text-primary);

--- a/static/scss/answers-variables.scss
+++ b/static/scss/answers-variables.scss
@@ -51,6 +51,7 @@ $container-width: 1000px;
   --yxt-searchbar-button-text-color-hover: var(--yxt-color-brand-primary);
   --yxt-filter-options-options-max-height: none;
   --yxt-filters-and-sorts-font-size: var(--yxt-font-size-md);
+  --yxt-filters-and-sorts-line-height: 20px;
   --yxt-alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-semibold);
   --yxt-text-snippet-highlight-color: #eef3fb;
   --yxt-text-snippet-font-color: var(--yxt-color-text-primary);

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -50,6 +50,7 @@ $container-width: 1000px;
   --yxt-searchbar-button-text-color-hover: var(--yxt-color-brand-primary);
   --yxt-filter-options-options-max-height: none;
   --yxt-filters-and-sorts-font-size: var(--yxt-font-size-md);
+  --yxt-filters-and-sorts-line-height: 20px;
   --yxt-alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-semibold);
   --yxt-text-snippet-highlight-color: #eef3fb;
   --yxt-text-snippet-font-color: var(--yxt-color-text-primary);

--- a/static/scss/answers/answers-variables-default.scss
+++ b/static/scss/answers/answers-variables-default.scss
@@ -50,7 +50,7 @@ $container-width: 1000px;
   --yxt-searchbar-button-text-color-hover: var(--yxt-color-brand-primary);
   --yxt-filter-options-options-max-height: none;
   --yxt-filters-and-sorts-font-size: var(--yxt-font-size-md);
-  --yxt-filters-and-sorts-line-height: 20px;
+  --yxt-filters-option-label-line-height: 20px;
   --yxt-alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-semibold);
   --yxt-text-snippet-highlight-color: #eef3fb;
   --yxt-text-snippet-font-color: var(--yxt-color-text-primary);

--- a/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
+++ b/static/scss/answers/collapsible-filters/sdk-filter-overrides.scss
@@ -23,8 +23,9 @@
     }
   
     &-options {
-      margin-top: 4px;
-      margin-bottom: 4px;
+      margin: 0;
+      padding-top: 4px;
+      padding-bottom: 4px;
       padding-left: 4px;
     }
   

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -192,7 +192,10 @@
   .yxt-FilterOptions-optionLabel,
   .yxt-SortOptions-optionLabel {
     font-size: var(--yxt-filters-and-sorts-font-size);
-    line-height: var(--yxt-filters-and-sorts-line-height);
+  }
+
+  .yxt-FilterOptions-optionLabel {
+    line-height: var(--yxt-filters-option-label-line-height);
   }
 
   .yxt-Card-child {

--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -192,6 +192,7 @@
   .yxt-FilterOptions-optionLabel,
   .yxt-SortOptions-optionLabel {
     font-size: var(--yxt-filters-and-sorts-font-size);
+    line-height: var(--yxt-filters-and-sorts-line-height);
   }
 
   .yxt-Card-child {


### PR DESCRIPTION
Change styling of `yxt-FilterOptions-options` to remove scrollbars that were appearing on filters even when all options were displayed for some cases with custom font sizes. Add a `--yxt-filters-and-sorts-line-height` variable so that customers can change the line-height of the `optionLabel` easily if the scrollbar appears with even larger custom font sizes.

J=SLAP-1727
TEST=visual

See that filter scrollbar was removed on a site where it was previously appearing.