### PR TITLE
Support direct rendering of HTML for richTextV2 and Markdown

### DIFF
--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -17,6 +17,8 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
     let snippetValue = '';
     if (answer.fieldType === "rich_text" && snippet) {
       snippetValue = ANSWERS.formatRichText(snippet.value, 'snippet', linkTarget);
+    } else if (answer.fieldType == "html" && snippet) {
+      snippetValue = snippet.value;
     } else if (snippet) {
       snippetValue = Formatter.highlightField(snippet.value, snippet.matchedSubstrings);
     }


### PR DESCRIPTION
Support direct rendering of HTML (if richTextV2 or Markdown is used and conversion to HTML is enabled)

J=BACK-2241

T=manual

created a test site using the answers hitchikers theme and verified that rich text was rendered properly