### PR TITLE
Add version number updates to package-lock.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.5.2",
         "@babel/core": "^7.9.6",

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@vimeo/player": "^2.15.3",


### PR DESCRIPTION
After merging [this](https://github.com/yext/answers-hitchhiker-theme/commit/df3f6b7c798a271ee5bf104c931c0f6a889c57c5) pull request, I realized there were two more lines in both package-lock.json and static/package-lock.json that needed to have the updated version numbers. Amending in this PR before merging from develop into master to avoid any conflicts.

J=BACK-2436
TEST=none