### PR TITLE
Correctly pass `searcher` in DA analytics

### DIFF
--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -25,7 +25,6 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
     this.validateDataForRender(cardData);
     return super.setState({
       ...cardData,
-      searcher: data.searcher,
       feedbackEnabled: ANSWERS.getAnalyticsOptIn(),
       feedbackSubmitted: data.feedbackSubmitted,
       isArray: Array.isArray(this.answer.value),
@@ -97,7 +96,7 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
       .addOptions({
         directAnswer: true,
         verticalKey: this.verticalConfigId,
-        searcher: this.getState('searcher'),
+        searcher: this._config.data.searcher,
         entityId: this.associatedEntityId
       });
 
@@ -120,7 +119,7 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
    */
   addDefaultEventOptions(eventOptions = {}) {
     return Object.assign({}, {
-        searcher: this.getState('searcher'),
+        searcher: this._config.data.searcher,
         verticalConfigId: this.verticalConfigId,
         entityId: this.associatedEntityId,
         ...eventOptions
@@ -144,7 +143,7 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
       verticalKey: this.verticalConfigId,
       directAnswer: true,
       fieldName: this.answer.fieldApiName,
-      searcher: this.getState('searcher'),
+      searcher: this._config.data.searcher,
       entityId: this.associatedEntityId,
       url: event.target.href
     };


### PR DESCRIPTION
Update the direct answer card component to correctly pass the `searcher` as part of analytics events.

Like in the SDK, for RTF and thumbs feedback analytics events, the `searcher` was passed correctly because the options for those analytics events are set from `onMount`, at which point the `searcher` has been set in state. But, for other analytics events like CTA clicks that used `addDefaultEventOptions` to set the options, the `searcher` is not necessarily set in state before the options for those events are calculated. In these cases, `this.getState('searcher')` returned `undefined`, so clicking on a CTA would hit the analytics endpoint without the required `searcher` data and get an error in the response. Using `this._config.data.searcher` directly fixes this issue. Since this data is available in the config, I updated all references to `searcher` and removed it from state so there is no ambiguity in how the information is being set/updated.

See [this Slack thread](https://yext.slack.com/archives/C016ZKY42CF/p1666202290083719) where the issue was raised for more context.

J=TECHOPS-7011
TEST=manual

Spin up the test-site and test on both universal and vertical pages. See that without this change, CTA clicks would result in a bad request to the analytics endpoint with the error `Record missing required field: searcher`. With this change, the correct value for `searcher` was sent in the request. Thumbs feedback and RTF analytics requests continued to pass the `searcher` correctly.