### PR TITLE
fix location bias not working on mobile full page map

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -355,6 +355,7 @@
       bottom: 0;
       background-color: var(--hh-color-gray-2);
       position: sticky;
+      pointer-events: all;
     }
 
     &-mapFooter {


### PR DESCRIPTION
Adds pointer-events: all so that it can be clicked on mobile.

J=TECHOPS-5514
TEST=manual

saw that without this change, the location bias button is not clickable,
but is clickable afterwards