### PR TITLE
Remove Node 12 deprecation warnings

### DIFF
--- a/.github/workflows/acceptance_browserstack.yml
+++ b/.github/workflows/acceptance_browserstack.yml
@@ -12,8 +12,8 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
       - run: npm ci
@@ -28,8 +28,8 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
       - run: npm ci

--- a/.github/workflows/acceptance_headless.yml
+++ b/.github/workflows/acceptance_headless.yml
@@ -7,8 +7,8 @@ jobs:
     name: Chrome Acceptance Tests (Headless)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
       - run: npm ci

--- a/.github/workflows/translation-test.yml
+++ b/.github/workflows/translation-test.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         node-version: [15.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci


### PR DESCRIPTION
Update `actions/checkout` and `actions/setup-node` GH actions to remove Node 12 deprecation warnings.

J=SLAP-2468
TEST=manual

See that the acceptance and translation test workflows no longer have warnings on the `Test` commit.