### PR TITLE
Upgrade Simple Git to latest major and minor.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "postcss": "^8.4.14",
         "puppeteer": "^10.2.0",
         "serve": "^11.3.2",
-        "simple-git": "^2.24.0",
+        "simple-git": "^3.17.0",
         "testcafe": "^1.20.0",
         "underscore.string": "^3.3.6",
         "urijs": "^1.19.11",
@@ -5986,12 +5986,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -9245,14 +9239,35 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.24.0.tgz",
-      "integrity": "sha512-nF31Xai5lTYgRCiSJ1lHzK0Vk9jWOvAFW12bdBaWy2bhodio04eOWYurvyM/nTBYsPIiQl3PFvdod5TRcPvzww==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/sisteransi": {
@@ -16931,11 +16946,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "icu4c-data": {
-      "version": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
-    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -19430,14 +19440,25 @@
       "dev": true
     },
     "simple-git": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.24.0.tgz",
-      "integrity": "sha512-nF31Xai5lTYgRCiSJ1lHzK0Vk9jWOvAFW12bdBaWy2bhodio04eOWYurvyM/nTBYsPIiQl3PFvdod5TRcPvzww==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "sisteransi": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "postcss": "^8.4.14",
     "puppeteer": "^10.2.0",
     "serve": "^11.3.2",
-    "simple-git": "^2.24.0",
+    "simple-git": "^3.17.0",
     "testcafe": "^1.20.0",
     "underscore.string": "^3.3.6",
     "urijs": "^1.19.11",

--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -52,6 +52,11 @@ exports.removeEmptyDirectoriesRecursively = removeEmptyDirectoriesRecursively;
  */
 async function isGitSubmodule(submodulePath) {
   const submodulePaths = await simpleGit.subModule(['foreach', '--quiet', 'echo $sm_path']);
+
+  const temp = !!submodulePaths
+    .split('\n')
+    .find(p => p === submodulePath);
+  console.log('TEMP', temp);
   
   return !!submodulePaths
     .split('\n')

--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const simpleGit = require('simple-git/promise')();
+const simpleGit = require('simple-git')();
 
 /**
  * Gets the value of a given --jambo command line argument.

--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -52,6 +52,8 @@ exports.removeEmptyDirectoriesRecursively = removeEmptyDirectoriesRecursively;
  */
 async function isGitSubmodule(submodulePath) {
   const submodulePaths = await simpleGit.subModule(['foreach', '--quiet', 'echo $sm_path']);
+  console.log(submodulePath);
+  console.log(submodulePaths);
 
   const temp = !!submodulePaths
     .split('\n')

--- a/postupgrade/utils.js
+++ b/postupgrade/utils.js
@@ -52,13 +52,6 @@ exports.removeEmptyDirectoriesRecursively = removeEmptyDirectoriesRecursively;
  */
 async function isGitSubmodule(submodulePath) {
   const submodulePaths = await simpleGit.subModule(['foreach', '--quiet', 'echo $sm_path']);
-  console.log(submodulePath);
-  console.log(submodulePaths);
-
-  const temp = !!submodulePaths
-    .split('\n')
-    .find(p => p === submodulePath);
-  console.log('TEMP', temp);
   
   return !!submodulePaths
     .split('\n')

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -56,7 +56,7 @@
         "rtlcss-webpack-plugin": "^4.0.7",
         "sass": "^1.34.0",
         "sass-loader": "^8.0.2",
-        "simple-git": "^2.15.0",
+        "simple-git": "^3.17.0",
         "webpack": "^5.37.1",
         "webpack-cli": "^4.2.0",
         "webpack-merge": "^5.7.3"
@@ -3062,13 +3062,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decimal.js": {
@@ -5316,23 +5323,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/jambo/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/jambo/node_modules/fs-extra": {
@@ -7794,14 +7784,18 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.15.0.tgz",
-      "integrity": "sha512-a1IE3q8pWsGhQR0/ugAkXls2ekbB7LDhJnFnrS/R+5zFZZbN4bfdIp3Vdht4x/z1oIH/8IHiKdjilN55FGL70g==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.1.1"
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/sisteransi": {
@@ -11790,12 +11784,12 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decimal.js": {
@@ -13524,15 +13518,6 @@
             "esprima": "^4.0.1",
             "has-own-prop": "^2.0.0",
             "repeat-string": "^1.6.1"
-          }
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
           }
         },
         "fs-extra": {
@@ -15402,14 +15387,14 @@
       "dev": true
     },
     "simple-git": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.15.0.tgz",
-      "integrity": "sha512-a1IE3q8pWsGhQR0/ugAkXls2ekbB7LDhJnFnrS/R+5zFZZbN4bfdIp3Vdht4x/z1oIH/8IHiKdjilN55FGL70g==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.1.1"
+        "debug": "^4.3.4"
       }
     },
     "sisteransi": {

--- a/static/package.json
+++ b/static/package.json
@@ -40,7 +40,7 @@
     "rtlcss-webpack-plugin": "^4.0.7",
     "sass": "^1.34.0",
     "sass-loader": "^8.0.2",
-    "simple-git": "^2.15.0",
+    "simple-git": "^3.17.0",
     "webpack": "^5.37.1",
     "webpack-cli": "^4.2.0",
     "webpack-merge": "^5.7.3"


### PR DESCRIPTION
This PR upgrades the version of `simple-git` used by the Theme. This will address a number of Snyk issues. In the latest version of `simple-git`, you import `simple-git` directly, not `simple-git/promise`. 

TEST=manual

Ensured that the logic for determining if the Theme is a submodule still worked as expected. This is the only usage of `simple-git` in the Theme. 