### PR TITLE
Fix CollapsibleFilters tab order

### DIFF
--- a/templates/vertical-full-page-map/page.html.hbs
+++ b/templates/vertical-full-page-map/page.html.hbs
@@ -33,7 +33,6 @@
               {{> templates/vertical-full-page-map/markup/verticalresultscount }}
               {{> templates/vertical-full-page-map/markup/appliedfilters }}
               {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/filterlink }} --}}
-              {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }} --}}
             </div>
             <div class="Answers-resultsHeaderBottom">
               {{> templates/vertical-full-page-map/markup/alternativeresults }}
@@ -45,6 +44,7 @@
             {{!-- {{> templates/vertical-full-page-map/markup/facets }} --}}
             {{!-- {{> templates/vertical-full-page-map/markup/filterbox }} --}}
           {{!-- </div> --}}
+          {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }} --}}
           <div class="Answers-resultsWrapper js-locator-resultsWrapper">
             <div class="Answers-resultsContainer js-locator-resultsContainer js-answersResultsWrapper">
               <div class="js-answersResultsColumn">

--- a/templates/vertical-grid/page.html.hbs
+++ b/templates/vertical-grid/page.html.hbs
@@ -32,7 +32,6 @@
         {{> templates/vertical-grid/markup/verticalresultscount }}
         {{> templates/vertical-grid/markup/appliedfilters }}
         {{!-- {{> templates/vertical-grid/collapsible-filters/markup/filterlink }} --}}
-        {{!-- {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }} --}}
       </div>
       <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
       {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
@@ -40,6 +39,7 @@
         {{!-- {{> templates/vertical-grid/markup/filterbox }} --}}
         {{!-- {{> templates/vertical-grid/markup/facets }} --}}
       {{!-- </div> --}}
+      {{!-- {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }} --}}
       <div class="Answers-results js-answersResults">
         {{> templates/vertical-grid/markup/verticalresults }}
         {{> templates/vertical-grid/markup/pagination }}

--- a/templates/vertical-map/page.html.hbs
+++ b/templates/vertical-map/page.html.hbs
@@ -34,7 +34,6 @@
           {{> templates/vertical-map/markup/verticalresultscount }}
           {{> templates/vertical-map/markup/appliedfilters }}
           {{!-- {{> templates/vertical-map/collapsible-filters/markup/filterlink }} --}}
-          {{!-- {{> templates/vertical-map/collapsible-filters/markup/viewresultsbutton }} --}}
         </div>
         <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
         {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
@@ -42,6 +41,7 @@
           {{!-- {{> templates/vertical-map/markup/facets }} --}}
           {{!-- {{> templates/vertical-map/markup/filterbox }} --}}
         {{!-- </div> --}}
+        {{!-- {{> templates/vertical-map/collapsible-filters/markup/viewresultsbutton }} --}}
         <div class="Answers-results js-answersResults">
           {{> templates/vertical-map/markup/verticalresults }}
           {{> templates/vertical-map/markup/pagination }}

--- a/templates/vertical-standard/page.html.hbs
+++ b/templates/vertical-standard/page.html.hbs
@@ -35,7 +35,6 @@
         {{> templates/vertical-standard/markup/verticalresultscount }}
         {{> templates/vertical-standard/markup/appliedfilters }}
         {{!-- {{> templates/vertical-standard/collapsible-filters/markup/filterlink }} --}}
-        {{!-- {{> templates/vertical-standard/collapsible-filters/markup/viewresultsbutton }} --}}
       </div>
       <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
       {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
@@ -43,6 +42,7 @@
         {{!-- {{> templates/vertical-standard/markup/filterbox }} --}}
         {{!-- {{> templates/vertical-standard/markup/facets }} --}}
       {{!-- </div> --}}
+      {{!-- {{> templates/vertical-standard/collapsible-filters/markup/viewresultsbutton }} --}}
       <div class="Answers-results js-answersResults">
         {{> templates/vertical-standard/markup/verticalresults }}
         {{> templates/vertical-standard/markup/pagination }}

--- a/test-site/pages-patches/healthcare_professionals.html.hbs.patch
+++ b/test-site/pages-patches/healthcare_professionals.html.hbs.patch
@@ -13,8 +13,8 @@
      {{!-- {{> templates/vertical-grid/script/qasubmission }} --}}
    {{/script/core }}
    <div class="Answers AnswersVerticalGrid CollapsibleFilters">
-@@ -34,11 +34,11 @@
-         {{!-- {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }} --}}
+@@ -33,11 +33,11 @@
+         {{!-- {{> templates/vertical-grid/collapsible-filters/markup/filterlink }} --}}
        </div>
        <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
 -      {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
@@ -27,6 +27,6 @@
 +        {{> templates/vertical-grid/markup/filterbox }}
 +        {{> templates/vertical-grid/markup/facets }}
 +      </div>
+       {{!-- {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }} --}}
        <div class="Answers-results js-answersResults">
          {{> templates/vertical-grid/markup/spellcheck }}
-         {{> templates/vertical-grid/markup/verticalresults }}

--- a/test-site/pages-patches/locations.html.hbs.patch
+++ b/test-site/pages-patches/locations.html.hbs.patch
@@ -23,9 +23,7 @@
            {{> templates/vertical-map/markup/verticalresultscount }}
            {{> templates/vertical-map/markup/appliedfilters }}
 -          {{!-- {{> templates/vertical-map/collapsible-filters/markup/filterlink }} --}}
--          {{!-- {{> templates/vertical-map/collapsible-filters/markup/viewresultsbutton }} --}}
 +          {{> templates/vertical-map/collapsible-filters/markup/filterlink }}
-+          {{> templates/vertical-map/collapsible-filters/markup/viewresultsbutton }}
          </div>
          <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
 -        {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
@@ -36,7 +34,9 @@
 +          {{> templates/vertical-map/markup/facets }}
            {{!-- {{> templates/vertical-map/markup/filterbox }} --}}
 -        {{!-- </div> --}}
+-        {{!-- {{> templates/vertical-map/collapsible-filters/markup/viewresultsbutton }} --}}
 +        </div>
++        {{> templates/vertical-map/collapsible-filters/markup/viewresultsbutton }}
          <div class="Answers-results js-answersResults">
            {{> templates/vertical-map/markup/spellcheck }}
            {{> templates/vertical-map/markup/verticalresults }}

--- a/test-site/pages-patches/locations_full_page_map_with_filters.html.hbs.patch
+++ b/test-site/pages-patches/locations_full_page_map_with_filters.html.hbs.patch
@@ -23,9 +23,7 @@
                {{> templates/vertical-full-page-map/markup/verticalresultscount }}
                {{> templates/vertical-full-page-map/markup/appliedfilters }}
 -              {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/filterlink }} --}}
