### PR TITLE
update styling for VerticalFullPageMap viewAllResults button

### DIFF
--- a/static/scss/answers/interactive-map/VerticalFullPageMap.scss
+++ b/static/scss/answers/interactive-map/VerticalFullPageMap.scss
@@ -640,6 +640,11 @@
       width: 100%;
       position: absolute;
     }
+
+    @include bplte($mobile-break-point-max)
+    {
+      pointer-events: all;
+    }
   }
 
   &.CollapsibleFilters .Answers-filtersWrapper {


### PR DESCRIPTION
Due to a layout change in vertical full page map template to [Fix CollapsibleFilters tab order](https://github.com/yext/answers-hitchhiker-theme/commit/51008f610c3c915e881ad98abd4620d83fe34ad3), the styling for the top level `Answers-contentWrap` class, `pointer-events: none;`, got applied to the view results button, making it unclickable. Even though other templates, like vertical grid, also had the same layout changes, this style is only use in VerticalFullPageMap.scss.
This pr added a styling `pointer-events: all;` targeting Answers-viewResultsButton classname specifically when it's use in mobile view in VerticalFullPageMap template.

J=TECHOP-5941
TEST=manual

spin up test site and open up page `locations_full_page_map_with_filters` (which is a vertical-full-page-map template). Bring screen size to mobile width, and click the filters button. See that the view results button is now clickable and return me to the results view.
As a sanity check, check the the view results button in `people` page (which is a vertical-grid template) works as expected still.