### PR TITLE
Fix font preloads on multilang sites

### DIFF
--- a/layouts/preload-fonts.hbs
+++ b/layouts/preload-fonts.hbs
@@ -1,5 +1,5 @@
 <!-- Preload the SourceSans fonts used by default in the Theme -->
-<link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-300.woff" type="font/woff" crossorigin="anonymous">
-<link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-600.woff" type="font/woff" crossorigin="anonymous">
-<link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-700.woff" type="font/woff" crossorigin="anonymous">
-<link rel="preload" as="font" href="{{relativePath}}/static/assets/fonts/source-sans-pro-v14-latin-regular.woff" type="font/woff" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{relativePath}}/source-sans-pro-v14-latin-300.woff" type="font/woff" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{relativePath}}/source-sans-pro-v14-latin-600.woff" type="font/woff" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{relativePath}}/source-sans-pro-v14-latin-700.woff" type="font/woff" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{relativePath}}/source-sans-pro-v14-latin-regular.woff" type="font/woff" crossorigin="anonymous">

--- a/static/webpack-config.js
+++ b/static/webpack-config.js
@@ -144,41 +144,10 @@ module.exports = function () {
           ],
         },
         {
-          test: /\.html$/i,
-          use: [
-            {
-              loader: 'html-loader',
-              options: {
-                sources: {
-                  list: [
-                    {
-                      tag: 'link',
-                      attribute: 'href',
-                      type: 'src',
-                      filter: (tag, attribute, attributes) => {
-                        const isPreload = attributes.find(attr => {
-                          return attr.name === 'rel' && attr.value === 'preload';
-                        });
-                        const isFont = attributes.find(attr => {
-                          return attr.name === 'as' && attr.value === 'font';
-                        });
-                        return isPreload && isFont;
-                      }
-                    }
-                  ],
-                  urlFilter: (attribute, value) => {
-                    return /^[./]*static\/assets\//.test(value);
-                  }
-                },
-              }
-            }
-          ]
-        },
-        {
           test: /\.(png|ico|gif|jpe?g|svg|webp|eot|otf|ttf|woff2?)$/,
           type: 'asset/resource',
           generator: {
-            filename: '[name].[hash].[ext]'
+            filename: '[name][ext]'
           }
         }
       ],


### PR DESCRIPTION
Fix font preloads on multilang sites and no longer generate a hash for fonts

When webpack was processing the preload tags to update them to use the hash, it was dropping the relative path which jambo was adding which caused the preloads to point to invalid links on multilang sites. I couldn't find an option to adjust the path names after webpack processed it, so the simpler solution is to remove the hashes from the fonts. That way webpack will no longer need to update the font preloads and we can instead rely on the relative path provided by Jambo.
 
There was an additional bug where we had an extra dot in the font names. (e.g. source-sans..woff), and this change fixes that as well.

Because we are removing the hash, that makes it more difficult to cache bust it. If someone uses a new font file and names it exactly the same as one of the previous fonts, they cache will return the old asset. The current font names are so specific that I find this unlikely to be a problem (e.g. source-sans-pro-v14-latin-300.woff). 

J=SLAP-1724
TEST=manual

Check the network tab for font loads on english experiences and on multilang pages. Check both universal and vertical pages and observe that the error in the console about invalid font preloads is gone for multilang sites. See that the loaded font no longer has an extra dot before the extension.