### PR TITLE
Add custom card for Generative Direct Answers

### DIFF
--- a/generativedirectanswercards/all.hbs
+++ b/generativedirectanswercards/all.hbs
@@ -1,0 +1,4 @@
+let BaseGDACard = {};
+{{#partialPattern '^generativedirectanswercards/(.*)/component'}}
+  {{> (lookup . 'key') relativePath=../relativePath }}
+{{/partialPattern}}

--- a/generativedirectanswercards/card_component.js
+++ b/generativedirectanswercards/card_component.js
@@ -1,0 +1,137 @@
+BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
+
+  BaseGDACard["{{componentName}}"] = class extends ANSWERS.Component {
+  constructor(config = {}, systemConfig = {}) {
+    super(config, systemConfig);
+    const data = config.data || {};
+    this.generativeDirectAnswer = data.directAnswer || '';
+    this.citations = data.citations || [];
+    this.resultStatus = data.resultStatus || 'NO_ANSWER';
+    this.citationsData = data.citationsData || [];
+    this.searchState = data.searchState;  // e.g. SEARCH_LOADING, SEARCH_COMPLETE
+  }
+
+  /**
+   * Transforms the state. The object returned from this method is the state for the component.
+   * The state is passed directly to the template renderer.
+   *
+   * @param {Object} data
+   */
+  setState(data) {
+    let cardData = this.dataForRender(this.searchState, this.generativeDirectAnswer, this.resultStatus, this.citationsData);
+    this.validateDataForRender(cardData);
+    return super.setState({
+      ...cardData,
+      cardName: `{{componentName}}`,
+      relativePath: `{{relativePath}}`
+    });
+  }
+
+  validateDataForRender(data) {
+    if (!data) {
+      console.error('Error: nothing returned from dataForRender');
+    }
+  }
+
+  onMount() {
+    const citations = this._container.querySelectorAll('.js-HitchhikerGDACard-citation');
+    citations && citations.forEach(citation => this._handleCitationClickAnalytics(citation));
+
+    const rtfElement = this._container.querySelector('.js-yxt-rtfValue');
+    rtfElement && rtfElement.addEventListener('click', e => this._handleRtfClickAnalytics(e));
+  }
+
+  /**
+   * A click handler for citations in a Generated Direct Answer.
+   *
+   * @param {HTMLElement} citationElement The citation element that was clicked.
+   */
+  _handleCitationClickAnalytics (citationElement) {
+    const searcher = this._config.data.searcher;
+    const analyticsReporter = this.analyticsReporter;
+    citationElement.addEventListener('click', function(clickEvent) {
+      let target = clickEvent.target;
+      const targetClassName = 'js-HitchhikerGDACard-citation';
+      while (target && !target.classList.contains(targetClassName)) {
+        target = target.parentElement;
+      }
+      if (!target) {
+        console.error('No citation target found for analytics.');
+        return;
+      }
+      const entityId = target.dataset.entityid;
+      if (!entityId) {
+        console.error('No entityId found for citation target.');
+        return;
+      }
+      const eventType = target.dataset.eventtype || 'CITATION_CLICK';
+      const event = new ANSWERS.AnalyticsEvent(eventType)
+        .addOptions({
+          entityId,
+          searcher
+        })
+      analyticsReporter.report(event);
+    });
+  }
+
+  /**
+   * A click handler for links in a Generated Direct Answer. When such a link
+   * is clicked, an {@link AnalyticsEvent} needs to be fired.
+   *
+   * @param {MouseEvent} event The click event.
+   */
+  _handleRtfClickAnalytics (event) {
+    if (!event.target.dataset.ctaType) {
+      return;
+    }
+    const ctaType = event.target.dataset.ctaType;
+
+    const analyticsOptions = {
+      directAnswer: true,
+      fieldName: 'gda-snippet',
+      searcher: this._config.data.searcher,
+      url: event.target.href
+    };
+
+    const analyticsEvent = new ANSWERS.AnalyticsEvent(ctaType);
+    analyticsEvent.addOptions(analyticsOptions);
+    this.analyticsReporter.report(analyticsEvent);
+  }
+
+  /**
+   * updateState enables for partial updates (the delta between the old and new)
+   * @type {object} The new state to apply to the old
+   */
+  updateState (state = {}) {
+    const newState = Object.assign({}, this.getState(), state);
+    this.setState(newState);
+  }
+
+  /**
+   * Returns an object with the default event options for the card, including
+   * any event options passed in
+   * @param {Object} eventOptions
+   */
+  addDefaultEventOptions(eventOptions = {}) {
+    return Object.assign({}, {
+        searcher: this._config.data.searcher,
+        ...eventOptions
+      },
+    );
+  }
+
+  /**
+   * Returns the type of component
+   */
+  static get type() {
+    return `{{componentName}}`;
+  }
+
+  /**
+   * Returns a boolean indicating whether there can be multiple components of this
+   * type with the same name.
+   */
+  static areDuplicateNamesAllowed() {
+    return false;
+  }
+}

--- a/generativedirectanswercards/generative-standard/component.js
+++ b/generativedirectanswercards/generative-standard/component.js
@@ -1,0 +1,38 @@
+{{> generativedirectanswercards/card_component componentName = 'generative-standard' }}
+
+class generative_standardComponent extends BaseGDACard['generative-standard'] {
+  constructor(config = {}, systemConfig = {}) {
+    super(config, systemConfig);
+  }
+
+  /**
+   * @param searchState the state of the search, e.g. SEARCH_LOADING, SEARCH_COMPLETE
+   * @param generativeDirectAnswer the answer returned from the API, if any
+   * @param resultStatus status of the answer, e.g. 'SUCCESS', 'NO_ANSWER'
+   * @param citationsData necessary results data for displaying and linking citations
+   */
+  dataForRender(searchState, generativeDirectAnswer, resultStatus, citationsData) {
+    const success = resultStatus === 'SUCCESS';
+    return {
+      searchState,
+      generativeDirectAnswer,
+      citationsData,
+      success
+    }
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'generativedirectanswercards/generative-standard';
+  }
+}
+
+ANSWERS.registerTemplate(
+  'generativedirectanswercards/generative-standard',
+  {{{stringifyPartial (read 'generativedirectanswercards/generative-standard/template') }}}
+);
+ANSWERS.registerComponentType(generative_standardComponent);

--- a/generativedirectanswercards/generative-standard/template.hbs
+++ b/generativedirectanswercards/generative-standard/template.hbs
@@ -1,0 +1,42 @@
+<div class="HitchhikerGenerativeStandard {{cardName}}">
+    {{#if (eq searchState 'search-loading')}}
+        <div class="HitchhikerGenerativeStandard-title">
+            <h2 class="HitchhikerGenerativeStandard-titleText">
+                AI Generating Answer...
+            </h2>
+        </div>
+    {{else if success}}
+        <div class="HitchhikerGenerativeStandard-title">
+            <h2 class="yxt-GenerativeDirectAnswer-titleText">
+                AI Generated Answer
+            </h2>
+        </div>
+        <div class="HitchhikerGenerativeStandard-content">
+            <div class="yxt-GenerativeDirectAnswer-snippet">
+                {{{ generativeDirectAnswer }}}
+            </div>
+        <hr class="HitchhikerGenerativeStandard-citationsDivider" noshade>
+        <h2 class="HitchhikerGenerativeStandard-citationsHeader">
+            Sources ({{citationsData.length}})
+        </h2>
+        <div class="HitchhikerGenerativeStandard-citationsScroller">
+            {{#each citationsData}}
+                {{> citation_card citation=this}}
+            {{/each}}
+        </div>
+    {{/if}}
+</div>
+
+
+{{#*inline 'citation_card'}}
+<a class="HitchhikerGenerativeStandard-citationCard js-HitchhikerGDACard-citation"
+    {{#if citation.link}}href={{citation.link}}{{/if}}
+    data-entityid={{citation.uid}}
+    data-eventtype="CITATION_CLICK"
+    >
+    <span class="HitchhikerGenerativeStandard-citationName">{{citation.name}}</span>
+    {{#if citation.description}}
+        <p class="HitchhikerGenerativeStandard-citationDescription">{{citation.description}}</p>
+    {{/if}}
+</a>
+{{/inline}}

--- a/global_config.json
+++ b/global_config.json
@@ -9,6 +9,7 @@
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
   // "initializeManually": true, // If true, the experience must be started by calling AnswersExperience.init() or AnswersExperienceFrame.init() for iframe integrations.
   // "useJWT": true, // Whether or not to enable JWT. If true, the apiKey will be hidden from the build output and the token must be specified through manual initialization.
+  // "useGenerativeDirectAnswers": true, // Whether or not to use generative direct answers when applicable
   "sessionTrackingEnabled": true, // Whether or not session tracking is enabled for all pages
   "analyticsEventsEnabled": true, // Whether or not to submit user interaction analytics events
   "logo": "", // The link to the logo for open graph meta tag - og:image.

--- a/static/scss/answers/_default.scss
+++ b/static/scss/answers/_default.scss
@@ -55,6 +55,9 @@
 @import "directanswercards/allfields-standard";
 @import "directanswercards/documentsearch-standard";
 
+// Generative Direct Answer Card styling
+@import "generativedirectanswercards/generative-standard";
+
 // Styling for CollapsibleFilters
 @import "collapsible-filters/collapsible-filters";
 @import "collapsible-filters/collapsible-filters-templates";

--- a/static/scss/answers/generativedirectanswercards/generative-standard.scss
+++ b/static/scss/answers/generativedirectanswercards/generative-standard.scss
@@ -1,0 +1,137 @@
+.HitchhikerGenerativeStandard
+{
+  margin-top: calc(var(--yxt-base-spacing) * 1.5);
+  background-color: var(--yxt-gda-content-background-color);
+
+  @include bpgte(sm) {
+    margin-top: calc(var(--yxt-base-spacing) * 2.35);
+  }
+
+  &-title
+  {
+    padding-top: calc(var(--yxt-base-spacing) / 2);
+    padding-left: var(--yxt-base-spacing);
+    padding-bottom: calc(var(--yxt-base-spacing) / 2);
+    padding-right: var(--yxt-base-spacing);
+    display: flex;
+    align-items: center;
+    background-color: var(--yxt-gda-title-background-color);
+    border: var(--yxt-gda-border);
+    @include Text(
+      $color: var(--yxt-gda-title-color)
+    );
+  }
+
+  &-titleText
+  {
+    margin: 0;
+    @include Text(
+      $size: var(--yxt-gda-title-font-size),
+      $line-height: var(--yxt-gda-title-line-height),
+      $weight: var(--yxt-gda-title-font-weight),
+      $color: var(--yxt-gda-title-color)
+    );
+  }
+
+  &-content
+  {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: var(--yxt-base-spacing);
+    background-color: var(--yxt-gda-content-background-color);
+    border-left: var(--yxt-gda-border);
+    border-right: var(--yxt-gda-border);
+    border-bottom: var(--yxt-gda-border);
+  }
+
+  &-citationsDivider
+  {
+    border-color: var(--yxt-gda-citations-divider-color);
+    width: 100%;
+  }
+
+  &-citationsHeader
+  {
+    @include Text(
+      $size: var(--yxt-gda-citations-header-font-size),
+      $line-height: var(--yxt-gda-citations-header-line-height),
+      $weight: var(--yxt-gda-citations-header-font-weight),
+      $color: var(--yxt-gda-citations-header-color)
+    );
+  }
+
+  &-citationsScroller
+  {
+    margin: 0;
+    overflow-x: auto;
+    white-space: nowrap;
+    padding-top: var(--yxt-base-spacing);
+  }
+
+  &-citationCard
+  {
+    display: inline-flex;
+    flex-direction: column;
+    gap: var(--yxt-base-spacing-sm);
+    text-align: left;
+    padding: 14px;
+    text-decoration: none;
+    border: var(--yxt-border-default);
+    border-radius: 4px;
+    width: 300px;
+    height: 85px;
+    margin-right: var(--yxt-gda-citation-button-spacing);
+    box-sizing: border-box;
+
+    &:hover,
+    &:active,
+    &:focus {
+      border: var(--yxt-border-hover);
+    }
+  }
+
+  &-citationName
+  {
+    @include Text(
+      $size: var(--yxt-gda-citation-name-font-size),
+      $line-height: var(--yxt-gda-citation-name-line-height),
+      $weight: var(--yxt-gda-citation-name-font-weight),
+      $color: var(--yxt-gda-citation-name-color)
+    );
+  }
+
+  &-citationDescription
+  {
+    @include Text(
+      $size: var(--yxt-gda-citation-description-font-size),
+      $line-height: var(--yxt-gda-citation-description-line-height),
+      $weight: var(--yxt-gda-citation-description-font-weight),
+      $color: var(--yxt-gda-citation-description-color)
+    );
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &-snippet
+  {
+    @include Text(
+      $size: var(--yxt-gda-content-font-size),
+      $line-height: var(--yxt-gda-content-line-height),
+      $weight: var(--yxt-gda-content-font-weight),
+      $color: var(--yxt-gda-content-color)
+    );
+
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    strong, b {
+      font-weight: var(--yxt-gda-content-bolded-font-weight);
+    }
+
+    a {
+      @include Link;
+    }
+  }
+}

--- a/templates/common-partials/markup/generativedirectanswer.hbs
+++ b/templates/common-partials/markup/generativedirectanswer.hbs
@@ -1,0 +1,1 @@
+<div class="Answers-generativeDirectAnswer js-answersGenerativeDirectAnswer" id="js-answersGenerativeDirectAnswer"></div>

--- a/templates/common-partials/script/generativedirectanswer.hbs
+++ b/templates/common-partials/script/generativedirectanswer.hbs
@@ -1,0 +1,4 @@
+ANSWERS.addComponent("GenerativeDirectAnswer", {
+  container: "#js-answersGenerativeDirectAnswer",
+  ...{{{json componentSettings.GenerativeDirectAnswer}}}
+});

--- a/templates/universal-standard/markup/generativedirectanswer.hbs
+++ b/templates/universal-standard/markup/generativedirectanswer.hbs
@@ -1,0 +1,1 @@
+{{> templates/common-partials/markup/generativedirectanswer }}

--- a/templates/universal-standard/page-config.json
+++ b/templates/universal-standard/page-config.json
@@ -10,6 +10,11 @@
       "privacyPolicyUrl": "" // The fully qualified URL to the privacy policy
     },
     **/
+    /**
+    "GenerativeDirectAnswer": {
+      "cardType": "generative-standard" // The card type to use for the generated direct answer
+    },
+    **/
     "DirectAnswer": {
       "types": {
         "FEATURED_SNIPPET": {
@@ -23,8 +28,8 @@
     "SearchBar": {
       "placeholderText": "Search", // The placeholder text in the answers search bar
       "loadingIndicator": {
-        "display": true //Optional, whether to include a loading indicator on seachbar
-        // "iconUrl": "" //Optional, use custom icon url instead of the default loading indicator animation
+        "display": true // Optional, whether to include a loading indicator on seachbar
+        // "iconUrl": "" // Optional, use custom icon url instead of the default loading indicator animation
       },
       "voiceSearch": {
         "enabled": false // Whether or not voice search is enabled

--- a/templates/universal-standard/page.html.hbs
+++ b/templates/universal-standard/page.html.hbs
@@ -2,10 +2,12 @@
   {{#> script/core }}
     {{> cards/all }}
     {{> directanswercards/all }}
+    {{!-- {{> generativedirectanswercards/all }} --}}
     {{> templates/universal-standard/script/searchbar }}
     {{> templates/universal-standard/script/spellcheck }}
     {{> templates/universal-standard/script/navigation }}
     {{> templates/universal-standard/script/directanswer }}
+    {{!-- {{> templates/universal-standard/script/generativedirectanswer }} --}}
     {{> templates/universal-standard/script/universalresults }}
     {{> templates/universal-standard/script/locationbias }}
     {{!-- {{> templates/universal-standard/script/qasubmission }} --}}
@@ -21,6 +23,7 @@
     <div class="Answers-container Answers-resultsWrapper">
       {{> templates/universal-standard/markup/spellcheck }}
       {{> templates/universal-standard/markup/directanswer }}
+      {{!-- {{> templates/universal-standard/markup/generativedirectanswer }} --}}
       <div class="Answers-filtersAndResults">
         {{> templates/universal-standard/markup/universalresults }}
       </div>

--- a/templates/universal-standard/script/generativedirectanswer.hbs
+++ b/templates/universal-standard/script/generativedirectanswer.hbs
@@ -1,0 +1,1 @@
+{{> templates/common-partials/script/generativedirectanswer }}

--- a/templates/vertical-standard/markup/generativedirectanswer.hbs
+++ b/templates/vertical-standard/markup/generativedirectanswer.hbs
@@ -1,0 +1,1 @@
+{{> templates/common-partials/markup/generativedirectanswer }}

--- a/templates/vertical-standard/page-config.json
+++ b/templates/vertical-standard/page-config.json
@@ -44,6 +44,11 @@
       }
     },
     **/
+    /**
+    "GenerativeDirectAnswer": {
+      "cardType": "generative-standard" // The card type to use for the generated direct answer
+    },
+    **/
     "AppliedFilters": {
       "removable": true
     },

--- a/templates/vertical-standard/page.html.hbs
+++ b/templates/vertical-standard/page.html.hbs
@@ -2,6 +2,7 @@
   {{#> script/core }}
     {{> cards/all }}
     {{!-- {{> directanswercards/all }} --}}
+    {{!-- {{> generativedirectanswercards/all }} --}}
     {{!-- {{> templates/vertical-standard/collapsible-filters/page-setup }} --}}
     {{> templates/vertical-standard/script/appliedfilters }}
     {{> templates/vertical-standard/script/verticalresultscount }}
@@ -9,6 +10,7 @@
     {{> templates/vertical-standard/script/spellcheck }}
     {{> templates/vertical-standard/script/navigation }}
     {{!-- {{> templates/vertical-standard/script/directanswer }} --}}
+    {{!-- {{> templates/vertical-standard/script/generativedirectanswer }} --}}
     {{> templates/vertical-standard/script/verticalresults }}
     {{> templates/vertical-standard/script/pagination }}
     {{> templates/vertical-standard/script/locationbias }}
@@ -24,8 +26,8 @@
         {{> templates/vertical-standard/markup/navigation }}
       </div>
     </div>
-    <!-- Uncomment the following if this page should be searched from the Answers Overlay panel. 
-    The overlay partial should only be added to ONE page of your site, e.g. if you uncomment the 
+    <!-- Uncomment the following if this page should be searched from the Answers Overlay panel.
+    The overlay partial should only be added to ONE page of your site, e.g. if you uncomment the
     partial for this page, you should not use it on any other page.  -->
     {{!-- {{> layouts/overlay-suggestions }} --}}
     <div class="Answers-container Answers-resultsWrapper">
@@ -39,6 +41,7 @@
       </div>
       <div class="Answers-mainContent js-answersMainContent">
         {{!-- {{> templates/vertical-standard/markup/directanswer }} --}}
+        {{!-- {{> templates/vertical-standard/markup/generativedirectanswer }} --}}
         {{> templates/vertical-standard/markup/spellcheck }}
         <div class="Answers-resultsHeader">
           {{> templates/vertical-standard/markup/verticalresultscount }}

--- a/templates/vertical-standard/script/generativedirectanswer.hbs
+++ b/templates/vertical-standard/script/generativedirectanswer.hbs
@@ -1,0 +1,1 @@
+{{> templates/common-partials/script/generativedirectanswer }}

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -16,5 +16,6 @@
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer
   "googleTagManagerId": "", // The container id associated with your Google Tag Manager container
   "googleAnalyticsId": "", // The tracking Id associated with your Google Analytics account
-  "conversionTrackingEnabled": true // Whether or not conversion tracking is enabled for all pages
+  "conversionTrackingEnabled": true, // Whether or not conversion tracking is enabled for all pages
+  "useGenerativeDirectAnswers": true // Whether or not to use generative direct answers
 }

--- a/test-site/config/index.json
+++ b/test-site/config/index.json
@@ -15,6 +15,9 @@
       "privacyPolicyUrl": "" // The fully qualified URL to the privacy policy
     },
     **/
+    "GenerativeDirectAnswer": {
+      "cardType": "generative-standard" // The card type to use for the generated direct answer
+    },
     "DirectAnswer": {
       "types": {
         "FEATURED_SNIPPET": {

--- a/test-site/jambo-yext-sites.json
+++ b/test-site/jambo-yext-sites.json
@@ -7,7 +7,8 @@
     "partials": [
       "script/on-ready.js",
       "cards",
-      "directanswercards"
+      "directanswercards",
+      "generativedirectanswercards"
     ],
     "preservedFiles": [
       "public/iframe_test.html",

--- a/test-site/jambo.json
+++ b/test-site/jambo.json
@@ -7,7 +7,8 @@
     "partials": [
       "script/on-ready.js",
       "cards",
-      "directanswercards"
+      "directanswercards",
+      "generativedirectanswercards"
     ],
     "preservedFiles": [
       "public/iframe_test.html",

--- a/test-site/pages/index.html.hbs
+++ b/test-site/pages/index.html.hbs
@@ -2,10 +2,12 @@
   {{#> script/core }}
     {{> cards/all }}
     {{> directanswercards/all }}
+    {{> generativedirectanswercards/all }}
     {{> templates/universal-standard/script/searchbar }}
     {{> templates/universal-standard/script/spellcheck }}
     {{> templates/universal-standard/script/navigation }}
     {{> templates/universal-standard/script/directanswer }}
+    {{> templates/universal-standard/script/generativedirectanswer }}
     {{> templates/universal-standard/script/universalresults }}
     {{> templates/universal-standard/script/locationbias }}
     {{!-- {{> templates/universal-standard/script/qasubmission }} --}}
@@ -21,6 +23,7 @@
     <div class="Answers-container Answers-resultsWrapper">
       {{> templates/universal-standard/markup/spellcheck }}
       {{> templates/universal-standard/markup/directanswer }}
+      {{> templates/universal-standard/markup/generativedirectanswer }}
       <div class="Answers-filtersAndResults">
         {{> templates/universal-standard/markup/universalresults }}
       </div>


### PR DESCRIPTION
GDA: Add custom card for Generative Direct Answers
    
This PR contains all the logic necessary to link the theme with
answers-search-ui for GDA. It also includes a custom card for GDA
in the theme (which looks essentially identical to the default).
    
To use GDA, the implementer will need to:
- uncomment the property in the global config json file
- uncomment the gda related lines in the page.html.hbs file(s)
- (if they want to use the theme's card) uncomment the GDA section
of the page-config json file(s)
    
J=[WAT-4595](https://yexttest.atlassian.net/browse/WAT-4595?atlOrigin=eyJpIjoiZGRkYzVlY2FkNDNiNDMyOThhNzc2NTFkMDYxMDQ2ZmYiLCJwIjoiaiJ9), [WAT-4599](https://yexttest.atlassian.net/browse/WAT-4599?atlOrigin=eyJpIjoiNGI3MzJiOTE4Y2E0NDU1YWE0ZGEzZGJjMTJjZTg1MWQiLCJwIjoiaiJ9)
TEST=manual
Spun up local test site, saw expected behavior. See demo here:
https://drive.google.com/file/d/1Bvi9TT5b1DYo84TZMxaeZDBXgqNtbqBk/view?usp=sharing