### PR TITLE
ksearch: add cloudChoice support to theme

### DIFF
--- a/global_config.json
+++ b/global_config.json
@@ -5,6 +5,7 @@
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "environment": "production", // The environment to run on for this Answers Experience. (i.e. 'production' or 'sandbox')
   // "cloudRegion": "us", // The cloud region to use for this Answers Experience. (i.e. 'us' or 'eu')
+  // "cloudChoice": "multi", // The cloud provider to use for this Answers Experience. (i.e. 'multi' or 'gcp')
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
   // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
   // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build output and the token must be specified through manual initialization.

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.34.2",
+      "version": "1.34.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@vimeo/player": "^2.15.3",

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -5,6 +5,7 @@
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "environment": "production", // The environment to run on for this Answers Experience. (i.e. 'production' or 'sandbox')
   // "cloudRegion": "eu", // The cloud region to use for this Answers Experience. (i.e. 'us' or 'eu')
+  // "cloudChoice": "multi", // The cloud provider to use for this Answers Experience. (i.e. 'multi' or 'gcp')
   "businessId": "3350634", // The business ID of the account. This will be provided automatically by the Yext CI system
   // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
   // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build and the token must be specified through the runtime config.


### PR DESCRIPTION
This PR makes it clear in global_config that
cloudChoice support is now live in the theme

J=WAT-4376
TEST=manual

Ran local theme and local sdk, and saw expected url being hit