### PR TITLE
Correct bug in `isStaging` method.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "answers-hitchhiker-theme",
       "version": "1.30.0",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0"
+      },
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.1",
         "@babel/core": "^7.9.6",
@@ -582,6 +585,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
@@ -3056,6 +3068,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/@oclif/parser/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@oclif/parser/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5220,6 +5241,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/boxen/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/boxen/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5538,6 +5568,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "node_modules/callsite-record/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/callsite-record/node_modules/has-flag": {
       "version": "3.0.0",
@@ -6885,12 +6924,14 @@
       "dev": true
     },
     "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escodegen": {
@@ -8188,6 +8229,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "node_modules/highlight-es/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/highlight-es/node_modules/has-flag": {
       "version": "3.0.0",
@@ -10515,6 +10565,15 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
+    "node_modules/match-url-wildcard/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -12752,6 +12811,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "node_modules/serve/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/serve/node_modules/fast-deep-equal": {
       "version": "2.0.1",
@@ -15206,6 +15274,15 @@
         }
       }
     },
+    "node_modules/testcafe/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/testcafe/node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -16990,6 +17067,12 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
@@ -18908,6 +18991,12 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -20660,6 +20749,12 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -20912,6 +21007,12 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
@@ -22019,10 +22120,9 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
     "escodegen": {
       "version": "1.14.1",
@@ -23078,6 +23178,12 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
@@ -24961,6 +25067,14 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        }
       }
     },
     "media-typer": {
@@ -26688,6 +26802,12 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -28194,6 +28314,12 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
         },
         "execa": {
           "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3241,6 +3241,7 @@
       "version": "1.0.0-beta.67",
       "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.0-beta.67.tgz",
       "integrity": "sha512-8XCCqpkheuB44s8IhAQt/jpjJTwLwqYAaPv33NyjwFfgJMfsENgwuGyqUYoukvCaSIEMkOc5zF6PlNyhayOm9Q==",
+      "deprecated": "Beta versions of @percy/cli are deprecated. Please update to the latest stable version to ensure compatibility",
       "dev": true,
       "dependencies": {
         "@oclif/plugin-help": "^3.2.0",
@@ -4595,6 +4596,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/asar/-/asar-2.1.0.tgz",
       "integrity": "sha512-d2Ovma+bfqNpvBzY/KU8oPY67ZworixTpkjSx0PCXnQi67c2cXmssaTxpFDUM0ttopXoGx/KRxNg/GDThYbXQA==",
+      "deprecated": "Please use @electron/asar moving forward.  There is no API change, just a package name change",
       "dev": true,
       "dependencies": {
         "chromium-pickle-js": "^0.2.0",
@@ -8448,6 +8450,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -11751,6 +11759,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.2.0.tgz",
       "integrity": "sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==",
+      "deprecated": "< 18.1.0 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -13124,6 +13133,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -13147,6 +13157,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/spdx-correct": {
@@ -16146,6 +16157,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dev": true,
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
@@ -23356,6 +23368,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icu4c-data": {
+      "version": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
       "/wcag/",
       "/acceptance/"
     ]
+  },
+  "dependencies": {
+    "escape-string-regexp": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
     "modulePathIgnorePatterns": [
       "/test-site/"
     ],
+    "transformIgnorePatterns": [
+      "!node_modules/escape-string-regexp"
+    ],
     "testPathIgnorePatterns": [
       "/fixtures/",
       "/test-utils/",

--- a/static/js/is-staging.js
+++ b/static/js/is-staging.js
@@ -1,9 +1,19 @@
+import escapeStringRegexp from 'escape-string-regexp';
+
 /**
  * Determines whether the current url is staging or production.
  */
 export function isStaging(stagingDomains) {
   const defaultStagingDomains = ['127.0.0.1', 'localhost', 'office.yext.com'];
-  const _stagingDomains = defaultStagingDomains.concat(stagingDomains);
-  const currentUrl = window.location.href;
-  return _stagingDomains.some(domain => currentUrl.includes(domain));
+  const _stagingDomains = stagingDomains
+    ? defaultStagingDomains.concat(stagingDomains)
+    : defaultStagingDomains;
+  const currentDomain = window.location.hostname;
+
+  return _stagingDomains.some(domain => {
+    const regexEscapedDomain = escapeStringRegexp(domain);
+    const isSubdomainRegex = new RegExp(`[A-Za-z0-9]?[A-Za-z0-9\-]{0,61}[A-Za-z0-9]?\.${regexEscapedDomain}`);
+
+    return domain === currentDomain || isSubdomainRegex.test(currentDomain);
+  });
 }

--- a/static/js/is-staging.js
+++ b/static/js/is-staging.js
@@ -12,6 +12,7 @@ export function isStaging(stagingDomains) {
 
   return _stagingDomains.some(domain => {
     const regexEscapedDomain = escapeStringRegexp(domain);
+    // The RFC for subdomains says they can contain a maximum of 63 characters. The leading and trailing characters must be alpha numeric. 
     const isSubdomainRegex = new RegExp(`[A-Za-z0-9]?[A-Za-z0-9\-]{0,61}[A-Za-z0-9]?\.${regexEscapedDomain}`);
 
     return domain === currentDomain || isSubdomainRegex.test(currentDomain);

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -13,6 +13,7 @@
         "core-js": "^3.6.5",
         "css-vars-ponyfill": "^2.3.1",
         "escape-html": "^1.0.3",
+        "escape-string-regexp": "^5.0.0",
         "file-system": "^2.2.2",
         "fs-extra": "^8.1.0",
         "iframe-resizer": "^4.1.1",
@@ -2434,6 +2435,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/chalk/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
@@ -3456,12 +3466,14 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escodegen": {
@@ -11279,6 +11291,14 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        }
       }
     },
     "chokidar": {
@@ -12105,10 +12125,9 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
     "escodegen": {
       "version": "1.14.3",

--- a/static/package.json
+++ b/static/package.json
@@ -50,6 +50,7 @@
     "core-js": "^3.6.5",
     "css-vars-ponyfill": "^2.3.1",
     "escape-html": "^1.0.3",
+    "escape-string-regexp": "^5.0.0",
     "file-system": "^2.2.2",
     "fs-extra": "^8.1.0",
     "iframe-resizer": "^4.1.1",

--- a/tests/static/js/is-staging.js
+++ b/tests/static/js/is-staging.js
@@ -6,32 +6,42 @@ describe('isStaging', () => {
   global.window = Object.create(window);
   global.window.location = {};
 
-  function setHref(href) {
-    window.location.href = href;
+  function setDomain(url) {
+    const domainRegex = /:\/\/([^:\/]+)[:\/]?/;
+    window.location.hostname = url.match(domainRegex)[1];
   }
 
   const testStagingDomains = ["yextpages.net", "landingpagespreview.com"];
-  beforeEach(() => {
-    // Reset window.location.href to the default value in a jest test
-    setHref('http://localhost/');
-  });
 
-  it('works correctly for default staging domains', () => {
+  it('handles locally hosted sites properly', () => {
+    setDomain('http://localhost:3000/my-local/url');
     expect(isStaging()).toBeTruthy();
-    setHref('http://localhost:3000/my-local/url');
-    expect(isStaging()).toBeTruthy();
-    setHref('http://127.0.0.1/my-local/url');
+    setDomain('http://127.0.0.1/my-local/url');
     expect(isStaging()).toBeTruthy()
-    setHref('http://breed.office.yext.com/my-local/url');
-    expect(isStaging()).toBeTruthy();
   });
 
-  it('can check stagingDomains correctly', () => {
-    setHref('https://yextpages.net/angelas-adventure-articles');
-    expect(isStaging()).toBeFalsy();
+  it('handles Office-hosted sites properly', () => {
+    setDomain('http://breed.office.yext.com/my-local/url');
+    expect(isStaging()).toBeTruthy();
+  })
+
+  it('handles a page of a Staging site properly', () => {
+    setDomain('https://yextpages.net/angelas-adventure-articles');
     expect(isStaging(testStagingDomains)).toBeTruthy();
-    setHref('https://bob.landingpagespreview.com/angelas-adventure-articles');
-    expect(isStaging()).toBeFalsy();
+  })
+
+  it('handles a subdomain of a Staging site properly', () => {
+    setDomain('https://bob.landingpagespreview.com/angelas-adventure-articles');
     expect(isStaging(testStagingDomains)).toBeTruthy();
   });
+
+  it('handles a port of a Staging site properly', () => {
+    setDomain('https://yextpages.net/angelas-adventure-articles:9000');
+    expect(isStaging(testStagingDomains)).toBeTruthy();
+  });
+
+  it('handles redirect from a Staging site to a Production site correctly', () => {
+    setDomain('https://production-url.com/page?referrerPageUrl=https://yextpages.net/');
+    expect(isStaging(testStagingDomains)).toBeFalsy();
+  })
 });


### PR DESCRIPTION
This PR corrects a bug in the `isStaging` method. If you were referred to a Production site from a Staging link, `isStaging` would incorrectly report `true`. This is because the `includes` check on the `href` would catch the Staging `referrerPageUrl`. Simply comparring `window.location.hostname` instead of `window.location.href` fixes this. I also did some code cleanup in this method and its test suite.

J=SLAP-2546
TEST=auto