### PR TITLE
fix: remove searcher analytics param from default cards

### DIFF
--- a/cards/card_component.js
+++ b/cards/card_component.js
@@ -157,7 +157,6 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
       .addOptions({
         directAnswer: false,
         verticalKey: this.verticalKey,
-        searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
         entityId: this.result.id
       });
 
@@ -176,7 +175,6 @@ BaseCard["{{componentName}}"] = class extends ANSWERS.Component {
   addDefaultEventOptions(eventOptions = {}) {
     return Object.assign({}, {
         verticalKey: this.verticalKey,
-        searcher: this._config.isUniversal ? "UNIVERSAL" : "VERTICAL",
         entityId: this.result.id
       },
       eventOptions

--- a/cards/faq-accordion/component.js
+++ b/cards/faq-accordion/component.js
@@ -113,8 +113,7 @@ class faq_accordionCardComponent extends BaseCard['faq-accordion'] {
         const event = new ANSWERS.AnalyticsEvent(isExpanded ? 'ROW_EXPAND' : 'ROW_COLLAPSE')
         .addOptions({
           verticalKey: self.verticalKey,
-          entityId: self.result._raw.id,
-          searcher: self._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL'
+          entityId: self.result._raw.id
         });
         self.analyticsReporter.report(event);
       }

--- a/cards/multilang-faq-accordion/component.js
+++ b/cards/multilang-faq-accordion/component.js
@@ -113,8 +113,7 @@ class multilang_faq_accordionCardComponent extends BaseCard['multilang-faq-accor
         const event = new ANSWERS.AnalyticsEvent(isExpanded ? 'ROW_EXPAND' : 'ROW_COLLAPSE')
         .addOptions({
           verticalKey: self.verticalKey,
-          entityId: self.result._raw.id,
-          searcher: self._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL'
+          entityId: self.result._raw.id
         });
         self.analyticsReporter.report(event);
       }

--- a/cards/multilang-product-prominentvideo/component.js
+++ b/cards/multilang-product-prominentvideo/component.js
@@ -83,7 +83,6 @@ class multilang_product_prominentvideoCardComponent extends BaseCard['multilang-
       .addOptions({
         verticalKey: this.verticalKey,
         entityId: this.result?._raw?.id,
-        searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
         ctaLabel: 'video_played'
       });
     this.analyticsReporter.report(event);

--- a/cards/product-prominentvideo/component.js
+++ b/cards/product-prominentvideo/component.js
@@ -83,7 +83,6 @@ class product_prominentvideoCardComponent extends BaseCard['product-prominentvid
       .addOptions({
         verticalKey: this.verticalKey,
         entityId: this.result?._raw?.id,
-        searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
         ctaLabel: 'video_played'
       });
     this.analyticsReporter.report(event);

--- a/directanswercards/card_component.js
+++ b/directanswercards/card_component.js
@@ -96,7 +96,6 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
       .addOptions({
         directAnswer: true,
         verticalKey: this.verticalConfigId,
-        searcher: this._config.data.searcher,
         entityId: this.associatedEntityId
       });
 
@@ -119,7 +118,6 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
    */
   addDefaultEventOptions(eventOptions = {}) {
     return Object.assign({}, {
-        searcher: this._config.data.searcher,
         verticalConfigId: this.verticalConfigId,
         entityId: this.associatedEntityId,
         ...eventOptions
@@ -143,7 +141,6 @@ BaseDirectAnswerCard["{{componentName}}"] = class extends ANSWERS.Component {
       verticalKey: this.verticalConfigId,
       directAnswer: true,
       fieldName: this.answer.fieldApiName,
-      searcher: this._config.data.searcher,
       entityId: this.associatedEntityId,
       url: event.target.href
     };

--- a/generativedirectanswercards/card_component.js
+++ b/generativedirectanswercards/card_component.js
@@ -96,8 +96,7 @@ BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
       .addOptions({
         generativeDirectAnswer: true,
         directAnswer: true,
-        verticalKey: this._config.data.verticalKey,
-        searcher: this._config.data.searcher
+        verticalKey: this._config.data.verticalKey
       });
 
     this.analyticsReporter.report(event);
@@ -109,7 +108,6 @@ BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
    * @param {HTMLElement} citationElement The citation element that was clicked.
    */
   _handleCitationClickAnalytics (citationElement) {
-    const searcher = this._config.data.searcher;
     const verticalKey = this._config.data.verticalKey;
     const analyticsReporter = this.analyticsReporter;
     citationElement.addEventListener('click', function(clickEvent) {
@@ -133,7 +131,6 @@ BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
           generativeDirectAnswer: true,
           directAnswer: true,
           entityId,
-          searcher,
           verticalConfigId: verticalKey,
         })
       analyticsReporter.report(event);
@@ -156,7 +153,6 @@ BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
       generativeDirectAnswer: true,
       directAnswer: true,
       fieldName: 'gda-snippet',
-      searcher: this._config.data.searcher,
       url: event.target.href,
       verticalConfigId: this._config.data.verticalKey,
     };
@@ -182,7 +178,6 @@ BaseGDACard = typeof (BaseGDACard) !== 'undefined' ? BaseGDACard : {};
    */
   addDefaultEventOptions(eventOptions = {}) {
     return Object.assign({}, {
-        searcher: this._config.data.searcher,
         verticalConfigId: this._config.data.verticalKey,
         ...eventOptions
       },

--- a/test-site/cards/multilang-product-prominentvideo-custom/component.js
+++ b/test-site/cards/multilang-product-prominentvideo-custom/component.js
@@ -83,7 +83,6 @@ class multilang_product_prominentvideo_customCardComponent extends BaseCard['mul
       .addOptions({
         verticalKey: this.verticalKey,
         entityId: this.result?._raw?.id,
-        searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
         ctaLabel: 'video_played'
       });
     this.analyticsReporter.report(event);


### PR DESCRIPTION
This analytics param no longer does anything, so this PR just removes it from the default cards.

J=WAT-5712
TEST=manual

Spun up test site, events send fine.