### PR TITLE
v2.0.0

### DIFF
--- a/cards/document-standard/template.hbs
+++ b/cards/document-standard/template.hbs
@@ -27,7 +27,7 @@
   {{#if card.url}}
   <a class="HitchhikerDocumentStandard-titleLink js-HitchhikerDocumentStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.title}}

--- a/cards/document-vertical-standard/template.hbs
+++ b/cards/document-vertical-standard/template.hbs
@@ -28,7 +28,7 @@
             {{#if card.url}}
                 <a class="HitchhikerDocumentVerticalStandard-titleLink js-HitchhikerDocumentVerticalStandard-titleLink"
                    href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-                   data-eventtype="TITLE_CLICK"
+                   data-eventtype="TITLE"
                    data-eventoptions='{{json card.titleEventOptions}}'
                    target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
                 {{card.title}}

--- a/cards/event-standard/component.js
+++ b/cards/event-standard/component.js
@@ -35,7 +35,7 @@ class event_standardCardComponent extends BaseCard['event-standard'] {
         iconName: 'calendar', // The icon to use for the CTA
         url: profile.ticketUrl || profile.website, // The URL a user will be directed to when clicking
         target: linkTarget, // Where the new URL will be opened
-        eventType: 'RSVP', // Type of Analytics event fired when clicking the CTA
+        eventType: 'BOOK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },

--- a/cards/event-standard/template.hbs
+++ b/cards/event-standard/template.hbs
@@ -15,7 +15,7 @@
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
               href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-              data-eventtype="TITLE_CLICK"
+              data-eventtype="TITLE"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
               {{card.title}}

--- a/cards/financial-professional-location/template.hbs
+++ b/cards/financial-professional-location/template.hbs
@@ -57,7 +57,7 @@
   {{#if card.url}}
   <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-    data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
+    data-eventtype="TITLE" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
   </a>

--- a/cards/job-standard/template.hbs
+++ b/cards/job-standard/template.hbs
@@ -27,7 +27,7 @@
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.title}}

--- a/cards/link-standard/template.hbs
+++ b/cards/link-standard/template.hbs
@@ -15,7 +15,7 @@
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}

--- a/cards/location-standard/template.hbs
+++ b/cards/location-standard/template.hbs
@@ -156,7 +156,7 @@
   {{#if card.url}}
   <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-    data-eventtype="TITLE_CLICK"
+    data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}

--- a/cards/menuitem-standard/template.hbs
+++ b/cards/menuitem-standard/template.hbs
@@ -35,7 +35,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}

--- a/cards/multilang-document-standard/template.hbs
+++ b/cards/multilang-document-standard/template.hbs
@@ -27,7 +27,7 @@
   {{#if card.url}}
   <a class="HitchhikerDocumentStandard-titleLink js-HitchhikerDocumentStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.title}}

--- a/cards/multilang-event-standard/component.js
+++ b/cards/multilang-event-standard/component.js
@@ -35,7 +35,7 @@ class multilang_event_standardCardComponent extends BaseCard['multilang-event-st
         iconName: 'calendar', // The icon to use for the CTA
         url: profile.ticketUrl || profile.website, // The URL a user will be directed to when clicking
         target: linkTarget, // Where the new URL will be opened
-        eventType: 'RSVP', // Type of Analytics event fired when clicking the CTA
+        eventType: 'BOOK', // Type of Analytics event fired when clicking the CTA
         eventOptions: this.addDefaultEventOptions(),
         // ariaLabel: '', // Accessible text providing a descriptive label for the CTA
       },

--- a/cards/multilang-event-standard/template.hbs
+++ b/cards/multilang-event-standard/template.hbs
@@ -15,7 +15,7 @@
           {{#if card.url}}
             <a class="HitchhikerEventStandard-titleLink"
               href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-              data-eventtype="TITLE_CLICK"
+              data-eventtype="TITLE"
               data-eventoptions='{{json card.titleEventOptions}}'
               target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
               {{card.title}}

--- a/cards/multilang-financial-professional-location/template.hbs
+++ b/cards/multilang-financial-professional-location/template.hbs
@@ -57,7 +57,7 @@
   {{#if card.url}}
   <a class="HitchhikerFinancialProfessionalLocation-titleLink js-HitchhikerFinancialProfessionalLocation-titleLink"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-    data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
+    data-eventtype="TITLE" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
   </a>

--- a/cards/multilang-job-standard/template.hbs
+++ b/cards/multilang-job-standard/template.hbs
@@ -27,7 +27,7 @@
   {{#if card.url}}
   <a class="HitchhikerJobStandard-titleLink js-HitchhikerJobStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.title}}

--- a/cards/multilang-link-standard/template.hbs
+++ b/cards/multilang-link-standard/template.hbs
@@ -15,7 +15,7 @@
   {{#if card.url}}
   <a class="HitchhikerLinkStandard-titleLink js-HitchhikerLinkStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}

--- a/cards/multilang-location-standard/template.hbs
+++ b/cards/multilang-location-standard/template.hbs
@@ -156,7 +156,7 @@
   {{#if card.url}}
   <a class="HitchhikerLocationStandard-titleLink js-Hitchhiker-title"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-    data-eventtype="TITLE_CLICK"
+    data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{{card.title}}}

--- a/cards/multilang-menuitem-standard/template.hbs
+++ b/cards/multilang-menuitem-standard/template.hbs
@@ -35,7 +35,7 @@
 {{#if card.title}}
 <div class="HitchhikerMenuItemStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerMenuItemStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}

--- a/cards/multilang-product-prominentimage-clickable/template.hbs
+++ b/cards/multilang-product-prominentimage-clickable/template.hbs
@@ -3,7 +3,7 @@
   <a class="HitchhikerProductProminentImageClickable-link"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
   >
   {{/if}}

--- a/cards/multilang-product-prominentimage/template.hbs
+++ b/cards/multilang-product-prominentimage/template.hbs
@@ -37,7 +37,7 @@
   <a class="HitchhikerProductProminentImage-titleLink"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
-    data-eventtype="TITLE_CLICK"
+    data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}'>
     {{card.title}}
   </a>

--- a/cards/multilang-product-prominentvideo/template.hbs
+++ b/cards/multilang-product-prominentvideo/template.hbs
@@ -15,7 +15,7 @@
   <a class="HitchhikerProductProminentVideo-titleLink"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
-    data-eventtype="TITLE_CLICK"
+    data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}'>
     {{card.title}}
   </a>

--- a/cards/multilang-product-standard/template.hbs
+++ b/cards/multilang-product-standard/template.hbs
@@ -32,7 +32,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}

--- a/cards/multilang-professional-location/template.hbs
+++ b/cards/multilang-professional-location/template.hbs
@@ -54,7 +54,7 @@
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
   <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-    data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
+    data-eventtype="TITLE" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
   </a>

--- a/cards/multilang-professional-standard/template.hbs
+++ b/cards/multilang-professional-standard/template.hbs
@@ -27,7 +27,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}

--- a/cards/multilang-standard/template.hbs
+++ b/cards/multilang-standard/template.hbs
@@ -27,7 +27,7 @@
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.title}}

--- a/cards/product-prominentimage-clickable/template.hbs
+++ b/cards/product-prominentimage-clickable/template.hbs
@@ -3,7 +3,7 @@
   <a class="HitchhikerProductProminentImageClickable-link"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
   >
   {{/if}}

--- a/cards/product-prominentimage/template.hbs
+++ b/cards/product-prominentimage/template.hbs
@@ -37,7 +37,7 @@
   <a class="HitchhikerProductProminentImage-titleLink"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
-    data-eventtype="TITLE_CLICK"
+    data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}'>
     {{card.title}}
   </a>

--- a/cards/product-prominentvideo/template.hbs
+++ b/cards/product-prominentvideo/template.hbs
@@ -15,7 +15,7 @@
   <a class="HitchhikerProductProminentVideo-titleLink"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
-    data-eventtype="TITLE_CLICK"
+    data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}'>
     {{card.title}}
   </a>

--- a/cards/product-standard/template.hbs
+++ b/cards/product-standard/template.hbs
@@ -32,7 +32,7 @@
 {{#if card.title}}
 <div class="HitchhikerProductStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProductStandard-titleLink js-Hitchhiker-title" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}

--- a/cards/professional-location/template.hbs
+++ b/cards/professional-location/template.hbs
@@ -54,7 +54,7 @@
 <div class="HitchhikerProfessionalLocation-title">
   {{#if card.url}}
   <a class="HitchhikerProfessionalLocation-titleLink js-HitchhikerProfessionalLocation-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-    data-eventtype="TITLE_CLICK" data-eventoptions='{{json card.titleEventOptions}}'
+    data-eventtype="TITLE" data-eventoptions='{{json card.titleEventOptions}}'
     target={{#if card.target}}"{{card.target}}"{{else}}"_top" rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}
   </a>

--- a/cards/professional-standard/template.hbs
+++ b/cards/professional-standard/template.hbs
@@ -27,7 +27,7 @@
 {{#if card.title}}
 <div class="HitchhikerProfessionalStandard-title">
   {{#if card.url}}
-  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE_CLICK"
+  <a class="HitchhikerProfessionalStandard-titleLink" href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}" data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}' target={{#if card.target}}"{{card.target}}"{{else}}"_top"
     rel="noopener noreferrer nofollow" {{/if}}>
     {{card.title}}

--- a/cards/standard/template.hbs
+++ b/cards/standard/template.hbs
@@ -27,7 +27,7 @@
   {{#if card.url}}
   <a class="HitchhikerStandard-titleLink js-HitchhikerStandard-titleLink"
      href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
-     data-eventtype="TITLE_CLICK"
+     data-eventtype="TITLE"
      data-eventoptions='{{json card.titleEventOptions}}'
      target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}>
     {{card.title}}

--- a/directanswercards/allfields-standard/template.hbs
+++ b/directanswercards/allfields-standard/template.hbs
@@ -35,7 +35,7 @@
   <a class="HitchhikerAllFieldsStandard-titleLink"
     href="{{#unless (isNonRelativeUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
-    data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
+    data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
   {{/if}}
   {{#if entityName}}

--- a/directanswercards/multilang-allfields-standard/template.hbs
+++ b/directanswercards/multilang-allfields-standard/template.hbs
@@ -35,7 +35,7 @@
   <a class="HitchhikerAllFieldsStandard-titleLink"
     href="{{#unless (isNonRelativeUrl link)}}{{@root.relativePath}}/{{/unless}}{{link}}"
     target={{#if linkTarget}}"{{linkTarget}}"{{else}}"_blank"{{/if}}
-    data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE_CLICK"{{/if}}
+    data-eventtype={{#if linkEventType}}"{{linkEventType}}"{{else}}"TITLE"{{/if}}
     data-eventoptions='{{{json linkEventOptions}}}'>
   {{/if}}
   {{#if entityName}}

--- a/global_config.json
+++ b/global_config.json
@@ -1,7 +1,8 @@
 {
-  "sdkVersion": "1.19", // The version of the Answers SDK to use
+  "sdkVersion": "2.0", // The version of the Answers SDK to use
   // "token": "<REPLACE ME>", // The auth token to access Answers experience.
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
+  // "eventsApiKey": "<REPLACE ME>", // An api key with Events API permissions. Required to send Analytics events.
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "environment": "production", // The environment to run on for this Answers Experience. (i.e. 'production' or 'sandbox')
   // "cloudRegion": "us", // The cloud region to use for this Answers Experience. (i.e. 'us' or 'eu')
@@ -16,6 +17,5 @@
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer
   "googleTagManagerId": "", // The container id associated with your Google Tag Manager container
-  "googleAnalyticsId": "", // The tracking Id associated with your Google Analytics account
-  "conversionTrackingEnabled": true // Whether or not conversion tracking is enabled for all pages
+  "googleAnalyticsId": "" // The tracking Id associated with your Google Analytics account
 }

--- a/layouts/html.hbs
+++ b/layouts/html.hbs
@@ -118,14 +118,6 @@
       <!-- End Google Tag Manager -->
     {{/if}}
 
-    {{#if global_config.conversionTrackingEnabled}}
-      {{#ifeq global_config.cloudRegion "eu"}}
-        <script src="https://assets.eu.sitescdn.net/ytag/ytag.min.js"></script>
-      {{else}}
-        <script src="https://assets.sitescdn.net/ytag/ytag.min.js"></script>
-      {{/ifeq}}
-    {{/if}}
-
     <script>
     {{#babel}}
       function iframeGetSearchParams() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.36.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.36.2",
+      "version": "2.0.0",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.5.2",
         "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.36.2",
+  "version": "2.0.0",
   "description": "A starter Search theme for hitchhikers",
   "keywords": [
     "jambo",

--- a/script/core.hbs
+++ b/script/core.hbs
@@ -79,10 +79,6 @@
           {{> script/on-ready}}
         {{/wrapJsPartial}}
 
-        {{#if global_config.conversionTrackingEnabled}}
-          ANSWERS.setConversionsOptIn(true);
-        {{/if}}
-
         ANSWERS.registerHelper('all', function (...args) {
           return args.filter(item => item).length === args.length;
         });

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.36.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "answers-hitchhiker-theme",
-      "version": "1.36.2",
+      "version": "2.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@vimeo/player": "^2.15.3",

--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-hitchhiker-theme",
-  "version": "1.36.2",
+  "version": "2.0.0",
   "description": "Toolchain for use with the HH Theme",
   "main": "Gruntfile.js",
   "scripts": {

--- a/test-site/cards/multilang-product-prominentvideo-custom/template.hbs
+++ b/test-site/cards/multilang-product-prominentvideo-custom/template.hbs
@@ -15,7 +15,7 @@
   <a class="HitchhikerProductProminentVideo-titleLink"
     href="{{#unless (isNonRelativeUrl card.url)}}{{@root.relativePath}}/{{/unless}}{{card.url}}"
     target={{#if card.target}}"{{card.target}}"{{else}}"_top"{{/if}}
-    data-eventtype="TITLE_CLICK"
+    data-eventtype="TITLE"
     data-eventoptions='{{json card.titleEventOptions}}'>
     {{card.title}}
   </a>

--- a/test-site/config/global_config.json
+++ b/test-site/config/global_config.json
@@ -2,6 +2,7 @@
   "sdkVersion": "develop", // The version of the Answers SDK to use
   // "token": "<REPLACE ME>", // The auth token to access Answers experience.
   "apiKey": "2d8c550071a64ea23e263118a2b0680b", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
+  // "eventsApiKey": "<REPLACE ME>", // An api key with Events API permissions. Required to send Analytics events.
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "environment": "production", // The environment to run on for this Answers Experience. (i.e. 'production' or 'sandbox')
   // "cloudRegion": "eu", // The cloud region to use for this Answers Experience. (i.e. 'us' or 'eu')
@@ -16,6 +17,5 @@
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer
   "googleTagManagerId": "", // The container id associated with your Google Tag Manager container
   "googleAnalyticsId": "", // The tracking Id associated with your Google Analytics account
-  "conversionTrackingEnabled": true, // Whether or not conversion tracking is enabled for all pages
   "useGenerativeDirectAnswers": true // Whether or not to use generative direct answers
 }


### PR DESCRIPTION
Adds support for SDK v2.0, which itself adds support for the Events API. This change is not too large, but does add a new global config field (eventsApiKey), and removes a deprectaed one (conversionTrackingEnabled). It also updates the old event names to the new ones in our premade code - mostly TITLE_CLICK -> TITLE.
J=WAT-4646
TEST=manual

Spun up the test site and saw new events send as expected.