### PR TITLE
v1.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.1",
         "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "A starter answers theme for hitchhikers",
   "scripts": {
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu jest --verbose",

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@vimeo/player": "^2.15.3",
@@ -43,7 +43,7 @@
         "fs-extra": "^9.0.1",
         "grunt": "^1.3.0",
         "grunt-contrib-watch": "^1.1.0",
-        "grunt-webpack": "^4.0.0",
+        "grunt-webpack": "^4.0.3",
         "html-loader": "^2.1.2",
         "html-webpack-plugin": "^5.3.1",
         "jambo": "^1.12.1",
@@ -4462,9 +4462,9 @@
       }
     },
     "node_modules/grunt-webpack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.2.tgz",
-      "integrity": "sha512-rrqb9SRlY69jEJuCglelB7IvGrI7lRpdfH2GXpFlIOGPRTTtlSxYMU4Fjg8FHaC6ilnMbW5jd55Ff1lR5OibCA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.3.tgz",
+      "integrity": "sha512-hRnTf7y9pe4K+M/AKUJFgHykZeyIOUHhZSMVD0/jF/uXphMCen7txPIz8IOnJoa6bX0JrpoueOwo7FgS/OtC2Q==",
       "dev": true,
       "dependencies": {
         "deep-for-each": "^3.0.0",
@@ -4474,7 +4474,7 @@
         "node": ">=10.13.0"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0"
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/grunt/node_modules/glob": {
@@ -13132,9 +13132,9 @@
       }
     },
     "grunt-webpack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.2.tgz",
-      "integrity": "sha512-rrqb9SRlY69jEJuCglelB7IvGrI7lRpdfH2GXpFlIOGPRTTtlSxYMU4Fjg8FHaC6ilnMbW5jd55Ff1lR5OibCA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-4.0.3.tgz",
+      "integrity": "sha512-hRnTf7y9pe4K+M/AKUJFgHykZeyIOUHhZSMVD0/jF/uXphMCen7txPIz8IOnJoa6bX0JrpoueOwo7FgS/OtC2Q==",
       "dev": true,
       "requires": {
         "deep-for-each": "^3.0.0",

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "fs-extra": "^9.0.1",
     "grunt": "^1.3.0",
     "grunt-contrib-watch": "^1.1.0",
-    "grunt-webpack": "^4.0.0",
+    "grunt-webpack": "^4.0.3",
     "html-loader": "^2.1.2",
     "html-webpack-plugin": "^5.3.1",
     "jambo": "^1.12.1",


### PR DESCRIPTION
### Bug Fixes
* Updated the `grunt-webpack` dependency to be compatible with `webpack` v5. Previous versions of `grunt-webpack` had the following peer dependency: `webpack: ^4.0.0`. This caused issues for certain Node versions because we use v5 of `webpack`. However, v4.0.3 of `grunt-webpack` has the peer dependency: `webpack: ^4.0.0 || ^5.0.0`.