### PR TITLE
Fix text truncation in accordion card

### DIFF
--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -111,6 +111,19 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
       }
     });
 
+    const showExcessDetailsToggleEls = this._container.querySelectorAll('.js-HitchhikerFaqAccordion-detailsToggle');
+    const excessDetailsEls = this._container.querySelectorAll('.js-HitchhikerFaqAccordion-detailsText');
+    if (showExcessDetailsToggleEls && excessDetailsEls) {
+      showExcessDetailsToggleEls.forEach(el =>
+        el.addEventListener('click', () => {
+          contentEl.style.height = 'auto';
+          showExcessDetailsToggleEls.forEach(toggleEl => toggleEl.classList.toggle('js-hidden'));
+          excessDetailsEls.forEach(detailsEl => detailsEl.classList.toggle('js-hidden'));
+          contentEl.style.height = `${contentEl.scrollHeight}px`;
+        })
+      );
+    }
+
     super.onMount();
   }
 

--- a/cards/faq-accordion/template.hbs
+++ b/cards/faq-accordion/template.hbs
@@ -50,21 +50,21 @@
 {{#if card.details}}
 <div class="HitchhikerFaqAccordion-details">
   {{#if showExcessDetailsToggle}}
-    <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerCard-detailsText">
+    <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerFaqAccordion-detailsText">
       {{{truncatedDetails}}}
     </div>
   {{/if}}
-  <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerCard-detailsText{{#if showExcessDetailsToggle}} js-hidden{{/if}}">
+  <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerFaqAccordion-detailsText{{#if showExcessDetailsToggle}} js-hidden{{/if}}">
     {{{card.details}}}
   </div>
   {{#if showExcessDetailsToggle}}
-  <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
+  <button class="HitchhikerCard-detailsToggle js-HitchhikerFaqAccordion-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
       {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
-  <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
+  <button class="HitchhikerCard-detailsToggle js-HitchhikerFaqAccordion-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
       {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}

--- a/cards/multilang-faq-accordion/component.js
+++ b/cards/multilang-faq-accordion/component.js
@@ -111,6 +111,19 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
       }
     });
 
+    const showExcessDetailsToggleEls = this._container.querySelectorAll('.js-HitchhikerFaqAccordion-detailsToggle');
+    const excessDetailsEls = this._container.querySelectorAll('.js-HitchhikerFaqAccordion-detailsText');
+    if (showExcessDetailsToggleEls && excessDetailsEls) {
+      showExcessDetailsToggleEls.forEach(el =>
+        el.addEventListener('click', () => {
+          contentEl.style.height = 'auto';
+          showExcessDetailsToggleEls.forEach(toggleEl => toggleEl.classList.toggle('js-hidden'));
+          excessDetailsEls.forEach(detailsEl => detailsEl.classList.toggle('js-hidden'));
+          contentEl.style.height = `${contentEl.scrollHeight}px`;
+        })
+      );
+    }
+
     super.onMount();
   }
 

--- a/cards/multilang-faq-accordion/template.hbs
+++ b/cards/multilang-faq-accordion/template.hbs
@@ -50,21 +50,21 @@
 {{#if card.details}}
 <div class="HitchhikerFaqAccordion-details">
   {{#if showExcessDetailsToggle}}
-    <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerCard-detailsText">
+    <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerFaqAccordion-detailsText">
       {{{truncatedDetails}}}
     </div>
   {{/if}}
-  <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerCard-detailsText{{#if showExcessDetailsToggle}} js-hidden{{/if}}">
+  <div class="HitchhikerFaqAccordion-detailsText js-HitchhikerFaqAccordion-detailsText{{#if showExcessDetailsToggle}} js-hidden{{/if}}">
     {{{card.details}}}
   </div>
   {{#if showExcessDetailsToggle}}
-  <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle">
+  <button class="HitchhikerCard-detailsToggle js-HitchhikerFaqAccordion-detailsToggle">
     {{card.showMoreDetails.showMoreText}}
     <span>
       {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseDown' }}
     </span>
   </button>
-  <button class="HitchhikerCard-detailsToggle js-HitchhikerCard-detailsToggle js-hidden">
+  <button class="HitchhikerCard-detailsToggle js-HitchhikerFaqAccordion-detailsToggle js-hidden">
     {{card.showMoreDetails.showLessText}}
     <span>
       {{> icons/builtInIcon iconName='chevron' classNames='Icon--sm Icon--collapseUp' }}


### PR DESCRIPTION
This PR adds an event listener specifically for the details toggle in accordion cards to update the height of the content along with toggling the visible text. The details toggle for other cards will remain as is. This change now expands/shrinks the height of the card to match the expanding/shrinking of the details text.

Since the details text is switched without animation, it looked the most natural to have the expanding behavior also not have any animation. This is accomplished by setting the `height` to `auto` to allow the `height` to be recalculated after toggling the displayed text. But, to ensure that the animation behavior for collapsing/expanding the entire accordion card remains as is, the `height` is then set to the actual, recalculated `scrollHeight` value so it can be used for the animation calculations.

J=SLAP-2047
TEST=manual

Test `faq-accordion` and `multilang-faq-accordion` cards with details truncation enabled and see that toggling the details updates the card height instantly, but collapsing/expanding the FAQ keeps it's animation behavior.