### PR TITLE
Remove styling to allow switching answers-search-ui icon divs to spans

### DIFF
--- a/static/scss/answers/theme.scss
+++ b/static/scss/answers/theme.scss
@@ -134,10 +134,6 @@
       margin-top: calc(var(--yxt-base-spacing) / 2);
       margin-bottom: calc(var(--yxt-base-spacing) / 4);
     }
-
-    span {
-      display: inline-block;
-    }
   }
 
   &-results {


### PR DESCRIPTION
This PR removes styling that targets arbitrary `span`s in `Answers-resultsHeader`. This styling was being automatically applied to icons using the answers-search-ui partial (or other icons) when the `div`s were changed to `span`s for accessibility reasons, which caused visual regressions. This was only an issue on vertical full page map templates which include the search bar and nav tabs in `Answers-resultsHeader`, instead of just the results count and applied filters.

Based on the [PR](https://github.com/yext/answers-hitchhiker-theme/pull/900) that initially added this styling, this was needed to ensure results count elements had the correct ordering on both ltr and rtl experiences. I checked a vertical template and vertical full page map template for `en` and `ar` locales in the test site and the results count elements seem to still be flipped, as expected. The only other `span`s that I saw within `Answers-resultsHeader` seemed to be the nav More icon and applied filters, both of which seemed fine after removing this styling.

J=TECHOPS-11042
TEST=manual

Since we no longer have a paid Percy subscription, our snapshots are not being generated. So I've included some screenshots of pages after the changes in this PR, pointing to v1.16.6 of answers-search-ui which contains the icon `div` to `span` change:

**en:**
<img width="1008" alt="Screenshot 2024-02-20 at 9 08 26 AM" src="https://github.com/yext/answers-hitchhiker-theme/assets/88398086/a6165616-2316-43b0-9112-7bedf0912017">
<img width="1159" alt="Screenshot 2024-02-20 at 9 08 01 AM" src="https://github.com/yext/answers-hitchhiker-theme/assets/88398086/4338ec87-7c12-4588-842a-7d7836856f11">
<img width="1157" alt="Screenshot 2024-02-20 at 9 07 39 AM" src="https://github.com/yext/answers-hitchhiker-theme/assets/88398086/8296e98e-d853-48b6-ae41-4decdec084cb">

**ar:**
<img width="1007" alt="Screenshot 2024-02-20 at 9 09 00 AM" src="https://github.com/yext/answers-hitchhiker-theme/assets/88398086/159e1481-a389-4738-ae9e-ac9544202787">
<img width="1153" alt="Screenshot 2024-02-20 at 9 09 16 AM" src="https://github.com/yext/answers-hitchhiker-theme/assets/88398086/85d7d97b-a3b1-4b0d-9a2f-8752b2225d8e">
<img width="1157" alt="Screenshot 2024-02-20 at 9 09 37 AM" src="https://github.com/yext/answers-hitchhiker-theme/assets/88398086/b550063b-ff37-411b-91b2-840eeb8cc739">