### PR TITLE
Fix jambo add card command

### DIFF
--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -167,10 +167,9 @@ class CardCreator {
       customCardName.replace(/-/g, '_') + cardNameSuffix;
 
     return content
-      .replace(/class (.*) extends/g, `class ${customComponentClassName} extends`)
-      .replace(registerComponentTypeRegex, `(${customComponentClassName})`)
       .replace(new RegExp(originalComponentName, 'g'), customCardName)
-      .replace(/cards[/_](.*)[/_]template/g, `cards/${customCardName}/template`);
+      .replace(/class (.*) extends/g, `class ${customComponentClassName} extends`)
+      .replace(registerComponentTypeRegex, `(${customComponentClassName})`);
   }
 }
 module.exports = CardCreator;

--- a/commands/cardcreator.js
+++ b/commands/cardcreator.js
@@ -156,7 +156,6 @@ class CardCreator {
    */
   _getRenamedCardComponent(content, customCardName) {
     const cardNameSuffix = 'CardComponent';
-    const registerComponentTypeRegex = /\([\w_]+CardComponent\)/g;
     const regexArray = [...content.matchAll(/componentName\s*=\s*'(.*)'/g)];
     if (regexArray.length === 0 || regexArray[0].length < 2) {
       return content;
@@ -168,8 +167,8 @@ class CardCreator {
 
     return content
       .replace(new RegExp(originalComponentName, 'g'), customCardName)
-      .replace(/class (.*) extends/g, `class ${customComponentClassName} extends`)
-      .replace(registerComponentTypeRegex, `(${customComponentClassName})`);
+      .replace(/(class )(.*)( extends)/g, `$1${customComponentClassName}$3`)
+      .replace(/(ANSWERS.registerComponentType\()(.*)(\))/g, `$1${customComponentClassName}$3`);
   }
 }
 module.exports = CardCreator;

--- a/commands/directanswercardcreator.js
+++ b/commands/directanswercardcreator.js
@@ -158,7 +158,6 @@ class DirectAnswerCardCreator {
    */
   _getRenamedCardComponent(content, customCardName) {
     const cardNameSuffix = 'Component';
-    const registerComponentTypeRegex = /\([\w_]+Component\)/g;
     const regexArray = [...content.matchAll(/componentName\s*=\s*'(.*)'/g)];
     if (regexArray.length === 0 || regexArray[0].length < 2) {
       return content;
@@ -169,12 +168,9 @@ class DirectAnswerCardCreator {
       customCardName.replace(/-/g, '_') + cardNameSuffix;
 
     return content
-      .replace(/class (.*) extends/g, `class ${customComponentClassName} extends`)
-      .replace(registerComponentTypeRegex, `(${customComponentClassName})`)
       .replace(new RegExp(originalComponentName, 'g'), customCardName)
-      .replace(
-        /directanswercards[/_](.*)[/_]template/g,
-        `directanswercards/${customCardName}/template`);
+      .replace(/(class )(.*)( extends)/g, `$1${customComponentClassName}$3`)
+      .replace(/(ANSWERS.registerComponentType\()(.*)(\))/g, `$1${customComponentClassName}$3`);
   }
 }
 


### PR DESCRIPTION
this pr resolve an issue that occur when there's a conflict between custom/new card name and the original card component name. Specifically, if the new card name contains the original card name, the series of replace functions invoked in `_getRenamedCardComponent` would not produce the correct file content (i.e. old name: 'standard', new name: 'standard-override'). This occurs in card and directanswercard command.

Fix: Update the series of replace functions in `_getRenamedCardComponent` to first replace all original component name with custom card name (without the underscore replacement), then update the two spots in the file that would require the custom card name with underscore replacement.


J=SLAP-1800
TEST=manual

cd into test-site and run `npx jambo [directanswer]card --name xxx  --templateCardFolder [directanswer]cards/xxx` with standard-override, documentstandard-override, event-custom2, product-standard-override, etc. See that component.js have correct class names. Used those cards in test site, see that pages work as expected.