### PR TITLE
close autocomplete on click in parent window

### DIFF
--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -145,6 +145,10 @@
             HitchhikerJS.RuntimeConfigReceiver.handle(message.runtimeConfig);
           } else if (window.isOverlay) {
             window.Overlay.onMessage(message);
+          } else if (message.eventType && message.eventType === 'click') {
+            ANSWERS.components._activeComponents
+              .filter(component => component.name === 'SearchBar.autocomplete')
+              .forEach(autocompleteComponent => autocompleteComponent.close());
           }
         }
       };

--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -87,6 +87,13 @@ export function generateIFrame(domain, answersExperienceFrame) {
 
   containerEl.appendChild(iframe);
 
+  // Notify iframe of a click event on parent window
+  document.addEventListener('click', e => {
+    if (e.isTrusted) {
+      sendToIframe({ eventType: e.type });
+    }
+  });
+
   // For dynamic iFrame resizing
   iFrameResize({
     checkOrigin: false,


### PR DESCRIPTION
close autocomplete on click in parent window by sending message from parent window to iframe using iFrameResizer library


in iframe-common.js, run by parent page, add an event listener to the document for click event. When trigger, check if the event is trusted (invoke by user, not external script) and send a message to iframe. In html.hbs, run by iframe, modify onMessage function in iframeResizer to check for message that contains event type 'click'. If so, get all active autocomplete components and invoke their close function.

J=SLAP-1182
TEST=manual

host a site in SGS with a page that uses iframe.js from localhost port (with the pr changes) for cross-origin test. Also modify page to have multiple search bar. See that autocomplete closes when click outside of iframe.