### PR TITLE
Stop default universal map scrolling

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -82,6 +82,9 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
     mapConfig: Object.assign({
       apiKey: HitchhikerJS.getDefaultMapApiKey("{{ mapConfig.mapProvider }}")
     },
+    {"providerOptions": {
+      "scrollZoom": false
+    }},
     {{{ json mapConfig }}},
     {{!-- This theme pin config must come after mapConfig in Object.assign --}}
     {

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -82,8 +82,9 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
     mapConfig: Object.assign({
       apiKey: HitchhikerJS.getDefaultMapApiKey("{{ mapConfig.mapProvider }}")
     },
-    {"providerOptions": {
-      "scrollZoom": false
+    {
+      "providerOptions": {
+        "scrollZoom": false
     }},
     {{{ json mapConfig }}},
     {{!-- This theme pin config must come after mapConfig in Object.assign --}}

--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -85,7 +85,8 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
     {
       "providerOptions": {
         "scrollZoom": false
-    }},
+      }
+    },
     {{{ json mapConfig }}},
     {{!-- This theme pin config must come after mapConfig in Object.assign --}}
     {


### PR DESCRIPTION
Set the default to off for map zoom while scrolling for maps on the universal search page. This was a problem for MapBox maps, because scrolling on the universal page would scroll in the map when the cursor was in the map, which was not ideal behavior.

Note: a [PR](https://github.com/yext/answers-search-ui/pull/1648) in the SDK added zoom control buttons for MapBox by default so that the map can still be zoomed if desired.

J=SLAP-1765
TEST=manual

Check that scrolling does not zoom the map on universal pages, but vertical pages are unchanged. Check that this can be switched back on if `scrollZoom` is set to true in the config