### PR TITLE
Upgrade Jambo to v1.12.6

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,7 @@ name: Playwright Tests
 on:
   push:
     branches-ignore: dev/*
+  pull_request:
 
 jobs:
   test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "file-system": "^2.2.2",
         "full-icu": "^1.3.1",
         "handlebars": "^4.7.7",
-        "jambo": "^1.12.5",
+        "jambo": "^1.12.6",
         "jest": "^25.5.2",
         "libphonenumber-js": "^1.9.6",
         "loader-utils": "^2.0.4",
@@ -6930,9 +6930,9 @@
       }
     },
     "node_modules/gettext-extractor": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.5.3.tgz",
-      "integrity": "sha512-9EgJ+hmbtAbATdMIvCj4WnrkeDWH6fv1z+IJJ1XCxdcUMGx6JQdVVFTdzJkSyIHh4td53ngoB5EQbavbKJU9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.6.2.tgz",
+      "integrity": "sha512-EzDL4re46WHR9XHCSsTtrTgd5FCPMtUkK3WpU69dhbYqcWKBFE5h2Sx6EXWjJ3KQLsMxQ/NcoAfg1pz6TqrRjA==",
       "dev": true,
       "dependencies": {
         "@types/glob": "5 - 7",
@@ -8058,9 +8058,9 @@
       }
     },
     "node_modules/jambo": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.5.tgz",
-      "integrity": "sha512-ao6M5GwWh+QN1ZlPnBRMEDnPCCRP0/r2lN3xj5Iu9uSc3Ynyr3gL5necu6dcXi8nxR/ezWN/fb0vJQUAkuPfyA==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.6.tgz",
+      "integrity": "sha512-tUNQ2dHqaie8OzOJKoY9muYMkWIXtpL/oxbNko4OBWyCX9Xq7rHPwumcH8q0X6ssOVILdwIr/l5cVbf5N84Uig==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.9.6",
@@ -8068,7 +8068,7 @@
         "comment-json": "^3.0.2",
         "file-system": "^2.2.2",
         "fs-extra": "^8.1.0",
-        "gettext-extractor": "^3.5.2",
+        "gettext-extractor": "~3.6.2",
         "glob-to-regexp": "^0.4.1",
         "globby": "^11.0.1",
         "handlebars": "^4.7.8",
@@ -20522,9 +20522,9 @@
       }
     },
     "gettext-extractor": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.5.3.tgz",
-      "integrity": "sha512-9EgJ+hmbtAbATdMIvCj4WnrkeDWH6fv1z+IJJ1XCxdcUMGx6JQdVVFTdzJkSyIHh4td53ngoB5EQbavbKJU9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.6.2.tgz",
+      "integrity": "sha512-EzDL4re46WHR9XHCSsTtrTgd5FCPMtUkK3WpU69dhbYqcWKBFE5h2Sx6EXWjJ3KQLsMxQ/NcoAfg1pz6TqrRjA==",
       "dev": true,
       "requires": {
         "@types/glob": "5 - 7",
@@ -21382,9 +21382,9 @@
       }
     },
     "jambo": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.5.tgz",
-      "integrity": "sha512-ao6M5GwWh+QN1ZlPnBRMEDnPCCRP0/r2lN3xj5Iu9uSc3Ynyr3gL5necu6dcXi8nxR/ezWN/fb0vJQUAkuPfyA==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.6.tgz",
+      "integrity": "sha512-tUNQ2dHqaie8OzOJKoY9muYMkWIXtpL/oxbNko4OBWyCX9Xq7rHPwumcH8q0X6ssOVILdwIr/l5cVbf5N84Uig==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.6",
@@ -21392,7 +21392,7 @@
         "comment-json": "^3.0.2",
         "file-system": "^2.2.2",
         "fs-extra": "^8.1.0",
-        "gettext-extractor": "^3.5.2",
+        "gettext-extractor": "~3.6.2",
         "glob-to-regexp": "^0.4.1",
         "globby": "^11.0.1",
         "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "file-system": "^2.2.2",
     "full-icu": "^1.3.1",
     "handlebars": "^4.7.7",
-    "jambo": "^1.12.5",
+    "jambo": "^1.12.6",
     "jest": "^25.5.2",
     "libphonenumber-js": "^1.9.6",
     "loader-utils": "^2.0.4",

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -46,7 +46,7 @@
         "grunt-webpack": "^4.0.3",
         "html-loader": "^2.1.2",
         "html-webpack-plugin": "^5.3.1",
-        "jambo": "^1.12.5",
+        "jambo": "^1.12.6",
         "jsdom": "^16.4.0",
         "locale-currency": "0.0.2",
         "mini-css-extract-plugin": "^1.6.0",
@@ -1553,9 +1553,9 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
       "dependencies": {
         "@types/minimatch": "*",
@@ -1574,9 +1574,9 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3826,9 +3826,9 @@
       }
     },
     "node_modules/gettext-extractor": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.5.3.tgz",
-      "integrity": "sha512-9EgJ+hmbtAbATdMIvCj4WnrkeDWH6fv1z+IJJ1XCxdcUMGx6JQdVVFTdzJkSyIHh4td53ngoB5EQbavbKJU9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.6.2.tgz",
+      "integrity": "sha512-EzDL4re46WHR9XHCSsTtrTgd5FCPMtUkK3WpU69dhbYqcWKBFE5h2Sx6EXWjJ3KQLsMxQ/NcoAfg1pz6TqrRjA==",
       "dev": true,
       "dependencies": {
         "@types/glob": "5 - 7",
@@ -5055,9 +5055,9 @@
       }
     },
     "node_modules/jambo": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.5.tgz",
-      "integrity": "sha512-ao6M5GwWh+QN1ZlPnBRMEDnPCCRP0/r2lN3xj5Iu9uSc3Ynyr3gL5necu6dcXi8nxR/ezWN/fb0vJQUAkuPfyA==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.6.tgz",
+      "integrity": "sha512-tUNQ2dHqaie8OzOJKoY9muYMkWIXtpL/oxbNko4OBWyCX9Xq7rHPwumcH8q0X6ssOVILdwIr/l5cVbf5N84Uig==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.9.6",
@@ -5065,7 +5065,7 @@
         "comment-json": "^3.0.2",
         "file-system": "^2.2.2",
         "fs-extra": "^8.1.0",
-        "gettext-extractor": "^3.5.2",
+        "gettext-extractor": "~3.6.2",
         "glob-to-regexp": "^0.4.1",
         "globby": "^11.0.1",
         "handlebars": "^4.7.8",
@@ -7915,9 +7915,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -9939,9 +9939,9 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "@types/glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -9960,9 +9960,9 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "@types/node": {
@@ -11764,9 +11764,9 @@
       "dev": true
     },
     "gettext-extractor": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.5.3.tgz",
-      "integrity": "sha512-9EgJ+hmbtAbATdMIvCj4WnrkeDWH6fv1z+IJJ1XCxdcUMGx6JQdVVFTdzJkSyIHh4td53ngoB5EQbavbKJU9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.6.2.tgz",
+      "integrity": "sha512-EzDL4re46WHR9XHCSsTtrTgd5FCPMtUkK3WpU69dhbYqcWKBFE5h2Sx6EXWjJ3KQLsMxQ/NcoAfg1pz6TqrRjA==",
       "dev": true,
       "requires": {
         "@types/glob": "5 - 7",
@@ -12675,9 +12675,9 @@
       "dev": true
     },
     "jambo": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.5.tgz",
-      "integrity": "sha512-ao6M5GwWh+QN1ZlPnBRMEDnPCCRP0/r2lN3xj5Iu9uSc3Ynyr3gL5necu6dcXi8nxR/ezWN/fb0vJQUAkuPfyA==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/jambo/-/jambo-1.12.6.tgz",
+      "integrity": "sha512-tUNQ2dHqaie8OzOJKoY9muYMkWIXtpL/oxbNko4OBWyCX9Xq7rHPwumcH8q0X6ssOVILdwIr/l5cVbf5N84Uig==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.6",
@@ -12685,7 +12685,7 @@
         "comment-json": "^3.0.2",
         "file-system": "^2.2.2",
         "fs-extra": "^8.1.0",
-        "gettext-extractor": "^3.5.2",
+        "gettext-extractor": "~3.6.2",
         "glob-to-regexp": "^0.4.1",
         "globby": "^11.0.1",
         "handlebars": "^4.7.8",
@@ -14834,9 +14834,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "typical": {

--- a/static/package.json
+++ b/static/package.json
@@ -31,7 +31,7 @@
     "grunt-webpack": "^4.0.3",
     "html-loader": "^2.1.2",
     "html-webpack-plugin": "^5.3.1",
-    "jambo": "^1.12.5",
+    "jambo": "^1.12.6",
     "jsdom": "^16.4.0",
     "locale-currency": "0.0.2",
     "mini-css-extract-plugin": "^1.6.0",


### PR DESCRIPTION
Bump Jambo to v1.12.6. Also, updated the Playwright GH workflow so tests are run on PR and not just after merging into develop.

J=WAT-4073
TEST=manual

Smoke tested in local test site.