### PR TITLE
Fix error resolving dependencies

### DIFF
--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -43,7 +43,7 @@
         "fs-extra": "^9.0.1",
         "grunt": "^1.3.0",
         "grunt-contrib-watch": "^1.1.0",
-        "grunt-webpack": "^4.0.0",
+        "grunt-webpack": "^4.0.3",
         "html-loader": "^2.1.2",
         "html-webpack-plugin": "^5.3.1",
         "jambo": "^1.12.1",
@@ -4462,9 +4462,9 @@
       }
     },
     "node_modules/grunt-webpack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.2.tgz",
-      "integrity": "sha512-rrqb9SRlY69jEJuCglelB7IvGrI7lRpdfH2GXpFlIOGPRTTtlSxYMU4Fjg8FHaC6ilnMbW5jd55Ff1lR5OibCA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.3.tgz",
+      "integrity": "sha512-hRnTf7y9pe4K+M/AKUJFgHykZeyIOUHhZSMVD0/jF/uXphMCen7txPIz8IOnJoa6bX0JrpoueOwo7FgS/OtC2Q==",
       "dev": true,
       "dependencies": {
         "deep-for-each": "^3.0.0",
@@ -4474,7 +4474,7 @@
         "node": ">=10.13.0"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0"
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/grunt/node_modules/glob": {
@@ -13132,9 +13132,9 @@
       }
     },
     "grunt-webpack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.2.tgz",
-      "integrity": "sha512-rrqb9SRlY69jEJuCglelB7IvGrI7lRpdfH2GXpFlIOGPRTTtlSxYMU4Fjg8FHaC6ilnMbW5jd55Ff1lR5OibCA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.3.tgz",
+      "integrity": "sha512-hRnTf7y9pe4K+M/AKUJFgHykZeyIOUHhZSMVD0/jF/uXphMCen7txPIz8IOnJoa6bX0JrpoueOwo7FgS/OtC2Q==",
       "dev": true,
       "requires": {
         "deep-for-each": "^3.0.0",

--- a/static/package.json
+++ b/static/package.json
@@ -28,7 +28,7 @@
     "fs-extra": "^9.0.1",
     "grunt": "^1.3.0",
     "grunt-contrib-watch": "^1.1.0",
-    "grunt-webpack": "^4.0.0",
+    "grunt-webpack": "^4.0.3",
     "html-loader": "^2.1.2",
     "html-webpack-plugin": "^5.3.1",
     "jambo": "^1.12.1",


### PR DESCRIPTION
Bump the `grunt-webpack` version in `static/package.json` to fix the error about resolving dependencies. v4.0.3 supports v5 of `webpack` as a peer dependency, which is what we use in the package.json. It seems like the inconsistency may have been introduced when upgrading to `lockfileVersion` 2.

![image](https://user-images.githubusercontent.com/88398086/170762266-5a8f331d-4166-47fc-b3f1-6acf4507a899.png)

J=none
TEST=manual

Set up the test-site and smoke tested. Saw that the error no longer occurred when running setup-test-site.