### PR TITLE
Add multilang doc standard card

### DIFF
--- a/cards/multilang-document-standard/component.js
+++ b/cards/multilang-document-standard/component.js
@@ -1,0 +1,73 @@
+{{> cards/card_component componentName='multilang-document-standard' }}
+
+class multilang_document_standardCardComponent extends BaseCard['multilang-document-standard'] {
+  constructor(config = {}, systemConfig = {}) {
+    super(config, systemConfig);
+  }
+
+  /**
+   * This returns an object that will be called `card`
+   * in the template. Put all mapping logic here.
+   *
+   * @param profile profile of the entity in the card
+   */
+  dataForRender(profile) {
+    let detailsData = '';
+    if (profile?.d_highlightedFields?.s_snippet) {
+      const { value, matchedSubstrings } = profile.d_highlightedFields.s_snippet;
+      detailsData = Formatter.highlightField(value, matchedSubstrings);
+    } else if (profile.s_snippet) {
+      detailsData = profile.s_snippet;
+    }
+
+    return {
+      title: profile.name, // The header text of the card
+      url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
+      target: '_top', // If the title's URL should open in a new tab, etc.
+      // image: '', // The URL of the image to display on the card
+      // altText: '', // The alternate text for the image
+      titleEventOptions: this.addDefaultEventOptions(),
+      subtitle: profile.externalArticleUpdateDate ? {{ translateJS phrase='Last Updated on [[date]]' date=profile.externalArticleUpdateDate }} : '', // The sub-header text of the card
+      details: detailsData, // The text in the body of the card
+      // The primary CTA of the card
+      CTA1: {
+        label: (profile.c_primaryCTA ? profile.c_primaryCTA.label : null), // The CTA's label
+        iconName: 'chevron', // The icon to use for the CTA
+        url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
+        target: '_top', // Where the new URL will be opened
+        eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
+      },
+      // The secondary CTA of the card
+      CTA2: {
+        label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
+        iconName: 'chevron',
+        url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
+        target: '_top',
+        eventType: 'CTA_CLICK',
+        eventOptions: this.addDefaultEventOptions(),
+        // ariaLabel: '',
+      },
+      feedback: false, // Shows thumbs up/down buttons to provide feedback on the result card
+      feedbackTextOnSubmission: {{ translateJS phrase='Thanks!' }}, // Text to display after a thumbs up/down is clicked
+      positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
+      negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }} // Screen reader only text for thumbs-down
+    };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/multilang-document-standard';
+  }
+}
+
+ANSWERS.registerTemplate(
+  'cards/multilang-document-standard',
+  {{{stringifyPartial (read 'cards/multilang-document-standard/template') }}}
+);
+ANSWERS.registerComponentType(multilang_document_standardCardComponent);

