### PR TITLE
remove rich text truncation warning comment

### DIFF
--- a/cards/multilang-product-prominentimage/component.js
+++ b/cards/multilang-product-prominentimage/component.js
@@ -32,7 +32,6 @@ class multilang_product_prominentimageCardComponent extends BaseCard['multilang-
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
-      // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
       //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text

--- a/cards/multilang-product-prominentvideo/component.js
+++ b/cards/multilang-product-prominentvideo/component.js
@@ -27,7 +27,6 @@ class multilang_product_prominentvideoCardComponent extends BaseCard['multilang-
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
-      // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
       //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 24) : null, // The truncated rich text
       //   showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text

--- a/cards/multilang-product-standard/component.js
+++ b/cards/multilang-product-standard/component.js
@@ -31,7 +31,6 @@ class multilang_product_standardCardComponent extends BaseCard['multilang-produc
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
-      // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
       //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text

--- a/cards/product-prominentimage/component.js
+++ b/cards/product-prominentimage/component.js
@@ -32,7 +32,6 @@ class product_prominentimageCardComponent extends BaseCard['product-prominentima
       // tag: profile.stockStatus ? profile.stockStatus : '', // The tag text for the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
-      // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
       //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: 'Show more', // Label when toggle will show truncated text

--- a/cards/product-prominentvideo/component.js
+++ b/cards/product-prominentvideo/component.js
@@ -27,7 +27,6 @@ class product_prominentvideoCardComponent extends BaseCard['product-prominentvid
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
-      // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
       //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 24) : null, // The truncated rich text
       //   showMoreText: 'Show more', // Label when toggle will show truncated text

--- a/cards/product-standard/component.js
+++ b/cards/product-standard/component.js
@@ -31,7 +31,6 @@ class product_standardCardComponent extends BaseCard['product-standard'] {
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
-      // Note: If you are using rich text for the details, you should not enable this feature.
       // showMoreDetails: {
       //   truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 350) : null, // The truncated rich text
       //   showMoreText: 'Show more', // Label when toggle will show truncated text

--- a/test-site/cards/multilang-product-prominentvideo-custom/component.js
+++ b/test-site/cards/multilang-product-prominentvideo-custom/component.js
@@ -27,7 +27,6 @@ class multilang_product_prominentvideo_customCardComponent extends BaseCard['mul
       details: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget) : null, // The text in the body of the card
       // If the card's details are longer than a certain character count, you can truncate the
       // text. A toggle will be supplied that can show or hide the truncated text.
-      // Note: If you are using rich text for the details, you should not enable this feature.
       showMoreDetails: {
         truncatedDetails: profile.richTextDescription ? ANSWERS.formatRichText(profile.richTextDescription, 'richTextDescription', linkTarget, 38) : null, // The truncated rich text
         showMoreText: {{ translateJS phrase='Show more' }}, // Label when toggle will show truncated text


### PR DESCRIPTION
Noticed this while writing instructions for how to use RTF truncation.
Obviously we don't need this warning now.

J=SLAP-2039
TEST=none