### PR TITLE
Use sourceUrlFields from config to set citation links

### DIFF
--- a/generativedirectanswercards/card_component.js
+++ b/generativedirectanswercards/card_component.js
@@ -4,6 +4,7 @@ BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
   constructor(config = {}, systemConfig = {}) {
     super(config, systemConfig);
     const data = config.data || {};
+    this.sourceUrlFields = config.sourceUrlFields || [];
     this.generativeDirectAnswer = data.directAnswer || '';
     this.citations = data.citations || [];
     this.resultStatus = data.resultStatus || 'NO_ANSWER';
@@ -18,7 +19,13 @@ BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
    * @param {Object} data
    */
   setState(data) {
-    let cardData = this.dataForRender(this.searchState, this.generativeDirectAnswer, this.resultStatus, this.citationsData);
+    let cardData = this.dataForRender(
+      this.searchState,
+      this.generativeDirectAnswer,
+      this.resultStatus,
+      this.citationsData,
+      this.sourceUrlFields
+    );
     this.validateDataForRender(cardData);
     return super.setState({
       ...cardData,

--- a/generativedirectanswercards/generative-standard/component.js
+++ b/generativedirectanswercards/generative-standard/component.js
@@ -10,14 +10,16 @@ class generative_standardComponent extends BaseGDACard['generative-standard'] {
    * @param generativeDirectAnswer the answer returned from the API, if any
    * @param resultStatus status of the answer, e.g. 'SUCCESS', 'NO_ANSWER'
    * @param citationsData necessary results data for displaying and linking citations
+   * @param sourceUrlFields the field(s) holding the URL for the redirect link of the citations
    */
-  dataForRender(searchState, generativeDirectAnswer, resultStatus, citationsData) {
+  dataForRender(searchState, generativeDirectAnswer, resultStatus, citationsData, sourceUrlFields) {
     const success = resultStatus === 'SUCCESS';
     return {
       searchState,
       generativeDirectAnswer,
       citationsData,
-      success
+      success,
+      sourceUrlFields
     }
   }
 

--- a/generativedirectanswercards/generative-standard/template.hbs
+++ b/generativedirectanswercards/generative-standard/template.hbs
@@ -21,7 +21,7 @@
             </h2>
             <div class="HitchhikerGenerativeStandard-citationsScroller">
                 {{#each citationsData}}
-                    {{> citation_card citation=this}}
+                    {{> citation_card citation=this sourceUrlFields=../sourceUrlFields}}
                 {{/each}}
             </div>
         </div>
@@ -31,7 +31,7 @@
 
 {{#*inline 'citation_card'}}
 <a class="HitchhikerGenerativeStandard-citationCard js-HitchhikerGDACard-citation"
-    {{#if citation.link}}href={{citation.link}}{{/if}}
+    {{getGdaSourceUrlHref sourceUrlFields citation.rawData}}
     data-entityid={{citation.id}}
     data-eventtype="CITATION_CLICK"
     data-is-analytics-attached="true"

--- a/hbshelpers/getGdaSourceUrlHref.js
+++ b/hbshelpers/getGdaSourceUrlHref.js
@@ -1,0 +1,54 @@
+/** KEEP IN SYNC WITH script/core.hbs */
+
+/**
+* Searches the raw data JSON for the source URL.
+* @param {string|string[]} sourceUrlFields - The field(s) to search for the source
+* URL. Can be either a single field or an array of fields.
+* @param {Object} rawData - The full raw data JSON of the source
+* @returns {string} The source URL, formatted as an href attribute, or an empty 
+* string if not found
+*/
+module.exports = function getGdaSourceUrlHref(sourceUrlFields, rawData) {
+  if (sourceUrlFields) {
+    const fields = Array.isArray(sourceUrlFields) ? sourceUrlFields : [sourceUrlFields];
+    for (const field of fields) {
+      const sourceUrl = findFieldInRawData(field, rawData);
+      if (sourceUrl) {
+        return `href="${sourceUrl}"`;
+      }
+    }
+  }
+  return '';
+}
+
+/**
+* Traverses the raw data JSON to find the leaf field, if it exists.
+* @param {string} fieldId - The field we are searching for
+* @param {Object} data - The full, or partial, raw data JSON that we are traversing
+* @returns {string|undefined} The leaf field value, if it exists
+*/
+function findFieldInRawData(fieldId, data) {
+  const parts = fieldId.split('.');
+  let currentValue = data;
+  for (const part of parts) {
+    if (currentValue[part] === undefined) {
+      return undefined;
+    }
+    currentValue = currentValue[part];
+  }
+  return isValidUrl(currentValue) ? currentValue : undefined;
+}
+
+/**
+* Determines if a string is a valid URL.
+* @param {string} value - The string to check
+* @returns {boolean} Whether the string is a valid URL
+*/
+function isValidUrl(value) {
+  try {
+    new URL(value);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -132,6 +132,61 @@
           return relativePath + '/' + url;
         });
 
+        /**
+        * Searches the raw data JSON for the source URL.
+        * @param {string|string[]} sourceUrlFields - The field(s) to search for the source
+        * URL. Can be either a single field or an array of fields.
+        * @param {Object} rawData - The full raw data JSON of the source
+        * @returns {string} The source URL, formatted as an href attribute, or an empty 
+        * string if not found
+        */
+        function getGdaSourceUrlHref(sourceUrlFields, rawData) {
+          if (sourceUrlFields) {
+            const fields = Array.isArray(sourceUrlFields) ? sourceUrlFields : [sourceUrlFields];
+            for (const field of fields) {
+              const sourceUrl = findFieldInRawData(field, rawData);
+              if (sourceUrl) {
+                return ANSWERS.renderer.SafeString(`href="${sourceUrl}"`);
+              }
+            }
+          }
+          return '';
+        }
+
+        /**
+        * Traverses the raw data JSON to find the leaf field, if it exists.
+        * @param {string} fieldId - The field we are searching for
+        * @param {Object} data - The full, or partial, raw data JSON that we are traversing
+        * @returns {string|undefined} The leaf field value, if it exists
+        */
+        function findFieldInRawData(fieldId, data) {
+          const parts = fieldId.split('.');
+          let currentValue = data;
+          for (const part of parts) {
+            if (currentValue[part] === undefined) {
+              return undefined;
+            }
+            currentValue = currentValue[part];
+          }
+          return isValidUrl(currentValue) ? currentValue : undefined;
+        }
+
+        /**
+        * Determines if a string is a valid URL.
+        * @param {string} value - The string to check
+        * @returns {boolean} Whether the string is a valid URL
+        */
+        function isValidUrl(value) {
+          try {
+            new URL(value);
+            return true;
+          } catch (_) {
+            return false;
+          }
+        }
+
+        ANSWERS.registerHelper('getGdaSourceUrlHref', getGdaSourceUrlHref);
+
         window.iframeLoaded.then(() => {
           {{#wrapJsPartial}}
             {{> script/iframe-messaging}}

--- a/templates/universal-standard/page-config.json
+++ b/templates/universal-standard/page-config.json
@@ -12,7 +12,8 @@
     **/
     /**
     "GenerativeDirectAnswer": {
-      "cardType": "generative-standard" // The card type to use for the generated direct answer
+      "cardType": "generative-standard", // The card type to use for the generated direct answer
+      "sourceUrlFields": ["website", "c_someField.url"] // The fields to use as the redirect URL for the sources
     },
     **/
     "DirectAnswer": {

--- a/templates/vertical-full-page-map/page-config.json
+++ b/templates/vertical-full-page-map/page-config.json
@@ -27,7 +27,8 @@
     **/
     /**
     "GenerativeDirectAnswer": {
-      "cardType": "generative-standard" // The card type to use for the generated direct answer
+      "cardType": "generative-standard", // The card type to use for the generated direct answer
+      "sourceUrlFields": ["website", "c_someField.url"] // The fields to use as the redirect URL for the sources
     },
     **/
     "FilterLink": {

--- a/templates/vertical-grid/page-config.json
+++ b/templates/vertical-grid/page-config.json
@@ -34,7 +34,8 @@
     **/
     /**
     "GenerativeDirectAnswer": {
-      "cardType": "generative-standard" // The card type to use for the generated direct answer
+      "cardType": "generative-standard", // The card type to use for the generated direct answer
+      "sourceUrlFields": ["website", "c_someField.url"] // The fields to use as the redirect URL for the sources
     },
     **/
     "AppliedFilters": {

--- a/templates/vertical-map/page-config.json
+++ b/templates/vertical-map/page-config.json
@@ -34,7 +34,8 @@
     **/
     /**
     "GenerativeDirectAnswer": {
-      "cardType": "generative-standard" // The card type to use for the generated direct answer
+      "cardType": "generative-standard", // The card type to use for the generated direct answer
+      "sourceUrlFields": ["website", "c_someField.url"] // The fields to use as the redirect URL for the sources
     },
     **/
     "AppliedFilters": {

--- a/templates/vertical-standard/page-config.json
+++ b/templates/vertical-standard/page-config.json
@@ -46,7 +46,8 @@
     **/
     /**
     "GenerativeDirectAnswer": {
-      "cardType": "generative-standard" // The card type to use for the generated direct answer
+      "cardType": "generative-standard", // The card type to use for the generated direct answer
+      "sourceUrlFields": ["website", "c_someField.url"] // The fields to use as the redirect URL for the sources
     },
     **/
     "AppliedFilters": {

--- a/test-site/config/index.json
+++ b/test-site/config/index.json
@@ -7,7 +7,7 @@
     "search": {
       "defaultInitialSearch": "virginia" // Enter a default search term
     }
-  },  
+  },
   "componentSettings": {
     /**
     "QASubmission": {
@@ -16,7 +16,8 @@
     },
     **/
     "GenerativeDirectAnswer": {
-      "cardType": "generative-standard" // The card type to use for the generated direct answer
+      "cardType": "generative-standard", // The card type to use for the generated direct answer
+      "sourceUrlFields": ["website", "featuredMessage.url"] // The fields to use as the redirect URL for the sources
     },
     "DirectAnswer": {
       "types": {

--- a/test-site/generativedirectanswercards/generative-custom/component.js
+++ b/test-site/generativedirectanswercards/generative-custom/component.js
@@ -10,14 +10,16 @@ class generative_customComponent extends BaseGDACard['generative-custom'] {
    * @param generativeDirectAnswer the answer returned from the API, if any
    * @param resultStatus status of the answer, e.g. 'SUCCESS', 'NO_ANSWER'
    * @param citationsData necessary results data for displaying and linking citations
+   * @param sourceUrlFields the field(s) holding the URL for the redirect link of the citations
    */
-  dataForRender(searchState, generativeDirectAnswer, resultStatus, citationsData) {
+  dataForRender(searchState, generativeDirectAnswer, resultStatus, citationsData, sourceUrlFields) {
     const success = resultStatus === 'SUCCESS';
     return {
       searchState,
       generativeDirectAnswer,
       citationsData,
-      success
+      success,
+      sourceUrlFields
     }
   }
 

--- a/test-site/generativedirectanswercards/generative-custom/template.hbs
+++ b/test-site/generativedirectanswercards/generative-custom/template.hbs
@@ -21,7 +21,7 @@
             </h2>
             <div class="HitchhikerGenerativeStandard-citationsScroller">
                 {{#each citationsData}}
-                    {{> citation_card citation=this}}
+                    {{> citation_card citation=this sourceUrlFields=../sourceUrlFields}}
                 {{/each}}
             </div>
         </div>
@@ -31,7 +31,7 @@
 
 {{#*inline 'citation_card'}}
 <a class="HitchhikerGenerativeStandard-citationCard js-HitchhikerGDACard-citation"
-    {{#if citation.link}}href={{citation.link}}{{/if}}
+    {{getGdaSourceUrlHref sourceUrlFields citation.rawData}}
     data-entityid={{citation.id}}
     data-eventtype="CITATION_CLICK"
     data-is-analytics-attached="true"

--- a/tests/hbshelpers/getGdaSourceUrlHref.js
+++ b/tests/hbshelpers/getGdaSourceUrlHref.js
@@ -1,0 +1,106 @@
+import getGdaSourceUrlHref from '../../hbshelpers/getGdaSourceUrlHref';
+
+const NOT_FOUND_URL = '';
+const withHref = (url) => `href="${url}"`;
+
+describe('Values are found when present on raw data', () => {
+  it('top level field', () => {
+    const fieldId = 'website';
+    const rawData = {
+      website: 'https://www.example.com',
+      name: 'Example',
+      description: 'This is an example',
+      c_otherUrl: 'https://www.example.com/other'
+    }
+    const expectedUrl = 'https://www.example.com'
+
+    expect(getGdaSourceUrlHref(fieldId, rawData)).toEqual(withHref(expectedUrl));
+  });
+
+  it('nested field', () => {
+    const fieldId = 'c_myStruct.website';
+    const rawData = {
+      name: 'Example',
+      description: 'This is an example',
+      c_myStruct: {
+        name: 'My Struct',
+        website: 'https://www.example.com'
+      }
+    }
+    const expectedUrl = 'https://www.example.com'
+
+    expect(getGdaSourceUrlHref(fieldId, rawData)).toEqual(withHref(expectedUrl));
+  });
+});
+
+describe('Fallback fields are used when primary is not found', () => {
+  it('top level field', () => {
+    const fieldIds = ['does_not_exist', 'website'];
+    const rawData = {
+      website: 'https://www.example.com',
+      name: 'Example',
+      description: 'This is an example',
+      c_otherUrl: 'https://www.example.com/other'
+    }
+    const expectedUrl = 'https://www.example.com'
+
+    expect(getGdaSourceUrlHref(fieldIds, rawData)).toEqual(withHref(expectedUrl));
+  });
+
+  it('nested field', () => {
+    const fieldIds = ['does_not_exist', 'c_myStruct.website'];
+    const rawData = {
+      name: 'Example',
+      description: 'This is an example',
+      c_myStruct: {
+        name: 'My Struct',
+        website: 'https://www.example.com'
+      }
+    }
+    const expectedUrl = 'https://www.example.com'
+
+    expect(getGdaSourceUrlHref(fieldIds, rawData)).toEqual(withHref(expectedUrl));
+  });
+});
+
+describe('Does not find URL if not present or invalid', () => {
+  it('not present in raw data top level', () => {
+    const fieldIds = ['does_not_exist', 'also_does_not_exist'];
+    const rawData = {
+      website: 'https://www.example.com',
+      name: 'Example',
+      description: 'This is an example',
+      c_otherUrl: 'https://www.example.com/other'
+    }
+
+    expect(getGdaSourceUrlHref(fieldIds, rawData)).toEqual(NOT_FOUND_URL);
+  });
+
+  it('not present in raw data nested field', () => {
+    const fieldIds = ['does_not_exist', 'c_myStruct.does_not_exist'];
+    const rawData = {
+      name: 'Example',
+      description: 'This is an example',
+      c_myStruct: {
+        name: 'My Struct',
+        website: 'https://www.example.com'
+      }
+    }
+
+    expect(getGdaSourceUrlHref(fieldIds, rawData)).toEqual(NOT_FOUND_URL);
+  });
+
+  it('field exists but URL is invalid', () => {
+    const fieldIds = ['c_myStruct.website'];
+    const rawData = {
+      name: 'Example',
+      description: 'This is an example',
+      c_myStruct: {
+        name: 'My Struct',
+        website: 'Do not get blue shelled'
+      }
+    }
+
+    expect(getGdaSourceUrlHref(fieldIds, rawData)).toEqual(NOT_FOUND_URL);
+  });
+});


### PR DESCRIPTION
Allow custom fields for GDA citation links

The entity field used to populate the `href` (click through link) on GDA citations is now configurable. 
This is configurable in the `sourceUrlFields` property of the GDA component, on a per-vertical basis. 
This value can be a single string, or a list of strings. If multiple are listed, then they will be tried in order, with the secondary fields being used if the primary field is not valid. 

J=[WAT-4680](https://yexttest.atlassian.net/browse/WAT-4680?atlOrigin=eyJpIjoiMmE2Y2M2MzU5MTY1NDcxZThkYWIyY2I1YzVmMjdkMzMiLCJwIjoiaiJ9)

Related change in `answers-search-ui`: https://github.com/yext/answers-search-ui/pull/1923
