### PR TITLE
GDA Card Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,13 @@ npx jambo directanswercard --name custom-directanswer --templateCardFolder direc
 ```
 
 See `jambo directanswercard --help` for more info.
+
+### Generative Direct Answer Card
+Creates a new, custom generative direct answer (GDA) card.
+
+Example usage:
+```bash
+npx jambo generativedirectanswercard --name custom-generativedirectanswer --templateCardFolder generativedirectanswercards/generative-standard
+```
+
+See `jambo generativedirectanswercard --help` for more info.

--- a/commands/generativedirectanswercardcreator.js
+++ b/commands/generativedirectanswercardcreator.js
@@ -5,52 +5,52 @@ const UserError = require('./helpers/errors/usererror');
 const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
 
 /**
- * DirectAnswerCardCreator represents the `directanswercard` custom jambo command.
- * The command creates a new, custom direct answer card in the top-level
- * 'directanswercards' directory of a jambo repo.
+ * GenerativeDirectAnswerCardCreator represents the `generativedirectanswercard` custom jambo command.
+ * The command creates a new, custom generative direct answer card in the top-level
+ * 'generativedirectanswercards' directory of a jambo repo.
  */
-class DirectAnswerCardCreator {
+class GenerativeDirectAnswerCardCreator {
   constructor(jamboConfig) {
     this.config = jamboConfig;
-    this._customCardsDir = 'directanswercards';
+    this._customCardsDir = 'generativedirectanswercards';
   }
 
   /**
-   * @returns {string} the alias for the create direct answer card command.
+   * @returns {string} the alias for the create generative direct answer card command.
    */
   static getAlias() {
-    return 'directanswercard';
+    return 'generativedirectanswercard';
   }
 
   /**
-   * @returns {string} a short description of the create direct answer card command.
+   * @returns {string} a short description of the create generative direct answer card command.
    */
   static getShortDescription() {
-    return 'add a new direct answer card for use in the site';
+    return 'add a new generative direct answer (GDA) card for use in the site';
   }
 
   /**
    * @returns {Object<string, ArgumentMetadata>} description of each argument for
-   *                                             the create direct answer card command, keyed by name
+   *                                             the create generative direct answer card command, keyed by name
    */
   static args() {
     return {
-      'name': new ArgumentMetadata(ArgumentType.STRING, 'name for the new direct answer card', true),
-      'templateCardFolder': new ArgumentMetadata(ArgumentType.STRING, 'folder of direct answer card to fork', true)
+      'name': new ArgumentMetadata(ArgumentType.STRING, 'name for the new generative direct answer card', true),
+      'templateCardFolder': new ArgumentMetadata(ArgumentType.STRING, 'folder of generative direct answer card to fork', true)
     };
   }
 
   /**
-   * @returns {Object} description of the direct answer card command, including paths to
-   *                   all available direct answer cards
+   * @returns {Object} description of the generative direct answer card command, including paths to
+   *                   all available generative direct answer cards
    */
   static describe(jamboConfig) {
-    const directAnswerCardPaths = this._getDirectAnswerCardPaths(jamboConfig);
+    const generativeDirectAnswerCardPaths = this._getGenerativeDirectAnswerCardPaths(jamboConfig);
     return {
-      displayName: 'Add Direct Answer Card',
+      displayName: 'Add Generative Direct Answer (GDA) Card',
       params: {
         name: {
-          displayName: 'Direct Answer Card Name',
+          displayName: 'Generative Direct Answer Card Name',
           required: true,
           type: 'string'
         },
@@ -58,22 +58,22 @@ class DirectAnswerCardCreator {
           displayName: 'Template Card Folder',
           required: true,
           type: 'singleoption',
-          options: directAnswerCardPaths
+          options: generativeDirectAnswerCardPaths
         }
       }
     };
   }
 
   /**
-   * @returns {Array<string>} the paths of the available direct answer cards
+   * @returns {Array<string>} the paths of the available generative direct answer cards
    */
-  static _getDirectAnswerCardPaths(jamboConfig) {
+  static _getGenerativeDirectAnswerCardPaths(jamboConfig) {
     const defaultTheme = jamboConfig.defaultTheme;
     const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
     if (!defaultTheme || !themesDir) {
       return [];
     }
-    const themeCardsDir = path.join(themesDir, defaultTheme, 'directanswercards');
+    const themeCardsDir = path.join(themesDir, defaultTheme, 'generativedirectanswercards');
     const cardPaths = new Set();
     const addCardsToSet = cardsDir => {
       if (!fs.existsSync(cardsDir)) {
@@ -81,14 +81,14 @@ class DirectAnswerCardCreator {
       }
       fs.readdirSync(cardsDir, { withFileTypes: true })
         .filter(dirent => !dirent.isFile())
-        .forEach(dirent => cardPaths.add(path.join('directanswercards', dirent.name)));
+        .forEach(dirent => cardPaths.add(path.join('generativedirectanswercards', dirent.name)));
     };
-    [themeCardsDir, 'directanswercards'].forEach(dir => addCardsToSet(dir));
+    [themeCardsDir, 'generativedirectanswercards'].forEach(dir => addCardsToSet(dir));
     return Array.from(cardPaths);
   }
 
   /**
-   * Executes the create direct answer card command with the provided arguments.
+   * Executes the create generative direct answer card command with the provided arguments.
    *
    * @param {Object<string, string} args The arguments, keyed by name
    */
@@ -97,9 +97,9 @@ class DirectAnswerCardCreator {
   }
 
   /**
-   * Creates a new, custom direct answer card in the top-level 'directanswercards'
-   * directory. This card will be based off either an existing custom card or one
-   * supplied by the Theme.
+   * Creates a new, custom generative direct answer card in the top-level
+   * 'generativedirectanswercards' directory. This card will be based off
+   * either an existing custom card or one supplied by the Theme.
    *
    * @param {string} cardName           The name of the new card. A folder with a
    *                                    lowercased version of this name will be
@@ -148,8 +148,8 @@ class DirectAnswerCardCreator {
   }
 
   /**
-   * Returns the internal contents for a newly-created direct answer card, updated
-   * based on the given customCardName. (e.g. allfields_standardComponent ->
+   * Returns the internal contents for a newly-created generative direct answer card,
+   * updated based on the given customCardName. (e.g. generative_customComponent ->
    * [CustomName]Component)
    *
    * @param {string} content
@@ -174,4 +174,4 @@ class DirectAnswerCardCreator {
   }
 }
 
-module.exports = DirectAnswerCardCreator;
+module.exports = GenerativeDirectAnswerCardCreator;

--- a/test-site/scripts/setup.sh
+++ b/test-site/scripts/setup.sh
@@ -23,7 +23,7 @@ cleanup_custom_cards () {
 create_custom_cards () {
   npx jambo card --name event-custom --templateCardFolder cards/event-standard
   npx jambo directanswercard --name allfields-custom --templateCardFolder directanswercards/allfields-standard
-  npx jambo generativedirectanswercard --name generative-custom --templateCardFolder generativedirectanswercards/generative-custom
+  npx jambo generativedirectanswercard --name generative-custom --templateCardFolder generativedirectanswercards/generative-standard
 }
 
 set_working_dir_to_test_site

--- a/test-site/scripts/setup.sh
+++ b/test-site/scripts/setup.sh
@@ -17,11 +17,13 @@ copy_static_files_into_working_dir () {
 cleanup_custom_cards () {
   rm -rf cards/event-custom
   rm -rf directanswercards/allfields-custom
+  rm -rf generativedirectanswercards/generative-custom
 }
 
 create_custom_cards () {
   npx jambo card --name event-custom --templateCardFolder cards/event-standard
   npx jambo directanswercard --name allfields-custom --templateCardFolder directanswercards/allfields-standard
+  npx jambo generativedirectanswercard --name generative-custom --templateCardFolder generativedirectanswercards/generative-custom
 }
 
 set_working_dir_to_test_site


### PR DESCRIPTION
Add card generation script for GDA. This should work in the same way as the existing direct answer card generation script.

J=[WAT-4596](https://yexttest.atlassian.net/browse/WAT-4596?atlOrigin=eyJpIjoiNTU5MzYxMWJjYmY4NGE2NTg5NDNjNmQxZDk0NzA4NjEiLCJwIjoiaiJ9)
TEST=manual
Ran `npx jambo init --theme answers-hitchhiker-theme` then `npx jambo upgrade --branch gda-card-generator`