### PR TITLE
Bump answers-search-ui version to 1.17

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -1,5 +1,5 @@
 {
-  "sdkVersion": "1.16", // The version of the Answers SDK to use
+  "sdkVersion": "1.17", // The version of the Answers SDK to use
   // "token": "<REPLACE ME>", // The auth token to access Answers experience.
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system


### PR DESCRIPTION
Bump answers-search-ui version to 1.17 to get the change for icon `div`s to `span`s