### PR TITLE
Testcafe Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "puppeteer": "^10.2.0",
         "serve": "^11.3.2",
         "simple-git": "^2.24.0",
-        "testcafe": "^1.17.0",
+        "testcafe": "^1.17.1",
         "testcafe-browser-provider-browserstack": "^1.13.1",
         "underscore.string": "^3.3.5",
         "urijs": "1.18.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.1",
         "@babel/core": "^7.9.6",
@@ -34,7 +34,7 @@
         "puppeteer": "^10.2.0",
         "serve": "^11.3.2",
         "simple-git": "^2.24.0",
-        "testcafe": "^1.15.0",
+        "testcafe": "^1.17.0",
         "testcafe-browser-provider-browserstack": "^1.13.1",
         "underscore.string": "^3.3.5",
         "urijs": "1.18.12",
@@ -3474,6 +3474,15 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
     },
+    "node_modules/@miherlosev/esm": {
+      "version": "3.2.26",
+      "resolved": "https://registry.npmjs.org/@miherlosev/esm/-/esm-3.2.26.tgz",
+      "integrity": "sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -4691,9 +4700,9 @@
       }
     },
     "node_modules/acorn-hammerhead": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.4.0.tgz",
-      "integrity": "sha512-zMjPa6kNgMB0zclCZI41sPofSeeHMF9Q6e3ALRsowmmNqoiz1qiJI9oemt9GfZ5e5EmQpElvePT3AVcLU3AzHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.5.0.tgz",
+      "integrity": "sha512-TI9TFfJBfduhcM2GggayNhdYvdJ3UgS/Bu3sB7FB2AUmNCmCJ+TSOT6GXu+bodG5/xL74D5zE4XRaqyjgjsYVQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "0.0.46"
@@ -5211,6 +5220,12 @@
         "@types/glob": "^7.1.1"
       }
     },
+    "node_modules/asar/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "node_modules/asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -5255,6 +5270,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
+      "integrity": "sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=",
+      "dev": true
     },
     "node_modules/async-exit-hook": {
       "version": "1.1.2",
@@ -6561,10 +6582,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/comment-json": {
       "version": "4.1.1",
@@ -7037,13 +7061,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -12240,23 +12271,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/puppeteer/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/puppeteer/node_modules/https-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -13394,23 +13408,6 @@
         "debug": "^4.3.1"
       }
     },
-    "node_modules/simple-git/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -14074,9 +14071,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.0.tgz",
-      "integrity": "sha512-wzuNLXW40UuzlTnI0/m8IFEKuwMM1Vt1IE5jWC8fAbJ6PPjFyM5HyC6Rn8gA0dwe4Bn1IhoybaQezS8tpIkcdg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.17.1.tgz",
+      "integrity": "sha512-G+IqL28PE9wzNKcLjLCjX3z3/KXpzNs0FNC63Y7dXcXx23qlx+yz+Abyh91CIzeiwtXDZX+xMXDYYLtPQLfhlQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.1",
@@ -14084,6 +14081,7 @@
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-proposal-decorators": "^7.12.1",
         "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+        "@babel/plugin-proposal-private-methods": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-transform-async-to-generator": "^7.12.1",
@@ -14094,6 +14092,7 @@
         "@babel/preset-flow": "^7.12.1",
         "@babel/preset-react": "^7.12.1",
         "@babel/runtime": "^7.12.5",
+        "@miherlosev/esm": "3.2.26",
         "@types/node": "^12.20.10",
         "async-exit-hook": "^1.1.2",
         "babel-plugin-module-resolver": "^4.0.0",
@@ -14106,7 +14105,7 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^2.8.1",
+        "commander": "^8.0.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
@@ -14152,9 +14151,9 @@
         "semver": "^5.6.0",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.15",
-        "testcafe-hammerhead": "24.3.1",
-        "testcafe-legacy-api": "5.0.2",
+        "testcafe-browser-tools": "2.0.16",
+        "testcafe-hammerhead": "24.5.7",
+        "testcafe-legacy-api": "5.1.2",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -14215,12 +14214,13 @@
       }
     },
     "node_modules/testcafe-browser-tools": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.15.tgz",
