### PR TITLE
Integrate with Yext Sites

### DIFF
--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -1,0 +1,24 @@
+{
+  "artifactStructure": {
+      "assets": [
+          {
+              "root": "test-site/public"
+          }
+      ],
+      "hbsTemplates": []
+  },
+  "base_image_tag": "node-12.18",
+  "dependencies": {
+      "installDepsCmd": "npm install",
+      "requiredFiles": []
+  },
+  "buildArtifacts": {
+      "build_setup_cmd": "npm install && ./test-site/scripts/setup_for_yext_sites.sh",
+      "build_cmd": "npm run setup-test-site && npm run build-test-site"
+  },
+  "livePreview": {
+      "serve_setup_cmd": "npm run setup-test-site && npm run build-test-site",
+      "serve_cmd": "npx serve -l 8080 test-site/public"
+  },
+  "watch_cmd": "npm run watch"
+}

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -17,7 +17,7 @@
       "build_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site"
   },
   "livePreview": {
-      "serve_setup_cmd": "npm run build-test-site",
+      "serve_setup_cmd": "mkdir -p /temp/theme && mv * /temp/theme && mkdir answers-hitchhiker-theme && mv /temp/theme/sites-config . && mv /temp/theme/* answers-hitchhiker-theme && npm run build-test-site",
       "serve_cmd": "npx serve -l 8080 test-site/public/ &"
   },
   "watch_cmd": "npm run watch"

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -13,11 +13,11 @@
       "requiredFiles": []
   },
   "buildArtifacts": {
-      "build_setup_cmd": "npm install && ./test-site/scripts/setup_for_yext_sites.sh",
-      "build_cmd": "npm run setup-test-site && npm run build-test-site"
+      "build_setup_cmd": "npm install",
+      "build_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site"
   },
   "livePreview": {
-      "serve_setup_cmd": "npm run setup-test-site && npm run build-test-site",
+      "serve_setup_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site",
       "serve_cmd": "npx serve -l 8080 test-site/public"
   },
   "watch_cmd": "npm run watch"

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -17,7 +17,7 @@
       "build_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site"
   },
   "livePreview": {
-      "serve_setup_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site",
+      "serve_setup_cmd": "npm run build-test-site",
       "serve_cmd": "npx serve -l 8080 test-site/public"
   },
   "watch_cmd": "npm run watch"

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -7,7 +7,7 @@
       ],
       "hbsTemplates": []
   },
-  "base_image_tag": "node-12.18",
+  "base_image_tag": "node-14",
   "dependencies": {
       "installDepsCmd": "npm install",
       "requiredFiles": []
@@ -17,8 +17,8 @@
       "build_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site"
   },
   "livePreview": {
-      "serve_setup_cmd": "mkdir -p /temp/theme && mv * /temp/theme && mkdir answers-hitchhiker-theme && mv /temp/theme/sites-config . && mv /temp/theme/* answers-hitchhiker-theme && npm run build-test-site",
-      "serve_cmd": "npx serve -l 8080 test-site/public/ &"
+      "serve_setup_cmd": "echo serve setup cmd",
+      "serve_cmd": "echo serve cmd"
   },
   "watch_cmd": "npm run watch"
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -17,8 +17,8 @@
       "build_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site"
   },
   "livePreview": {
-      "serve_setup_cmd": "echo serve setup cmd",
-      "serve_cmd": "echo serve cmd"
+      "serve_setup_cmd": "npm run build-test-site",
+      "serve_cmd": "npx serve -l 8080 test-site/public/ &"
   },
   "watch_cmd": "npm run watch"
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -17,8 +17,8 @@
       "build_cmd": "./test-site/scripts/setup_for_yext_sites.sh && npm run setup-test-site && npm run build-test-site"
   },
   "livePreview": {
-      "serve_setup_cmd": "npm run build-test-site",
-      "serve_cmd": "npx serve -l 8080 test-site/public"
+      "serve_setup_cmd": "echo serve setup cmd",
+      "serve_cmd": "echo serve cmd"
   },
   "watch_cmd": "npm run watch"
 }

--- a/sites-global/global.json
+++ b/sites-global/global.json
@@ -1,3 +1,0 @@
-{
-	"name": "Answers Hitchhiker Theme"
-}

--- a/sites-global/global.json
+++ b/sites-global/global.json
@@ -1,0 +1,3 @@
+{
+	"name": "Answers Hitchhiker Theme"
+}

--- a/test-site/jambo-yext-sites.json
+++ b/test-site/jambo-yext-sites.json
@@ -14,5 +14,5 @@
       "public/overlay.html"
     ]
   },
-  "defaultTheme": "root"
+  "defaultTheme": "repo"
 }

--- a/test-site/jambo-yext-sites.json
+++ b/test-site/jambo-yext-sites.json
@@ -1,0 +1,18 @@
+{
+  "dirs": {
+    "themes": "../../",
+    "config": "config",
+    "output": "public",
+    "pages": "pages",
+    "partials": [
+      "script/on-ready.js",
+      "cards",
+      "directanswercards"
+    ],
+    "preservedFiles": [
+      "public/iframe_test.html",
+      "public/overlay.html"
+    ]
+  },
+  "defaultTheme": "root"
+}

--- a/test-site/scripts/setup_for_yext_sites.sh
+++ b/test-site/scripts/setup_for_yext_sites.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set_working_dir_to_test_site () {
+  path_to_this_script="$( dirname "${BASH_SOURCE[0]}" )"
+  cd "$path_to_this_script/.."
+}
+
+set_working_dir_to_test_site
+# Use the jambo config for yext sites
+cp jambo-yext-sites.json jambo.json

--- a/test-site/scripts/setup_for_yext_sites.sh
+++ b/test-site/scripts/setup_for_yext_sites.sh
@@ -8,7 +8,3 @@ set_working_dir_to_test_site () {
 set_working_dir_to_test_site
 # Use the jambo config for yext sites
 cp jambo-yext-sites.json jambo.json
-
-echo "Setup for Yext Sites"
-echo "Current jambo.json:"
-cat jambo.json

--- a/test-site/scripts/setup_for_yext_sites.sh
+++ b/test-site/scripts/setup_for_yext_sites.sh
@@ -8,3 +8,7 @@ set_working_dir_to_test_site () {
 set_working_dir_to_test_site
 # Use the jambo config for yext sites
 cp jambo-yext-sites.json jambo.json
+
+echo "Setup for Yext Sites"
+echo "Current jambo.json:"
+cat jambo.json


### PR DESCRIPTION
Integrate with Yext Sites
 
Add config to support yext sites. The main "gotcha" is that Sites renames the answers-hitchhiker-theme to 'repo', so I added an extra jambo config which we can use with Yext Sites which refers the the theme as 'repo'.

Once we merge this into develop and master, we should be able to see those sites hosted at:
- theme.slapshot.pagescdn.com
- https://develop-theme-slapshot-pagescdn-com.preview.pagescdn.com/

The live preview integration is a little out of scope, but I think it would be useful if we add it in the future. I ran into an issue with it which may also have to do with repo renaming. It would allow us to open up the test site for any PR that we push to Github which would be useful for testing

J=SLAP-1679
TEST=manual

Connect this branch to Yext Sites and see the site hosted at https://devserveonyextsites-theme-slapshot-pagescdn-com.preview.pagescdn.com/