### PR TITLE
Update version number in package-lock.json files

### DIFF
--- a/directanswercards/documentsearch-standard/component.js
+++ b/directanswercards/documentsearch-standard/component.js
@@ -17,6 +17,8 @@ class documentsearch_standardComponent extends BaseDirectAnswerCard['documentsea
     let snippetValue = '';
     if (answer.fieldType === "rich_text" && snippet) {
       snippetValue = ANSWERS.formatRichText(snippet.value, 'snippet', linkTarget);
+    } else if (answer.fieldType == "html" && snippet) {
+      snippetValue = snippet.value;
     } else if (snippet) {
       snippetValue = Formatter.highlightField(snippet.value, snippet.matchedSubstrings);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.5.2",
         "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "A starter Search theme for hitchhikers",
   "keywords": [
     "jambo",

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@vimeo/player": "^2.15.3",

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {


### PR DESCRIPTION
After merging [this](https://github.com/yext/answers-hitchhiker-theme/commit/df3f6b7c798a271ee5bf104c931c0f6a889c57c5) pull request, I realized there were two more lines in both package-lock.json and static/package-lock.json that needed to have the updated version numbers. Amending in this PR before merging from develop into master to avoid any conflicts.

J=BACK-2436
TEST=none