### PR TITLE
support rtf truncation

### DIFF
--- a/.github/workflows/percy-snapshots.yml
+++ b/.github/workflows/percy-snapshots.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18]
+        node-version: [16]
     needs: nonce
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18]
+        node-version: [16]
     needs: nonce
     steps:
       - uses: actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18]
+        node-version: [16]
     needs: nonce
     steps:
       - uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18]
+        node-version: [16]
     needs: nonce
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/percy-snapshots.yml
+++ b/.github/workflows/percy-snapshots.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [12.18]
     needs: nonce
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [12.18]
     needs: nonce
     steps:
       - uses: actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [12.18]
     needs: nonce
     steps:
       - uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [12.18]
     needs: nonce
     steps:
       - uses: actions/checkout@v2

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -99,7 +99,6 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
     if (userSpecifiedTruncatedDetails) {
       const showExcessDetailsToggle = userSpecifiedTruncatedDetails.length + 3 < details.length
       const truncatedDetails = showExcessDetailsToggle ? userSpecifiedTruncatedDetails : '';
-      console.log(truncatedDetails.length, details.length)
       return {
         showExcessDetailsToggle,
         truncatedDetails
@@ -108,12 +107,15 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
 
     // Set the value of excessDetailsToggle. Note that it is not enough to have a showMoreLimit.
     // The card's details must extend past this limit as well for the toggling to be enabled.
-    const showExcessDetailsToggle = showMoreLimit && (details.length + 3) > showMoreLimit;
+    const showExcessDetailsToggle = showMoreLimit && (details.length + 3 > showMoreLimit);
     
     const truncatedDetails = showExcessDetailsToggle
       ? `${details.substring(0, showMoreLimit)}...`
       : '';
-    return truncatedDetails;
+    return {
+      showExcessDetailsToggle,
+      truncatedDetails
+    };
   }
 
   validateDataForRender(data) {

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -80,30 +80,40 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
     
     cardData.feedbackEnabled = ANSWERS.getAnalyticsOptIn() && cardData.feedback;
 
-    const { details, showMoreDetails } = cardData;
-
-    const cardDetails = details || '';
-    const cardShowMoreConfig = showMoreDetails || {};
-    const { showMoreLimit } = cardShowMoreConfig;
-
-    // Set the value of excessDetailsToggle. Note that it is not enough to have a showMoreLimit.
-    // The card's details must extend past this limit as well for the toggling to be enabled.
-    const showExcessDetailsToggle = showMoreLimit && cardDetails.length > showMoreLimit;
-
-    const truncatedDetails = showExcessDetailsToggle
-      ? `${cardDetails.substring(0, showMoreLimit)}...`
-      : '';
+    const { showExcessDetailsToggle, truncatedDetails } = this._getTruncatedDetails(cardData);
     
     this.validateDataForRender(cardData);
 
     return super.setState({
       ...data,
       card: cardData,
-      showExcessDetailsToggle: showExcessDetailsToggle,
-      truncatedDetails: truncatedDetails,
+      showExcessDetailsToggle,
+      truncatedDetails,
       cardName: `{{componentName}}`,
       relativePath: `{{relativePath}}`
     });
+  }
+
+  _getTruncatedDetails({ details, showMoreDetails }) {
+    const { showMoreLimit, truncatedDetails: userSpecifiedTruncatedDetails } = showMoreDetails || {};
+    if (userSpecifiedTruncatedDetails) {
+      const showExcessDetailsToggle = userSpecifiedTruncatedDetails.length + 3 < details.length
+      const truncatedDetails = showExcessDetailsToggle ? userSpecifiedTruncatedDetails : '';
+      console.log(truncatedDetails.length, details.length)
+      return {
+        showExcessDetailsToggle,
+        truncatedDetails
+      }
+    }
+
+    // Set the value of excessDetailsToggle. Note that it is not enough to have a showMoreLimit.
+    // The card's details must extend past this limit as well for the toggling to be enabled.
+    const showExcessDetailsToggle = showMoreLimit && (details.length + 3) > showMoreLimit;
+    
+    const truncatedDetails = showExcessDetailsToggle
+      ? `${details.substring(0, showMoreLimit)}...`
+      : '';
+    return truncatedDetails;
   }
 
   validateDataForRender(data) {

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -97,7 +97,7 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
   _getTruncatedDetails({ details = '', showMoreDetails }) {
     const { showMoreLimit, truncatedDetails: userSpecifiedTruncatedDetails } = showMoreDetails || {};
     if (userSpecifiedTruncatedDetails) {
-      const showExcessDetailsToggle = userSpecifiedTruncatedDetails.length + 3 < details.length
+      const showExcessDetailsToggle = userSpecifiedTruncatedDetails.length < details.length
       const truncatedDetails = showExcessDetailsToggle ? userSpecifiedTruncatedDetails : '';
       return {
         showExcessDetailsToggle,
@@ -105,12 +105,14 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
       }
     }
 
+    const suffix = '...';
+
     // Set the value of excessDetailsToggle. Note that it is not enough to have a showMoreLimit.
     // The card's details must extend past this limit as well for the toggling to be enabled.
-    const showExcessDetailsToggle = showMoreLimit && (details.length + 3 > showMoreLimit);
+    const showExcessDetailsToggle = showMoreLimit && (details.length + suffix.length > showMoreLimit);
     
     const truncatedDetails = showExcessDetailsToggle
-      ? `${details.substring(0, showMoreLimit)}...`
+      ? details.substring(0, showMoreLimit) + suffix
       : '';
     return {
       showExcessDetailsToggle,

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -95,7 +95,14 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
   }
 
   _getTruncatedDetails({ details = '', showMoreDetails }) {
+    /**
+     * @type {{
+     *   showMoreLimit?: number,
+     *   truncatedDetails?: string
+     * }}
+     */
     const { showMoreLimit, truncatedDetails: userSpecifiedTruncatedDetails } = showMoreDetails || {};
+
     if (userSpecifiedTruncatedDetails) {
       const showExcessDetailsToggle = userSpecifiedTruncatedDetails.length < details.length
       const truncatedDetails = showExcessDetailsToggle ? userSpecifiedTruncatedDetails : '';

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -94,7 +94,7 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
     });
   }
 
-  _getTruncatedDetails({ details, showMoreDetails }) {
+  _getTruncatedDetails({ details = '', showMoreDetails }) {
     const { showMoreLimit, truncatedDetails: userSpecifiedTruncatedDetails } = showMoreDetails || {};
     if (userSpecifiedTruncatedDetails) {
       const showExcessDetailsToggle = userSpecifiedTruncatedDetails.length + 3 < details.length

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -80,7 +80,8 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
     
     cardData.feedbackEnabled = ANSWERS.getAnalyticsOptIn() && cardData.feedback;
 
-    const { showExcessDetailsToggle, truncatedDetails } = this._getTruncatedDetails(cardData);
+    const { showExcessDetailsToggle, truncatedDetails } =
+      this._getTruncatedDetails(cardData.details, cardData.showMoreDetails);
     
     this.validateDataForRender(cardData);
 
@@ -94,14 +95,17 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
     });
   }
 
-  _getTruncatedDetails({ details = '', showMoreDetails }) {
-    /**
-     * @type {{
-     *   showMoreLimit?: number,
-     *   truncatedDetails?: string
-     * }}
-     */
-    const { showMoreLimit, truncatedDetails: userSpecifiedTruncatedDetails } = showMoreDetails || {};
+  /**
+   * Returns the whether to render the excess details toggle, and
+   * if so, the truncated details text.
+   * 
+   * @param {string} details 
+   * @param {Object} showMoreDetails
+   * @param {number} showMoreDetails.showMoreLimit
+   * @param {string} showMoreDetails.truncatedDetails
+   */
+  _getTruncatedDetails(details = '', showMoreDetails = {}) {
+    const { showMoreLimit, truncatedDetails: userSpecifiedTruncatedDetails } = showMoreDetails;
 
     if (userSpecifiedTruncatedDetails) {
       const showExcessDetailsToggle = userSpecifiedTruncatedDetails.length < details.length

--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -96,7 +96,7 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
   }
 
   /**
-   * Returns the whether to render the excess details toggle, and
+   * Returns whether to render the excess details toggle, and
    * if so, the truncated details text.
    * 
    * @param {string} details 

--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -21,7 +21,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // showMoreDetails: {
-      //   showMoreLimit: null, // Character count limit
+      //   truncatedDetails: profile.answer ? ANSWERS.formatRichText(profile.answer, "answer", linkTarget, 500) : null, // The truncated rich text
       //   showMoreText: '', // Label when toggle will show truncated text
       //   showLessText: '' // Label when toggle will hide truncated text
       // },

--- a/cards/multilang-faq-accordion/component.js
+++ b/cards/multilang-faq-accordion/component.js
@@ -21,7 +21,7 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // showMoreDetails: {
-      //   showMoreLimit: null, // Character count limit
+      //   truncatedDetails: profile.answer ? ANSWERS.formatRichText(profile.answer, "answer", linkTarget, 500) : null, // The truncated rich text
       //   showMoreText: '', // Label when toggle will show truncated text
       //   showLessText: '' // Label when toggle will hide truncated text
       // },

--- a/cards/multilang-product-prominentimage/component.js
+++ b/cards/multilang-product-prominentimage/component.js
@@ -34,7 +34,7 @@ class multilang_product_prominentimageCardComponent extends BaseCard['multilang-
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
-      //   showMoreLimit: 350, // Character count limit
+      //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text
       //   showLessText: {{ translateJS phrase='Show less' }} // Label when toggle will hide truncated text
       // },

--- a/cards/multilang-product-standard/component.js
+++ b/cards/multilang-product-standard/component.js
@@ -33,7 +33,7 @@ class multilang_product_standardCardComponent extends BaseCard['multilang-produc
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
-      //   showMoreLimit: 350, // Character count limit
+      //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text
       //   showLessText: {{ translateJS phrase='Show less' }} // Label when toggle will hide truncated text
       // },

--- a/cards/product-prominentimage/component.js
+++ b/cards/product-prominentimage/component.js
@@ -34,7 +34,7 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
-      //   showMoreLimit: 350, // Character count limit
+      //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: 'Show more', // Label when toggle will show truncated text
       //   showLessText: 'Show less' // Label when toggle will hide truncated text
       // },

--- a/cards/product-prominentvideo/component.js
+++ b/cards/product-prominentvideo/component.js
@@ -29,7 +29,7 @@ class product_prominentvideoCardComponent extends BaseCard['product-prominentvid
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
-      //   showMoreLimit: 24, // Character count limit
+      //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 24) : null, // The truncated rich text
       //   showMoreText: 'Show more', // Label when toggle will show truncated text
       //   showLessText: 'Show less' // Label when toggle will hide truncated text
       // },

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -33,7 +33,7 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
-      //   showMoreLimit: 350, // Character count limit
+      //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: 'Show more', // Label when toggle will show truncated text
       //   showLessText: 'Show less' // Label when toggle will hide truncated text
       // },

--- a/test-site/.gitignore
+++ b/test-site/.gitignore
@@ -9,6 +9,7 @@ package.json
 webpack-config.js
 
 !cards/custom-cta-icons/
+!cards/multilang-product-prominentvideo-custom/
 !config/global_config.json
 !config/locale_config.json
 !config/index.json

--- a/test-site/cards/multilang-product-prominentvideo-custom/component.js
+++ b/test-site/cards/multilang-product-prominentvideo-custom/component.js
@@ -1,6 +1,6 @@
-{{> cards/card_component componentName='multilang-product-prominentvideo' }}
+{{> cards/card_component componentName='multilang-product-prominentvideo-custom' }}
 
-class multilang_product_prominentvideoCardComponent extends BaseCard['multilang-product-prominentvideo'] {
+class multilang_product_prominentvideo_customCardComponent extends BaseCard['multilang-product-prominentvideo-custom'] {
   constructor(config = {}, systemConfig = {}) {
     super(config, systemConfig);
   }
@@ -28,11 +28,11 @@ class multilang_product_prominentvideoCardComponent extends BaseCard['multilang-
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
       // Note: If you are using rich text for the details, you should not enable this feature.
-      // showMoreDetails: {
-      //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 24) : null, // The truncated rich text
-      //   showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text
-      //   showLessText: {{ translateJS phrase='Show less' }} // Label when toggle will hide truncated text
-      // },
+      showMoreDetails: {
+        truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 38) : null, // The truncated rich text
+        showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text
+        showLessText: {{ translateJS phrase='Show less' }} // Label when toggle will hide truncated text
+      },
       // The primary CTA of the card
       CTA1: {
         label: profile.c_primaryCTA ? profile.c_primaryCTA.label : null, // The CTA's label
@@ -96,12 +96,12 @@ class multilang_product_prominentvideoCardComponent extends BaseCard['multilang-
    * @override
    */
   static defaultTemplateName (config) {
-    return 'cards/multilang-product-prominentvideo';
+    return 'cards/multilang-product-prominentvideo-custom';
   }
 }
 
 ANSWERS.registerTemplate(
-  'cards/multilang-product-prominentvideo',
-  {{{stringifyPartial (read 'cards/multilang-product-prominentvideo/template') }}}
+  'cards/multilang-product-prominentvideo-custom',
+  {{{stringifyPartial (read 'cards/multilang-product-prominentvideo-custom/template') }}}
 );
-ANSWERS.registerComponentType(multilang_product_prominentvideoCardComponent);
+ANSWERS.registerComponentType(multilang_product_prominentvideo_customCardComponent);

--- a/test-site/cards/multilang-product-prominentvideo-custom/template.hbs
+++ b/test-site/cards/multilang-product-prominentvideo-custom/template.hbs
@@ -1,0 +1,129 @@
+<div class="HitchhikerProductProminentVideo {{cardName}}">
+  {{> video }}
+  <div class="HitchhikerProductProminentVideo-body">
+    {{> title }}
+    {{> subtitle }}
+    {{> content }}
+    {{> thumbsfeedback card feedbackSubmitted=feedbackSubmitted}}
+  </div>
+</div>
+
+{{#*inline 'title'}}
+{{#if card.title}}
+<div class="HitchhikerProductProminentVideo-title">
+  {{#if card.url}}
+  <a class="HitchhikerProductProminentVideo-titleLink"
+    href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
+    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
+    data-eventtype="TITLE_CLICK"
+    data-eventoptions='{{json card.titleEventOptions}}'>
+    {{card.title}}
+  </a>
+  {{else}}
+  {{card.title}}
+  {{/if}}
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'subtitle'}}
+{{#if card.subtitle}}
+<div class="HitchhikerProductProminentVideo-subtitle">
+  {{card.subtitle}}
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'video'}}
+{{#if card.videoUrl}}
+  <div class="HitchhikerProductProminentVideo-videoWrapper">
+    <iframe
+      class="HitchhikerProductProminentVideo-video js-HitchhikerProductProminentVideo-video"
+      src="{{card.videoUrl}}"
+      allowfullscreen
+      frameBorder='0'
+      webkitAllowFullScreen
+      mozallowfullscreen>
+    </iframe>
+  </div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'content'}}
+{{#if (any card.details (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
+  <div class="HitchhikerProductProminentVideo-contentWrapper">
+    {{> details }}
+    {{> ctas }}
+  </div>
+{{/if}}
+{{/inline}}
+
+{{! Displays the details for the card. If showMoreDetails has been configured,
+    this partial handles the show more toggle, show less toggle, truncated details,
+    and full details. If showMoreDetails has not been configured, it will display the
+    the regular card details.
+}}
+{{#*inline 'details'}}
+{{#if card.details}}
+<div class="HitchhikerProductProminentVideo-cardDetails">
+  {{#if showExcessDetailsToggle}}
+    <div class="HitchhikerProductProminentVideo-detailsText js-HitchhikerCard-detailsText">
+      {{{truncatedDetails}}}
+    </div>
+  {{/if}}
+  <div class="HitchhikerProductProminentVideo-detailsText js-HitchhikerCard-detailsText{{#if showExcessDetailsToggle}} js-hidden{{/if}}">
+    {{{card.details}}}
+  </div>
+  {{#if showExcessDetailsToggle}}
+  <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
+    {{card.showMoreDetails.showMoreText}}
+    <span>
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
+    </span>
+  </button>
+  <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
+    {{card.showMoreDetails.showLessText}}
+    <span>
+      {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}
+    </span>
+  </button>
+  {{/if}}
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'ctas'}}
+{{#if (any (all card.CTA1 card.CTA1.url card.CTA1.label) (all card.CTA2 card.CTA2.url card.CTA2.label))}}
+<div class="HitchhikerProductProminentVideo-ctasWrapper">
+  {{> CTA card.CTA1 ctaName="primaryCTA" }}
+  {{> CTA card.CTA2 ctaName="secondaryCTA" }}
+</div>
+{{/if}}
+{{/inline}}
+
+{{#*inline 'CTA'}}
+{{#if (all url label)}}
+<div class="HitchhikerProductProminentVideo-{{ctaName}}">
+  <a class="HitchhikerCTA js-HitchhikerCTA{{#if modifiers}} {{modifiers}}{{/if}}"
+    href="{{#unless (isNonRelativeUrl url)}}{{@root.relativePath}}/{{/unless}}{{url}}"
+    data-eventtype="{{eventType}}"
+    data-eventoptions='{{json eventOptions}}'
+    target="{{#if target}}{{target}}{{else}}_top{{/if}}"
+    {{#if ariaLabel}}aria-label="{{ariaLabel}}"{{/if}}>
+    {{#if (any iconName iconUrl)}}
+    <div class="HitchhikerCTA-iconWrapper">
+      <div class="HitchhikerCTA-icon">
+        {{> icons/iconPartial
+            iconName=iconName
+            iconUrl=(relativePathHandler url=iconUrl relativePath=@root.relativePath)
+        }}
+      </div>
+    </div>
+    {{/if}}
+    <div class='HitchhikerCTA-iconLabel'>
+      {{label}}
+    </div>
+  </a>
+</div>
+{{/if}}
+{{/inline}}

--- a/test-site/config-overrides/products.json
+++ b/test-site/config-overrides/products.json
@@ -1,0 +1,9 @@
+{
+  "verticalsToConfig": {
+    "products": {
+      "universalLimit": 3,
+      "cardType": "multilang-product-prominentvideo-custom",
+      "universalSectionTemplate": "grid-three-columns"
+    }
+  }
+}

--- a/tests/browser-automation/pageoperator.js
+++ b/tests/browser-automation/pageoperator.js
@@ -51,7 +51,6 @@ class PageOperator {
       return;
     }
     for (const command of commands ) {
-      console.log('executing', command)
       await this._pageNavigator[command.type].call(this._pageNavigator, command.params);
     }
   }

--- a/tests/browser-automation/pageoperator.js
+++ b/tests/browser-automation/pageoperator.js
@@ -51,6 +51,7 @@ class PageOperator {
       return;
     }
     for (const command of commands ) {
+      console.log('executing', command)
       await this._pageNavigator[command.type].call(this._pageNavigator, command.params);
     }
   }

--- a/tests/percy/index.js
+++ b/tests/percy/index.js
@@ -36,17 +36,23 @@ async function rtlSnapshots(page) {
   await captureSnapshots(standardPageNavigator, page, standardCamera, 'ar');
 }
 
-async function captureSnapshots(navigator, page, camera, locale='en') {
-  const operator = new PageOperator(navigator, page, getTestingLocations(locale));
-  while (operator.hasNextTestLocation()) {
-    const testConfig = await operator.nextTestLocation();
-    if (testConfig.viewport) {
-      testConfig.viewport === 'mobile'
-       ? await camera.snapshotMobileOnly(testConfig.name)
-       : await camera.snapshotDesktopOnly(testConfig.name);
-    } else {
-      await camera.snapshot(testConfig.name);
+async function captureSnapshots(navigator, page, camera, locale = 'en') {
+  try {
+    const operator = new PageOperator(navigator, page, getTestingLocations(locale));
+    while (operator.hasNextTestLocation()) {
+      const testConfig = await operator.nextTestLocation();
+      if (testConfig.viewport) {
+        testConfig.viewport === 'mobile'
+          ? await camera.snapshotMobileOnly(testConfig.name)
+          : await camera.snapshotDesktopOnly(testConfig.name);
+      } else {
+        await camera.snapshot(testConfig.name);
+      }
     }
+  } catch (e) {
+    console.error('Error taking snapshot of', textConfig.name);
+    console.error(e);
+    process.exit(1);
   }
 }
 

--- a/tests/percy/index.js
+++ b/tests/percy/index.js
@@ -50,7 +50,7 @@ async function captureSnapshots(navigator, page, camera, locale = 'en') {
       }
     }
   } catch (e) {
-    console.error('Error taking snapshot of', textConfig.name);
+    console.error('Error taking snapshot of', testConfig.name);
     console.error(e);
     process.exit(1);
   }


### PR DESCRIPTION
This commit adds a new truncatedDetails property to the showMoreDetails
portion of dataForRender's return value. This property is intended to be used
for truncating rich text card details, though it is not necessarily limited to that.

Updated all cards that use ANSWERS.formatRichText by default to have truncatedDetails
instead of showMoreLimit in their showMoreDetails. We are not removing showMoreLimit.

Added a try catch to our percy snapshots that will exist on error, otherwise it looks like the node process
hangs forever. The snapshots still run on node 12.18, I think upgrading them to 16 also fix this issues,
since unhandled promise rejections automatically kill the process in later node versions. However,
the promise rejections would still be unhandled without the try catch. I didn't upgrade to 16 since people may still be using on 12.18.

J=SLAP-2039
TEST=manual,auto

updated the products test-site page to have rtf truncation

test non rtf truncation using showMoreLimit

cards with no details render correctly