### PR TITLE
Add Locator support for the Job Entity Type

### DIFF
--- a/cards/location-standard/component.js
+++ b/cards/location-standard/component.js
@@ -28,7 +28,7 @@ class location_standardCardComponent extends BaseCard['location-standard'] {
       // subtitle: '', // The sub-header text of the card
       hours: Formatter.openStatus(profile),
       // services: [], // Used for a comma delimited list of services for the location
-      address: Formatter.address(profile), // The address for the card
+      address: Formatter.address(profile) || profile.locationString || '', // The address for the card
       phone: Formatter.nationalizedPhoneDisplay(profile), // The phone number for the card
       phoneEventOptions: this.addDefaultEventOptions(), // The analytics event options for phone clicks
       distance: Formatter.toLocalizedDistance(profile), // Distance from the user’s or inputted location

--- a/static/js/theme-map/Renderer/MapRenderTarget.js
+++ b/static/js/theme-map/Renderer/MapRenderTarget.js
@@ -83,8 +83,12 @@ class MapRenderTarget extends RenderTarget {
     Object.values(this._pins).forEach(pin => pin.remove());
     this._pins = {};
 
-    (data.response.entities || []).forEach((entity, index) =>
-      this._pins[this._idForEntity(entity)] = this._pinBuilder(this._map.newPinOptions(), entity, index + 1)
+    (data.response.entities || []).forEach((entity, index) => {
+      const pin = this._pinBuilder(this._map.newPinOptions(), entity, index + 1);
+      if (pin) {
+        this._pins[this._idForEntity(entity)] = pin;
+      }
+    }
     );
 
     const pins = Object.values(this._pins);

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -345,7 +345,7 @@ class ThemeMap extends ANSWERS.Component {
     const defaultPin = this.config.pinImages.getDefaultPin(index, entity.profile);
     const hoveredPin = this.config.pinImages.getHoveredPin(index, entity.profile);
     const selectedPin = this.config.pinImages.getSelectedPin(index, entity.profile);
-    const entityCoordinate = entity.profile.yextDisplayCoordinate ?? entity.profile.displayCoordinate;
+    const entityCoordinate = entity.profile.yextDisplayCoordinate;
     if (!entityCoordinate) {
       return null;
     }

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -219,7 +219,8 @@ class ThemeMap extends ANSWERS.Component {
         }
 
         if (!pins[id]) {
-          throw new Error(`A pin with the id ${id} could not be found on the map.`);
+          console.warn(`A pin with the id ${id} could not be found on the map.`);
+          return;
         }
 
         if (this.config.enablePinClustering && pinClusterer) {
@@ -328,9 +329,26 @@ class ThemeMap extends ANSWERS.Component {
    */
   buildPin(pinOptions, entity, index) {
     const id = 'js-yl-' + entity.profile.meta.id;
+    const cardFocusUpdateListener = {
+      eventType: 'update',
+      storageKey: StorageKeys.LOCATOR_CARD_FOCUS,
+      callback: (data) => {
+        const cardIndex = data.index;
+        if (cardIndex + 1 === index) {
+          this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, id);
+        }
+      }
+    };
+    this.resultsSpecificStorageListeners.push(cardFocusUpdateListener);
+    this.core.storage.registerListener(cardFocusUpdateListener);
+    
     const defaultPin = this.config.pinImages.getDefaultPin(index, entity.profile);
     const hoveredPin = this.config.pinImages.getHoveredPin(index, entity.profile);
     const selectedPin = this.config.pinImages.getSelectedPin(index, entity.profile);
+    const entityCoordinate = entity.profile.yextDisplayCoordinate ?? entity.profile.displayCoordinate;
+    if (!entityCoordinate) {
+      return null;
+    }
     const pin = pinOptions
       .withId(id)
       .withIcon(
@@ -343,7 +361,7 @@ class ThemeMap extends ANSWERS.Component {
         'selected',
         getEncodedSvg(selectedPin.svg))
       .withHideOffscreen(false)
-      .withCoordinate(new Coordinate(entity.profile.yextDisplayCoordinate))
+      .withCoordinate(new Coordinate(entityCoordinate))
       .withPropertiesForStatus(status => {
         const properties = new PinProperties()
           .setIcon(status.selected ? 'selected' : ((status.hovered || status.focused) ? 'hovered' : 'default'))
@@ -365,18 +383,6 @@ class ThemeMap extends ANSWERS.Component {
       })
       .build();
 
-    const cardFocusUpdateListener = {
-      eventType: 'update',
-      storageKey: StorageKeys.LOCATOR_CARD_FOCUS,
-      callback: (data) => {
-        const cardIndex = data.index;
-        if (cardIndex + 1 === index) {
-          this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, id);
-        }
-      }
-    };
-    this.resultsSpecificStorageListeners.push(cardFocusUpdateListener);
-    this.core.storage.registerListener(cardFocusUpdateListener);
     pin.setClickHandler(() => this.config.pinFocusListener(index, id));
     pin.setFocusHandler(() => this.config.pinFocusListener(index, id));
     pin.setHoverHandler(hovered => this.core.storage.set(

--- a/static/js/theme-map/Util/transformers.js
+++ b/static/js/theme-map/Util/transformers.js
@@ -9,7 +9,7 @@ const transformDataToUniversalData = (data) => {
       ...marker.item,
       meta: {
         accountId: '',
-        countryCode: marker.item.address.countryCode,
+        countryCode: marker.item.address?.countryCode || '',
         entityType: marker.item.type,
         folderId: '',
         id: marker.item.id,
@@ -37,7 +37,7 @@ const transformDataToVerticalData = (data) => {
       ...ent._raw,
       meta: {
         accountId: '',
-        countryCode: ent._raw.address.countryCode,
+        countryCode: ent._raw.address?.countryCode || '',
         entityType: ent._raw.type,
         folderId: '',
         id: ent.id,


### PR DESCRIPTION
Update ThemeMap to support coordinate and pin constructions based on data from job entity type. 
- update transformDataToUniversalData and transformDataToVerticalData to guard access to countryCode field since job entity will not have the address field like location entity.
- update ThemeMap to NOT construct pin if entity doesn't have `entity.profile.yextDisplayCoordinate`. 
   - Note: job entity may include only mapMarker field without a location field. This would not give us `entity.profile.yextDisplayCoordinate` but instead in `entity.profile.displayCoordinate`. Product only wants display from `entity.profile.yextDisplayCoordinate` for now.
- move cardFocusUpdateListener up to make sure selecting cards that doesn't have pin would still deselect previously selected pin

J=SLAP-1744
TEST=manual

Added some more job entities into knowledge graph: some with location field, some with map marker, some without any location or map marker:
- test with `locations_full_page_map` page with verticalKey: 'jobs' and cardName: 'location-standard'
  - See no errors in console.
  - Click on cards and pins. See that cards with corresponding pins work as normal. See that cards without pins would still highlight the card but unhighlight the previous selected pin.
  - Drag map arounds and see that only cards with pins shows up when rerender
  - modify pin to display index number, see that the index displayed is correct corresponding to the ordinal number of the cards
- test with `locations_full_page_map` page with verticalKey: 'jobs' and cardName: 'job-standard'
  - see no errors in console. 
  - pins still work as expected
- test with `locations_full_page_map` page with verticalKey: 'KM' and cardName: 'location-standard'
  - smoke test the page with location entities to confirm that it still work as expected with clusters and non clusters pins 
 - test with  job entities on other pages: 
   - `locations_full_page_map_with_filters`: no errors, pins and cards show up and can be selected as expected
   -  `locations_google` and `locations` (uses map from SDK): no errors, pins and cards show up
       - NOTE: SDK map component currently will NOT have the right the pin ordering with the card ordinal numbers if there are cards created from job entity without location field. This will be investigated in another item