### PR TITLE
dateRange formatter: Use dateFormatOptions for same-day end times

### DIFF
--- a/static/js/formatters-internal.js
+++ b/static/js/formatters-internal.js
@@ -208,9 +208,10 @@ export function dateRange(
   if (startString && endString) {
     if (start.toLocaleDateString() === end.toLocaleDateString()) {
       endString = end.toLocaleString(locale, {
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: true,
+        ...dateFormatOptions,
+        month: undefined,
+        day: undefined,
+        year: undefined,
       });
     }
 


### PR DESCRIPTION
If an end date is on the same day, the dateRange formatter will not show the month, day, and year of the end date, only the time.

However, it was passing in the default format options with month, day, and year removed instead of using the format options passed in through the dateFormatOptions parameter.

This update makes it so that dateFormatOptions are respected for end times with only the options for month, day, and year removed.

J=PC-201542
TEST=manual