-      "integrity": "sha512-bzkh5B1+Ws/I3YZL+9M4TSUq3aAewjvF2oue2l7T7eROIvqwPDE22ZFfPuLew6VIZcotCFZj432s1EgJDFyH7g==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.16.tgz",
+      "integrity": "sha512-JljbS0FboABksIMEH1L7P4ZdI82AQ8saWb/7WsxkDCOtDuHID5ZSEb/w9tqLN1+4BQaCgS5veN3lWUnfb0saEA==",
       "dev": true,
       "dependencies": {
         "array-find": "^1.0.0",
+        "debug": "^4.3.1",
         "dedent": "^0.7.0",
         "del": "^5.1.0",
         "execa": "^3.3.0",
@@ -14252,6 +14252,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/testcafe-browser-tools/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/testcafe-browser-tools/node_modules/dedent": {
@@ -14334,12 +14351,15 @@
       }
     },
     "node_modules/testcafe-browser-tools/node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/testcafe-browser-tools/node_modules/nanoid": {
@@ -14412,12 +14432,12 @@
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.3.1.tgz",
-      "integrity": "sha512-c6eoxfEeLN47/2ToVKP7n8jupUtZijMjIBhhAiVW4HqZ2v+9GNn6wH8GKyWbsmov0hacaYMEvp4mwehJstKjxg==",
+      "version": "24.5.7",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.7.tgz",
+      "integrity": "sha512-4pY6GQQaCZAlOolWB2vaYZ/MIpgtmOrZeh4BVbENkbh6DDiPeOxvC0K6yZS5JfINRau5S9mzuNkm2FS7G0urSA==",
       "dev": true,
       "dependencies": {
-        "acorn-hammerhead": "0.4.0",
+        "acorn-hammerhead": "0.5.0",
         "asar": "^2.0.1",
         "bowser": "1.6.0",
         "brotli": "^1.3.1",
@@ -14452,23 +14472,6 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
       "integrity": "sha1-N/w4e2Fstq7zcNq01r1AK3TFxU0=",
       "dev": true
-    },
-    "node_modules/testcafe-hammerhead/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/testcafe-hammerhead/node_modules/iconv-lite": {
       "version": "0.5.1",
@@ -14564,9 +14567,9 @@
       }
     },
     "node_modules/testcafe-legacy-api": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.0.2.tgz",
-      "integrity": "sha512-2BWjCIN5YOUOTyOT4B0wy2TiaJgV8dWhIGpKqE3S34RjNEH62WR+JNhcnh4BSE+btp6H8n1TefcP/AObqSDSDQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.1.2.tgz",
+      "integrity": "sha512-vc9A4rFUdijlBFnNOVMk0hFfxnrAmtA7FMz1P/LtvNyui5JfkLmbyIQcJbxR2rjTINp0owZ2c+xQvYms/us7Fw==",
       "dev": true,
       "dependencies": {
         "async": "0.2.6",
@@ -14584,12 +14587,6 @@
         "strip-bom": "^2.0.0",
         "testcafe-hammerhead": ">=19.4.0"
       }
-    },
-    "node_modules/testcafe-legacy-api/node_modules/async": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
-      "integrity": "sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=",
-      "dev": true
     },
     "node_modules/testcafe-legacy-api/node_modules/dedent": {
       "version": "0.6.0",
@@ -20098,6 +20095,12 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
     },
+    "@miherlosev/esm": {
+      "version": "3.2.26",
+      "resolved": "https://registry.npmjs.org/@miherlosev/esm/-/esm-3.2.26.tgz",
+      "integrity": "sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -21091,9 +21094,9 @@
       }
     },
     "acorn-hammerhead": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.4.0.tgz",
-      "integrity": "sha512-zMjPa6kNgMB0zclCZI41sPofSeeHMF9Q6e3ALRsowmmNqoiz1qiJI9oemt9GfZ5e5EmQpElvePT3AVcLU3AzHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.5.0.tgz",
+      "integrity": "sha512-TI9TFfJBfduhcM2GggayNhdYvdJ3UgS/Bu3sB7FB2AUmNCmCJ+TSOT6GXu+bodG5/xL74D5zE4XRaqyjgjsYVQ==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.46"
@@ -21512,6 +21515,14 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "tmp-promise": "^1.0.5"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        }
       }
     },
     "asn1": {
@@ -21545,6 +21556,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "async": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
+      "integrity": "sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=",
       "dev": true
     },
     "async-exit-hook": {
@@ -22590,9 +22607,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true
     },
     "comment-json": {
@@ -22999,12 +23016,12 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -27184,15 +27201,6 @@
             "debug": "4"
           }
         },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "https-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -28110,17 +28118,6 @@
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
         "debug": "^4.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "sisteransi": {
@@ -28659,9 +28656,9 @@
       }
     },
     "testcafe": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.0.tgz",
-      "integrity": "sha512-wzuNLXW40UuzlTnI0/m8IFEKuwMM1Vt1IE5jWC8fAbJ6PPjFyM5HyC6Rn8gA0dwe4Bn1IhoybaQezS8tpIkcdg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.17.1.tgz",
+      "integrity": "sha512-G+IqL28PE9wzNKcLjLCjX3z3/KXpzNs0FNC63Y7dXcXx23qlx+yz+Abyh91CIzeiwtXDZX+xMXDYYLtPQLfhlQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.1",
@@ -28669,6 +28666,7 @@
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-proposal-decorators": "^7.12.1",
         "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+        "@babel/plugin-proposal-private-methods": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-transform-async-to-generator": "^7.12.1",
@@ -28679,6 +28677,7 @@
         "@babel/preset-flow": "^7.12.1",
         "@babel/preset-react": "^7.12.1",
         "@babel/runtime": "^7.12.5",
+        "@miherlosev/esm": "3.2.26",
         "@types/node": "^12.20.10",
         "async-exit-hook": "^1.1.2",
         "babel-plugin-module-resolver": "^4.0.0",
