### PR TITLE
Update `set-output` command

### DIFF
--- a/.github/workflows/percy-snapshots.yml
+++ b/.github/workflows/percy-snapshots.yml
@@ -12,7 +12,7 @@ jobs:
       result: ${{ steps.nonce.outputs.result }}
     steps:
     - id: nonce
-      run: echo "::set-output name=result::${{ github.run_id }}-$(date +%s)"
+      run: echo result=${{ github.run_id }}-$(date +%s) >> $GITHUB_OUTPUT
 
   call_snapshots_default:
     needs: nonce


### PR DESCRIPTION
Update the `set-output` call in the Percy snapshots workflow to remove a deprecation warning based on [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). Warnings for the deprecation of [Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) will be handled in a different [item](https://yexttest.atlassian.net/browse/SLAP-2468).

J=SLAP-2427
TEST=manual

Test in this PR and see that the warning for `set-output` is no longer present.