### PR TITLE
spread universal map providerOptions for default scrollZoom=false

### DIFF
--- a/templates/universal-standard/script/universalresults.hbs
+++ b/templates/universal-standard/script/universalresults.hbs
@@ -82,12 +82,13 @@ ANSWERS.addComponent("UniversalResults", Object.assign({}, {
     mapConfig: Object.assign({
       apiKey: HitchhikerJS.getDefaultMapApiKey("{{ mapConfig.mapProvider }}")
     },
+    {{{ json mapConfig }}},
     {
       "providerOptions": {
-        "scrollZoom": false
+        "scrollZoom": false,
+        ...{{{ json mapConfig.providerOptions }}}
       }
     },
-    {{{ json mapConfig }}},
     {{!-- This theme pin config must come after mapConfig in Object.assign --}}
     {
       pin: {{> templates/universal-standard/script/map-pin mapConfig }},

--- a/test-site/config/index.json
+++ b/test-site/config/index.json
@@ -55,7 +55,13 @@
       "cardType": "link-standard"
     },
     "healthcare_professionals": {
-      "cardType": "professional-location"
+      "cardType": "professional-location",
+      "mapConfig": {
+        "mapProvider": "mapbox",
+        "providerOptions": {
+          "style": "mapbox://styles/mapbox/dark-v10"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
note that scrollZoom only works for Mapbox and is a no-op with a Google mapProvider.

J=SLAP-1866
TEST=manual

test setting scrollZoom to true and false
test not specifying providerOptions -> scrollZoom defaults to false
test specifying providerOptions without scrollZoom -> scrollZoom defaults to false

add a dark theme mapbox map to the test-site on universal