@@ -28691,7 +28690,7 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^2.8.1",
+        "commander": "^8.0.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
@@ -28737,9 +28736,9 @@
         "semver": "^5.6.0",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.15",
-        "testcafe-hammerhead": "24.3.1",
-        "testcafe-legacy-api": "5.0.2",
+        "testcafe-browser-tools": "2.0.16",
+        "testcafe-hammerhead": "24.5.7",
+        "testcafe-legacy-api": "5.1.2",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -29979,12 +29978,13 @@
       }
     },
     "testcafe-browser-tools": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.15.tgz",
-      "integrity": "sha512-bzkh5B1+Ws/I3YZL+9M4TSUq3aAewjvF2oue2l7T7eROIvqwPDE22ZFfPuLew6VIZcotCFZj432s1EgJDFyH7g==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.16.tgz",
+      "integrity": "sha512-JljbS0FboABksIMEH1L7P4ZdI82AQ8saWb/7WsxkDCOtDuHID5ZSEb/w9tqLN1+4BQaCgS5veN3lWUnfb0saEA==",
       "dev": true,
       "requires": {
         "array-find": "^1.0.0",
+        "debug": "^4.3.1",
         "dedent": "^0.7.0",
         "del": "^5.1.0",
         "execa": "^3.3.0",
@@ -30010,6 +30010,15 @@
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "dedent": {
@@ -30074,9 +30083,9 @@
           "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "nanoid": {
@@ -30133,12 +30142,12 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.3.1.tgz",
-      "integrity": "sha512-c6eoxfEeLN47/2ToVKP7n8jupUtZijMjIBhhAiVW4HqZ2v+9GNn6wH8GKyWbsmov0hacaYMEvp4mwehJstKjxg==",
+      "version": "24.5.7",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.7.tgz",
+      "integrity": "sha512-4pY6GQQaCZAlOolWB2vaYZ/MIpgtmOrZeh4BVbENkbh6DDiPeOxvC0K6yZS5JfINRau5S9mzuNkm2FS7G0urSA==",
       "dev": true,
       "requires": {
-        "acorn-hammerhead": "0.4.0",
+        "acorn-hammerhead": "0.5.0",
         "asar": "^2.0.1",
         "bowser": "1.6.0",
         "brotli": "^1.3.1",
@@ -30170,15 +30179,6 @@
           "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
           "integrity": "sha1-N/w4e2Fstq7zcNq01r1AK3TFxU0=",
           "dev": true
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
         },
         "iconv-lite": {
           "version": "0.5.1",
@@ -30264,9 +30264,9 @@
       }
     },
     "testcafe-legacy-api": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.0.2.tgz",
-      "integrity": "sha512-2BWjCIN5YOUOTyOT4B0wy2TiaJgV8dWhIGpKqE3S34RjNEH62WR+JNhcnh4BSE+btp6H8n1TefcP/AObqSDSDQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.1.2.tgz",
+      "integrity": "sha512-vc9A4rFUdijlBFnNOVMk0hFfxnrAmtA7FMz1P/LtvNyui5JfkLmbyIQcJbxR2rjTINp0owZ2c+xQvYms/us7Fw==",
       "dev": true,
       "requires": {
         "async": "0.2.6",
@@ -30285,12 +30285,6 @@
         "testcafe-hammerhead": ">=19.4.0"
       },
       "dependencies": {
-        "async": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
-          "integrity": "sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=",
-          "dev": true
-        },
         "dedent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "puppeteer": "^10.2.0",
     "serve": "^11.3.2",
     "simple-git": "^2.24.0",
-    "testcafe": "^1.15.0",
+    "testcafe": "^1.17.0",
     "testcafe-browser-provider-browserstack": "^1.13.1",
     "underscore.string": "^3.3.5",
     "urijs": "1.18.12",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "puppeteer": "^10.2.0",
     "serve": "^11.3.2",
     "simple-git": "^2.24.0",
-    "testcafe": "^1.17.0",
+    "testcafe": "^1.17.1",
     "testcafe-browser-provider-browserstack": "^1.13.1",
     "underscore.string": "^3.3.5",
     "urijs": "1.18.12",

--- a/tests/acceptance/index.js
+++ b/tests/acceptance/index.js
@@ -31,7 +31,7 @@ runTests(argv.browsers, argv.concurrency);
  */
 async function runTests (browsers, concurrency) {
   const testcafe = await createTestCafe({
-    configFile: './testcafe.json'
+    configFile: './tests/acceptance/testcafe.json'
   });
   try {
     const numberTestsFailed = await testcafe.createRunner()


### PR DESCRIPTION
Fix Testcafe errors in safari by bumping the Testcafe version number

This PR fixes the "undefined is not an object (evaluating 'qa.objectHasOwnProperty.call(s,"writable")') hasOwnProperty@[native code]" error which was occurring in Testcafe on Safari.

Also fix the path to the testcafe config file.

J=none
TEST=none

Run the acceptance tests and see that they now pass