--- a/cards/multilang-document-standard/template.hbs
+++ b/cards/multilang-document-standard/template.hbs
@@ -1,0 +1,94 @@
+<div class="HitchhikerDocumentStandard {{cardName}}">
+  {{> image }}
+  <div class="HitchhikerDocumentStandard-body">
+    {{> title }}
+    {{> subtitle }}
+    <div class="HitchhikerDocumentStandard-contentWrapper">
+      <div class="HitchhikerDocumentStandard-info">
+        {{> details }}
+      </div>
+      {{> ctas }}
+    </div>
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
+  </div>
+</div>
+
+{{#*inline 'image'}}
+{{#if card.image}}
+<div class="HitchhikerDocumentStandard-imgWrapper">
+  <img class="HitchhikerDocumentStandard-img" src="{{#unless (isNonRelativeUrl card.image)}}{{@root.relativePath}}/{{/unless}}{{card.image}}" alt="{{#if card.altText}}{{card.altText}}{{/if}}"/>
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'title'}}
+{{#if card.title}}
+<div class="HitchhikerDocumentStandard-title">
+  {{#if card.url}}
+  <a class="HitchhikerDocumentStandard-titleLink js-HitchhikerDocumentStandard-titleLink"
+     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+     data-eventtype="TITLE_CLICK"
+     data-eventoptions='{{json card.titleEventOptions}}'
+     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
+    {{card.title}}
+  </a>
+  {{else}}
+  {{card.title}}
+  {{/if}}
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'subtitle'}}
+{{#if card.subtitle}}
+<div class="HitchhikerDocumentStandard-subtitle">
+  {{card.subtitle}}
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'details'}}
+{{#if card.details}}
+<div class="HitchhikerDocumentStandard-cardDetails">
+  <div class="HitchhikerDocumentStandard-detailsText js-HitchhikerCard-detailsText">
+    {{{card.details}}}
+  </div>
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'ctas'}}
+{{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
+<div class="HitchhikerDocumentStandard-ctasWrapper">
+  {{> CTA card.CTA1 ctaName="primaryCTA" }}
+  {{> CTA card.CTA2 ctaName="secondaryCTA" }}
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'CTA'}}
+{{#if (all url label)}}
+<div class="HitchhikerDocumentStandard-{{ctaName}}">
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target="{{#if target}}{{target}}{{else}}_top{{/if}}"
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
+    {{#if (any iconName iconUrl)}}
+    <div class="HitchhikerCTA-iconWrapper">
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
+    </div>
+    {{/if}}
+    <div class='HitchhikerCTA-iconLabel'>
+      {{label}}
+    </div>
+  </a>
+</div>
+{{/if}}
+{{/inline}}

--- a/test-site/config-overrides/help_articles.es.json
+++ b/test-site/config-overrides/help_articles.es.json
@@ -4,7 +4,7 @@
       "label": "Artículos de ayuda", // The name of the vertical in the section header and the navigation bar
       // "verticalLimit": 15, // The result count limit for vertical search
       // "universalLimit": 5, // The result count limit for universal search
-      "cardType": "document-standard", // The name of the card to use - e.g. accordion, location, customcard
+      "cardType": "multilang-document-standard", // The name of the card to use - e.g. accordion, location, customcard
       "icon": "star", // The icon to use on the card for this vertical
       "universalSectionTemplate": "standard"
     }

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -52,6 +52,10 @@ msgstr ""
 msgid "Hours"
 msgstr ""
 
+#: cards/multilang-document-standard/component.js:30
+msgid "Last Updated on [[date]]"
+msgstr ""
+
 #: templates/vertical-full-page-map/page.html.hbs:23
 msgid "Main location search"
 msgstr ""
@@ -136,6 +140,7 @@ msgstr ""
 msgid "Thank you for your feedback!"
 msgstr ""
 
+#: cards/multilang-document-standard/component.js:53
 #: cards/multilang-event-standard/component.js:53
 #: cards/multilang-faq-accordion/component.js:51
 #: cards/multilang-financial-professional-location/component.js:69
@@ -159,6 +164,7 @@ msgid_plural "The following search categories yielded results for <span class=\"
 msgstr[0] ""
 msgstr[1] ""
 
+#: cards/multilang-document-standard/component.js:54
 #: cards/multilang-event-standard/component.js:54
 #: cards/multilang-faq-accordion/component.js:52
 #: cards/multilang-financial-professional-location/component.js:70
@@ -177,6 +183,7 @@ msgstr[1] ""
 msgid "This answered my question"
 msgstr ""
 
+#: cards/multilang-document-standard/component.js:55
 #: cards/multilang-event-standard/component.js:55
 #: cards/multilang-faq-accordion/component.js:53
 #: cards/multilang-financial-professional-location/component.js:71


### PR DESCRIPTION
Add a multi-lang document standard card. Update help_articles.es.json to use this card for the test-site.

J=SLAP-1839
TEST=manual

Check that help articles on the es test-site use the new card and show translated text for feedback submission.