### PR TITLE
Fix iframe Answers Map/List toggle button on Mobile Error

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -70,6 +70,8 @@ export function generateIFrame(domain, answersExperienceFrame) {
   iframe.frameBorder = 0;
 
    // For dynamic iFrame sizing
+  iframe.style.height = '100%';
+  iframe.style.minHeight = '100%';
   iframe.style.width = '1px';
   iframe.style.minWidth = '100%';
   iframe.id = 'answers-frame';


### PR DESCRIPTION
Iframe needs height in order for map and toggle button to be initialized and to fill js-answersMap