### PR TITLE
Fix failing translation tests

### DIFF
--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -147,7 +147,7 @@ msgstr ""
 
 #: cards/multilang-document-standard/component.js:53
 #: cards/multilang-event-standard/component.js:53
-#: cards/multilang-faq-accordion/component.js:51
+#: cards/multilang-faq-accordion/component.js:60
 #: cards/multilang-financial-professional-location/component.js:69
 #: cards/multilang-job-standard/component.js:44
 #: cards/multilang-link-standard/component.js:32
@@ -171,7 +171,7 @@ msgstr[1] ""
 
 #: cards/multilang-document-standard/component.js:54
 #: cards/multilang-event-standard/component.js:54
-#: cards/multilang-faq-accordion/component.js:52
+#: cards/multilang-faq-accordion/component.js:61
 #: cards/multilang-financial-professional-location/component.js:70
 #: cards/multilang-job-standard/component.js:45
 #: cards/multilang-link-standard/component.js:33
@@ -191,7 +191,7 @@ msgstr ""
 
 #: cards/multilang-document-standard/component.js:55
 #: cards/multilang-event-standard/component.js:55
-#: cards/multilang-faq-accordion/component.js:53
+#: cards/multilang-faq-accordion/component.js:62
 #: cards/multilang-financial-professional-location/component.js:71
 #: cards/multilang-job-standard/component.js:46
 #: cards/multilang-link-standard/component.js:34


### PR DESCRIPTION
The translation files were failing because the line numbers in the multilang-accordion card changed

I ran `npm run extract-translations` to update the files

J=BACK-2463
TEST=manual

Confirmed tests now pass