### PR TITLE
Add multilang doc search DA card

### DIFF
--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -19,7 +19,7 @@
 
 {{#*inline 'icon'}}
 {{#if (any iconName iconUrl)}}
-<div class="HitchhikerAllFieldsStandard-titleIconWrapper"></div>
+<div class="HitchhikerAllFieldsStandard-titleIconWrapper">
   {{> icons/iconPartial
       iconName=iconName
       iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)

--- a/directanswercards/multilang-documentsearch-standard/component.js
+++ b/directanswercards/multilang-documentsearch-standard/component.js
@@ -1,0 +1,64 @@
+{{> directanswercards/card_component componentName = 'multilang-documentsearch-standard' }}
+
+class multilang_documentsearch_standardComponent extends BaseDirectAnswerCard['multilang-documentsearch-standard'] {
+  constructor(config = {}, systemConfig = {}) {
+    super(config, systemConfig);
+  }
+
+  /**
+   * @param type the type of direct answer
+   * @param answer the full answer returned from the API, corresponds to response.directAnswer.answer.
+   * @param relatedItem profile of the related entity for the direct answer
+   * @param snippet the snippet for the document search direct answer
+   */
+  dataForRender(type, answer, relatedItem, snippet) {
+    const relatedItemData = relatedItem.data || {};
+    const linkTarget = AnswersExperience.runtimeConfig.get('linkTarget') || '_top';
+    let snippetValue = '';
+    if (answer.fieldType === "rich_text" && snippet) {
+      snippetValue = ANSWERS.formatRichText(snippet.value, 'snippet', linkTarget);
+    } else if (snippet) {
+      snippetValue = Formatter.highlightField(snippet.value, snippet.matchedSubstrings);
+    }
+    const viewDetailsUrl = relatedItemData.website || (relatedItemData.fieldValues && relatedItemData.fieldValues.landingPageUrl);
+
+    return {
+      value: answer.value,
+      snippet: snippetValue, // Text snippet to include alongside the answer
+      viewDetailsText: relatedItemData.fieldValues && relatedItemData.fieldValues.name, // Text below the direct answer and snippet
+      viewDetailsLink: Formatter.getUrlWithTextHighlight(snippet, viewDetailsUrl), // Link for the "view details" text
+      viewDetailsEventOptions: this.addDefaultEventOptions({
+        ctaLabel: 'VIEW_DETAILS',
+        fieldName: 'snippet'
+      }), // The event options for viewDetails click analytics
+      linkTarget: linkTarget, // Target for all links in the direct answer
+      // CTA: {
+      //   label: '', // The CTA's label
+      //   iconName: 'chevron', // The icon to use for the CTA
+      //   url: '', // The URL a user will be directed to when clicking
+      //   target: linkTarget, // Where the new URL will be opened
+      //   eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
+      //   eventOptions: this.addDefaultEventOptions({ fieldName: 'snippet' }) // The event options for CTA click analytics
+      // },
+      feedbackTextOnSubmission: {{ translateJS phrase='Thank you for your feedback!' }}, // Text to display in the footer when a thumbs up/down is clicked
+      feedbackText: {{ translateJS phrase='Was this the answer you were looking for?' }}, // Text to display in the footer
+      positiveFeedbackSrText: {{ translateJS phrase='This answered my question' }}, // Screen reader only text for thumbs-up
+      negativeFeedbackSrText: {{ translateJS phrase='This did not answer my question' }}, // Screen reader only text for thumbs-down
+    };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'directanswercards/multilang-documentsearch-standard';
+  }
+}
+
+ANSWERS.registerTemplate(
+  'directanswercards/multilang-documentsearch-standard',
+  {{{stringifyPartial (read 'directanswercards/multilang-documentsearch-standard/template') }}}
+);
+ANSWERS.registerComponentType(multilang_documentsearch_standardComponent);

--- a/directanswercards/multilang-documentsearch-standard/template.hbs
+++ b/directanswercards/multilang-documentsearch-standard/template.hbs
@@ -31,7 +31,7 @@
 {{#*inline 'view_details_link'}}
 {{#if (all viewDetailsLink viewDetailsText)}}
   <div class="HitchhikerDocumentSearchStandard-viewMoreWrapper">
-    {{ translateJS phrase='Read more about' }}
+    {{ translate phrase='Read more about' }}
     <a class="HitchhikerDocumentSearchStandard-viewMore"
         href="{{#unless (isNonRelativeUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
         data-eventtype="CTA_CLICK"

--- a/directanswercards/multilang-documentsearch-standard/template.hbs
+++ b/directanswercards/multilang-documentsearch-standard/template.hbs
@@ -1,0 +1,68 @@
+<div class="HitchhikerDocumentSearchStandard {{cardName}}">
+  <div class="HitchhikerDocumentSearchStandard-titleAndContent">
+    {{> title }}
+    <div class="HitchhikerDocumentSearchStandard-content">
+      <div class="HitchhikerDocumentSearchStandard-column">
+        {{> featured_snippet }}
+        {{> view_details_link }}
+      </div>
+      {{> cta CTA linkTarget=linkTarget}}
+    </div>
+  </div>
+  {{> thumbsfeedback directAnswerClass="HitchhikerDocumentSearchStandard"}}
+</div>
+
+{{#*inline 'title'}}
+{{#if value}}
+  <h2 class="HitchhikerDocumentSearchStandard-title">
+    {{value}}
+  </h2>
+{{/if}}
+{{/inline}}
+
+{{#* inline 'featured_snippet'}}
+{{#if snippet}}
+  <div class="HitchhikerDocumentSearchStandard-snippet">
+    {{{snippet}}}
+  </div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'view_details_link'}}
+{{#if (all viewDetailsLink viewDetailsText)}}
+  <div class="HitchhikerDocumentSearchStandard-viewMoreWrapper">
+    {{ translateJS phrase='Read more about' }}
+    <a class="HitchhikerDocumentSearchStandard-viewMore"
+        href="{{#unless (isNonRelativeUrl viewDetailsLink)}}{{@root.relativePath}}/{{/unless}}{{viewDetailsLink}}"
+        data-eventtype="CTA_CLICK"
+        data-eventoptions='{{{json viewDetailsEventOptions}}}'
+        target="{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}">
+      {{viewDetailsText}}
+    </a>
+  </div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'cta'}}
+{{#if (all url label)}}
+  <div class="HitchhikerDocumentSearchStandard-cta">
+    <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}" href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+      data-eventtype="{{eventType}}" data-eventoptions='{{{json eventOptions}}}'
+      target="{{#if target}}{{target}}{{else}}{{#if linkTarget}}{{linkTarget}}{{else}}_blank{{/if}}{{/if}}">
+      {{#if (any iconName iconUrl)}}
+      <div class="HitchhikerCTA-iconWrapper">
+        <div class="HitchhikerCTA-icon">
+          {{> icons/iconPartial
+              iconName=iconName
+              iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+          }}
+        </div>
+      </div>
+      {{/if}}
+      <div class='HitchhikerCTA-iconLabel'>
+        {{label}}
+      </div>
+    </a>
+  </div>
+{{/if}}
+{{/inline}}

--- a/test-site/config/index.ar.json
+++ b/test-site/config/index.ar.json
@@ -9,7 +9,7 @@
     "DirectAnswer": {
       "types": {
         "FEATURED_SNIPPET": {
-          "cardType": "documentsearch-standard"
+          "cardType": "multilang-documentsearch-standard"
         },
         "FIELD_VALUE": {
           "cardType": "multilang-allfields-standard"

--- a/test-site/config/index.es.json
+++ b/test-site/config/index.es.json
@@ -9,7 +9,7 @@
     "DirectAnswer": {
       "types": {
         "FEATURED_SNIPPET": {
-          "cardType": "documentsearch-standard"
+          "cardType": "multilang-documentsearch-standard"
         },
         "FIELD_VALUE": {
           "cardType": "multilang-allfields-standard"

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -80,6 +80,10 @@ msgstr ""
 msgid "Order Now"
 msgstr ""
 
+#: directanswercards/multilang-documentsearch-standard/template.hbs:34
+msgid "Read more about"
+msgstr ""
+
 #: theme-components/collapsible-filters/filter-link/component.js:3
 msgid "reset filters"
 msgstr ""
@@ -133,6 +137,7 @@ msgid "Sunday"
 msgstr ""
 
 #: directanswercards/multilang-allfields-standard/component.js:188
+#: directanswercards/multilang-documentsearch-standard/component.js:43
 msgid "Thank you for your feedback!"
 msgstr ""
 
@@ -174,6 +179,7 @@ msgstr[1] ""
 #: cards/multilang-professional-standard/component.js:60
 #: cards/multilang-standard/component.js:55
 #: directanswercards/multilang-allfields-standard/component.js:190
+#: directanswercards/multilang-documentsearch-standard/component.js:45
 msgid "This answered my question"
 msgstr ""
 
@@ -192,6 +198,7 @@ msgstr ""
 #: cards/multilang-professional-standard/component.js:61
 #: cards/multilang-standard/component.js:56
 #: directanswercards/multilang-allfields-standard/component.js:191
+#: directanswercards/multilang-documentsearch-standard/component.js:46
 msgid "This did not answer my question"
 msgstr ""
 
@@ -218,6 +225,7 @@ msgid "View Menu"
 msgstr ""
 
 #: directanswercards/multilang-allfields-standard/component.js:189
+#: directanswercards/multilang-documentsearch-standard/component.js:44
 msgid "Was this the answer you were looking for?"
 msgstr ""
 


### PR DESCRIPTION
Add a multi-lang document search DA card. Update index.es.json and index.ar.json to use this card for featured snippets in the test-site. Fix a bug in the allfields DA card template that affected the styling for the title when there is an icon.

J=SLAP-1830
TEST=manual

Check that the doc search card has translated feedback text and that the allfields DA card title is styled correctly with an icon.