### PR TITLE
Change ID used for map pins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.27.0",
+      "version": "1.28.1",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.1",
         "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "A starter answers theme for hitchhikers",
   "scripts": {
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu jest --verbose",

--- a/static/js/theme-map/Renderer/MapRenderTarget.js
+++ b/static/js/theme-map/Renderer/MapRenderTarget.js
@@ -7,7 +7,7 @@ class MapRenderTargetOptions extends RenderTargetOptions {
   constructor() {
     super();
 
-    this.idForEntity = entity => 'js-yl-' + entity.profile.meta.id;
+    this.idForEntity = entity => 'js-yl-' + entity.profile.uid;
     this.map = null;
     this.pinBuilder = (pinOptions, entity, index) => pinOptions.build();
     this.pinClusterer = null;

--- a/static/js/theme-map/ThemeMap.js
+++ b/static/js/theme-map/ThemeMap.js
@@ -328,7 +328,7 @@ class ThemeMap extends ANSWERS.Component {
    * @param {Number} index The index of the entity in the result list ordering
    */
   buildPin(pinOptions, entity, index) {
-    const id = 'js-yl-' + entity.profile.meta.id;
+    const id = 'js-yl-' + entity.profile.uid;
     const cardFocusUpdateListener = {
       eventType: 'update',
       storageKey: StorageKeys.LOCATOR_CARD_FOCUS,

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -498,7 +498,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
 
       const entityId = cardId.replace('js-yl-', '');
       const verticalResults = this.core.storage.get(StorageKeys.VERTICAL_RESULTS).results;
-      const entityData = verticalResults.find(entity => entity.id.toString() === entityId);
+      const entityData = verticalResults.find(entity => entity._raw.uid.toString() === entityId);
       const opts = {
         parentContainer: this._container, 
         container: `.yxt-Card-${entityId}`,

--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -484,7 +484,7 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
   /**
    * The callback when a result pin on the map is clicked or tabbed onto
    * @param {Number} index The index of the pin in the current result list order
-   * @param {string} cardId The unique id for the pin entity, usually of the form `js-yl-${meta.id}`
+   * @param {string} cardId The unique id for the pin entity, usually of the form `js-yl-${uid}`
    */
   pinFocusListener (index, cardId) {
     this.core.storage.set(StorageKeys.LOCATOR_SELECTED_RESULT, cardId);

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {


### PR DESCRIPTION
Use a result's internal `uid` instead of the external entity `id` for identifying map pins. The `id` can be any string specified by the user. This causes an error when clicking on a map pin on mobile if the `id` has spaces, apostrophes, etc. The `uid` is a unique, automatically-generated string that only consists of numbers, so it would not have this problem.

J=SLAP-1962
TEST=manual

Check that map pins on mobile can now be clicked regardless of external entity ID because the `uid` is used instead.