### PR TITLE
drop version to 1.34.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.34.5",
+  "version": "1.34.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.34.5",
+      "version": "1.34.4",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.5.2",
         "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.34.5",
+  "version": "1.34.4",
   "description": "A starter Search theme for hitchhikers",
   "keywords": [
     "jambo",


### PR DESCRIPTION
We have not released the last two versions, so for brevity this change drops the version back to .4, to have all changes consolidated.