### PR TITLE
fix(iframe-common.js): properly encode referrerPageUrl param

### DIFF
--- a/static/js/iframe-common.js
+++ b/static/js/iframe-common.js
@@ -29,7 +29,7 @@ export function generateIFrame(domain, answersExperienceFrame) {
     // Parse the params out of the URL
     var params = paramString.split('&'),
                  verticalUrl;
-    var referrerPageUrl = document.referrer.split('?')[0].split('#')[0];
+    var referrerPageUrl = encodeURIComponent(document.referrer.split('?')[0].split('#')[0]);
 
     if (pathToIndex) {
       verticalUrl = pathToIndex;


### PR DESCRIPTION
Currently, referrerPageUrl is added as a query param value without being escaped. That can cause problems on sites with tighter security restrictions. We faced this problem on several sites such as this one: https://yexttest.atlassian.net/browse/PC-208916

It can also cause functional problems when the referrer URL has query parameters. For example, a URL of http://example.com?a=1&b=2 will lead to https://answers.example.com?query=TEST&referrerPageUrl=http://example.com?a=1&b=2

In that example, &b=2 will be treated as a query parameter of the  results page URL instead of being part of the referrerPageUrl value.