### PR TITLE
Update vertical-grid universalSectionTemplate

### DIFF
--- a/templates/vertical-grid/page-config.json
+++ b/templates/vertical-grid/page-config.json
@@ -69,7 +69,7 @@
       "universalLimit": 4, // The result count limit for universal search
       "cardType": "product-prominentimage", // The name of the card to use - e.g. accordion, location, customcard 
       // "icon": "star", // The icon to use on the card for this vertical
-      "universalSectionTemplate": "standard"
+      "universalSectionTemplate": "grid-three-columns"
     }
   }
 }


### PR DESCRIPTION
Change the default `universalSectionTemplate` for vertical-grid to grid-three-columns.

J=SLAP-1831
TEST=manual

Check that the test-site shows the correct layout on the universal page for the people vertical.