### PR TITLE
Keep full page map location filter for pagination

### DIFF
--- a/static/js/theme-map/VerticalFullPageMapOrchestrator.js
+++ b/static/js/theme-map/VerticalFullPageMapOrchestrator.js
@@ -8,6 +8,7 @@ import ZoomTriggers from './Maps/ZoomTriggers.js';
 import PanTriggers from './Maps/PanTriggers.js';
 import MobileStates from './MobileStates';
 
+import QueryTriggers from '../constants/query-triggers.js';
 import StorageKeys from '../constants/storage-keys.js';
 
 /**
@@ -184,7 +185,13 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
     this.core.storage.registerListener({
       eventType: 'update',
       storageKey: StorageKeys.QUERY,
-      callback: () => this.updateMostRecentSearchState()
+      callback: () => {
+        const queryTrigger = this.core.storage.get(StorageKeys.QUERY_TRIGGER);
+        if (queryTrigger !== QueryTriggers.PAGINATION) {
+          this.core.clearStaticFilterNode('SearchThisArea');
+        }
+        this.updateMostRecentSearchState();
+      }
     });
 
     const searchThisAreaToggleEls = this._container.querySelectorAll('.js-searchThisAreaToggle');
@@ -680,7 +687,6 @@ class VerticalFullPageMapOrchestrator extends ANSWERS.Component {
       useFacets: true
     });
     this.updateMostRecentSearchState();
-    this.core.clearStaticFilterNode('SearchThisArea');
   }
 
   /**


### PR DESCRIPTION
This PR updates the vertical full page map so that location static filters applied when searching on map move (or Search This Area) are not automatically cleared immediately after conducting the search. We need this filter to remain present if users paginate to the next set of results so that they don't see different (or no) results on the next page. The corresponding techops shows an example of this. But, we do want the filter to be removed if a new search is conducted (see PR #819 where the removal behavior was initially added). So, this is now done when a query update is detected as long as it wasn't triggered from pagination (i.e. a new search is conducted by clicking the Search button, typing Enter in the search bar, clearing the search bar using the X button, or adding/removing a static filter or facet). For map interactions that trigger a new search, the static filter removal is already handled because we set a new static filter for the new map location that replaces the previous one.

Note: it's still possible to get into a bad state via browser navigation (back/forward/refresh) because we don't properly respect the location filter in the URL. This will be fixed in a separate [item](https://yexttest.atlassian.net/browse/WAT-3958).

J=TECHOPS-11475
TEST=manual

Tested these changes on the site in the techops as well as our test site and saw that a search with an NLP location filter can be conducted as expected both before and after any map interactions that apply a static location filter. Pagination after a map interaction no longer drops the static location filter.