### PR TITLE
Fix handling of the `universalLimit` in `verticalsToConfig`.

### DIFF
--- a/hbshelpers/getDefaultUniversalLimit.js
+++ b/hbshelpers/getDefaultUniversalLimit.js
@@ -9,15 +9,15 @@
  */
  module.exports = function getDefaultUniversalLimit(pageConfigs) {
   const universalLimit = Object.entries(pageConfigs)
-    .filter(([key, _]) => key != 'index')
-    .reduce((limit, [_, config]) => {
-      const verticalKey = config.verticalKey;
+    .filter(([pageName, _]) => pageName != 'index')
+    .reduce((limit, [_, pageConfig]) => {
+      const verticalKey = pageConfig.verticalKey;
       const hasUniversalLimit = 
-        config.verticalsToConfig &&
-        config.verticalsToConfig[verticalKey] &&
-        config.verticalsToConfig[verticalKey].universalLimit;
+        pageConfig.verticalsToConfig &&
+        pageConfig.verticalsToConfig[verticalKey] &&
+        pageConfig.verticalsToConfig[verticalKey].universalLimit;
       if (hasUniversalLimit) {
-        limit[verticalKey] = config.verticalsToConfig[verticalKey].universalLimit;
+        limit[verticalKey] = pageConfig.verticalsToConfig[verticalKey].universalLimit;
       }
 
       return limit;

--- a/hbshelpers/getDefaultUniversalLimit.js
+++ b/hbshelpers/getDefaultUniversalLimit.js
@@ -5,7 +5,7 @@
  * be used.
  * 
  * @param {Object} pageConfigs - The configurations for each page.
- * @returns {Object} The default search.universalLimit for the page.
+ * @returns {Object} The partial of the search configuration related to universal limits.
  */
  module.exports = function getDefaultUniversalLimit(pageConfigs) {
   const universalLimit = Object.entries(pageConfigs)

--- a/hbshelpers/getDefaultUniversalLimit.js
+++ b/hbshelpers/getDefaultUniversalLimit.js
@@ -10,9 +10,13 @@
  module.exports = function getDefaultUniversalLimit(pageConfigs) {
   const universalLimit = Object.entries(pageConfigs)
     .filter(([key, _]) => key != 'index')
-    .reduce((limit, [key, config]) => {
+    .reduce((limit, [_, config]) => {
       const verticalKey = config.verticalKey;
-      if (config.verticalsToConfig?.[verticalKey]?.universalLimit) {
+      const hasUniversalLimit = 
+        config.verticalsToConfig &&
+        config.verticalsToConfig[verticalKey] &&
+        config.verticalsToConfig[verticalKey].universalLimit;
+      if (hasUniversalLimit) {
         limit[verticalKey] = config.verticalsToConfig[verticalKey].universalLimit;
       }
 

--- a/hbshelpers/getDefaultUniversalLimit.js
+++ b/hbshelpers/getDefaultUniversalLimit.js
@@ -1,0 +1,9 @@
+module.exports = function getDefaultUniversalLimit(verticalsToConfig) {
+  return Object.entries().reduce(([key, config], limit) => {
+    if (config.universalLimit) {
+      limit[key] = config.universalLimit;
+    }
+
+    return limit;
+  }, {});
+}

--- a/hbshelpers/getDefaultUniversalLimit.js
+++ b/hbshelpers/getDefaultUniversalLimit.js
@@ -1,9 +1,23 @@
-module.exports = function getDefaultUniversalLimit(verticalsToConfig) {
-  return Object.entries().reduce(([key, config], limit) => {
-    if (config.universalLimit) {
-      limit[key] = config.universalLimit;
-    }
+/**
+ * Generates a default result limit for each vertical on the universal page. The
+ * default is taken from the vertical's `universalLimit`, specified in the related
+ * page's VTC. If there is no such `universalLimit`, the back-end default of 10 will
+ * be used.
+ * 
+ * @param {Object} pageConfigs - The configurations for each page.
+ * @returns {Object} The default search.universalLimit for the page.
+ */
+ module.exports = function getDefaultUniversalLimit(pageConfigs) {
+  const universalLimit = Object.entries(pageConfigs)
+    .filter(([key, _]) => key != 'index')
+    .reduce((limit, [key, config]) => {
+      const verticalKey = config.verticalKey;
+      if (config.verticalsToConfig?.[verticalKey]?.universalLimit) {
+        limit[verticalKey] = config.verticalsToConfig[verticalKey].universalLimit;
+      }
 
-    return limit;
-  }, {});
+      return limit;
+    }, {});
+
+    return { universalLimit };
 }

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -25,6 +25,7 @@
         {{#if verticalLimit}}
           search: {
             limit: {{verticalLimit}},
+            {{> getDefaultUniversalLimit verticalsToConfig=verticalsToConfig }},
             ...{{{ json search }}}
           },
         {{/if}}

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -25,10 +25,15 @@
         {{#if verticalLimit}}
           search: {
             limit: {{verticalLimit}},
-            {{> getDefaultUniversalLimit verticalsToConfig=verticalsToConfig }},
             ...{{{ json search }}}
           },
         {{/if}}
+        {{#unless ../verticalKey}}
+          search: {
+            ...{{{ json (getDefaultUniversalLimit ../verticalConfigs) }}},
+            ...{{{ json search }}}
+          },
+        {{/unless}}
       {{/with}}
     };
     const token = window.AnswersExperience.runtimeConfig?.get('token');

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -88,19 +88,6 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
       pin: {{> templates/universal-standard/script/map-pin mapConfig }},
     }),
   {{/if}}
-  {{#if universalLimit}}
-    transformData: (data) => {
-      let results = data.results;
-      if (results) {
-        results = results.filter((rex, idx) => {
-          return idx < {{{universalLimit}}};
-        });
-      }
-      return Object.assign(data, {
-        results: results
-      });
-    },
-  {{/if}}
 {{/inline}}
 
 {{!--


### PR DESCRIPTION
Previously, if a `universalLimit` were specified for a vertical, we would perform client-side filtering. Instead, we should be creating a `search.universalLimit` object and passing that to `ANSWERS.init`. Not only does this remove responsibility from the front-end, but it allows the HH to display more than 10 results per vertical on the Universal page.

This PR adds a `getDefaultUniversalLimit` helper that iterates through the vertical page configs and uses the `verticalsToConfig.universalLimits` to build a `search.universalLimit`. 

J=SLAP-1749
TEST=manual

Tested the following scenarios and verified correct behavior in each:

- No `universalLimit` values are set and there is no limit specified in the `global_config` or `pageSettings`.
- Some `universalLimit` values are set, but not others. There is no universal limit in the `global_config` or `pageSettings`.
- Some `universalLimit` values are set, but a universal limit is also present in the `global_config`.