--              {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }} --}}
 +              {{> templates/vertical-full-page-map/collapsible-filters/markup/filterlink }}
-+              {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }}
              </div>
              <div class="Answers-resultsHeaderBottom">
                {{> templates/vertical-full-page-map/markup/alternativeresults }}
@@ -39,7 +37,9 @@
 +            {{> templates/vertical-full-page-map/markup/facets }}
              {{!-- {{> templates/vertical-full-page-map/markup/filterbox }} --}}
 -          {{!-- </div> --}}
+-          {{!-- {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }} --}}
 +          </div>
++          {{> templates/vertical-full-page-map/collapsible-filters/markup/viewresultsbutton }}
            <div class="Answers-resultsWrapper js-locator-resultsWrapper">
              <div class="Answers-resultsContainer js-locator-resultsContainer js-answersResultsWrapper">
                <div class="js-answersResultsColumn">

--- a/test-site/pages-patches/people.html.hbs.patch
+++ b/test-site/pages-patches/people.html.hbs.patch
@@ -25,9 +25,7 @@
          {{> templates/vertical-grid/markup/verticalresultscount }}
          {{> templates/vertical-grid/markup/appliedfilters }}
 -        {{!-- {{> templates/vertical-grid/collapsible-filters/markup/filterlink }} --}}
--        {{!-- {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }} --}}
 +        {{> templates/vertical-grid/collapsible-filters/markup/filterlink }}
-+        {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }}
        </div>
        <!-- Uncomment the following div if you want to include filters, facets, or sort options  -->
 -      {{!-- <div class="Answers-filtersWrapper js-answersFiltersWrapper CollapsibleFilters-inactive"> --}}
@@ -37,8 +35,10 @@
          {{!-- {{> templates/vertical-grid/markup/filterbox }} --}}
 -        {{!-- {{> templates/vertical-grid/markup/facets }} --}}
 -      {{!-- </div> --}}
+-      {{!-- {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }} --}}
 +        {{> templates/vertical-grid/markup/facets }}
 +      </div>
++      {{> templates/vertical-grid/collapsible-filters/markup/viewresultsbutton }}
        <div class="Answers-results js-answersResults">
          {{> templates/vertical-grid/markup/spellcheck }}
          {{> templates/vertical-grid/markup/verticalresults }}


### PR DESCRIPTION
In the vertical page templates, move the View Results button from the results header to after the filters so that for collapsible filters the tab order goes through the filters first before going to the button at the bottom of the page. Update the page patch files for the test-site to reflect the changed page templates.

I also looked into doing this using the `tabindex` attribute, as specifying values greater than 0 sets the tab ordering of a page. However, this is not recommended for accessibility reasons because screen reader announcements don't follow `tabindex` order. Also, it would be cumbersome to add and maintain because each element on the page would need to be assigned a `tabindex` to maintain a natural order.

J=SLAP-829
TEST=manual

Check various vertical pages in the test-site (including people, healthcare_professionals, locations, and locations_full_page_map_with_filters) and see that the tab ordering is now correct. 