### PR TITLE
Add missing rtf styling in components

### DIFF
--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -178,11 +178,11 @@
 <div class="HitchhikerLocationStandard-details">
   {{#if showExcessDetailsToggle}}
     <div class="HitchhikerLocationStandard-detailsText js-HitchhikerCard-detailsText">
-      {{truncatedDetails}}
+      {{{truncatedDetails}}}
     </div>
   {{/if}}
   <div class="HitchhikerLocationStandard-detailsText js-HitchhikerCard-detailsText{{#if showExcessDetailsToggle}} js-hidden{{/if}}">
-    {{card.details}}
+    {{{card.details}}}
   </div>
   {{#if showExcessDetailsToggle}}
   <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">

--- a/static/scss/answers/cards/event-standard.scss
+++ b/static/scss/answers/cards/event-standard.scss
@@ -79,6 +79,7 @@
 
   &-detailsText
   {
+    @include rich_text_formatting;
     margin-top: calc(var(--yxt-base-spacing) / 2);
     color: var(--yxt-color-text-primary);
   }

--- a/static/scss/answers/cards/faq-accordion.scss
+++ b/static/scss/answers/cards/faq-accordion.scss
@@ -86,8 +86,6 @@
 
   &-details
   {
-    @include rich_text_formatting;
-
     margin: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
     font-size: var(--yxt-font-size-md);
     line-height: var(--yxt-line-height-md);
@@ -95,6 +93,7 @@
 
   &-detailsText
   {
+    @include rich_text_formatting;
     color: var(--yxt-color-text-primary);
   }
 

--- a/static/scss/answers/cards/location-standard.scss
+++ b/static/scss/answers/cards/location-standard.scss
@@ -242,12 +242,12 @@ $location-standard-ordinal-dimensions: calc(var(--hh-location-standard-base-spac
 
   &-details
   {
-    @include rich_text_formatting;
     margin-top: calc(var(--hh-location-standard-base-spacing) / 2);
   }
 
   &-detailsText
   {
+    @include rich_text_formatting;
     color: var(--yxt-color-text-primary);
   }
 


### PR DESCRIPTION
- Add rtf styling to event-standard component
- move rtf styling from `&-details` to `&-detailsText` for faq-accordion and location-standard component.
  - update location-standard template to use non-html escape syntax (triple curly braces) when displaying details
 
J=SLAP-1804
TEST=manual

test event page, location_google page, and faq page with rich text description. See that the text is styled properly with rtf styling.